### PR TITLE
fix(security): build parity JSON with an encoder, drop the dead nil check

### DIFF
--- a/cmd/cyoda/help/openapi_tags.go
+++ b/cmd/cyoda/help/openapi_tags.go
@@ -229,9 +229,9 @@ func marshalComponent(comps *openapi3.Components, ref string) ([]byte, error) {
 	// missing map key gives a NIL pointer, and a nil pointer stored in an `any`
 	// is a non-nil interface — so a plain `v == nil` never fires. Without the
 	// reflect check a dangling $ref marshals to "null" instead of being skipped.
-	if v == nil {
-		return nil, nil
-	}
+	// No `v == nil` check: every arm assigns a typed pointer, so v always holds
+	// a type and the interface itself is never nil. Only the pointer inside it
+	// can be.
 	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Ptr && rv.IsNil() {
 		return nil, nil
 	}

--- a/e2e/parity/callback_txjoin.go
+++ b/e2e/parity/callback_txjoin.go
@@ -2,7 +2,6 @@ package parity
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -60,17 +59,6 @@ const cbSecondaryWorkflow = `{
 // processors read to learn the secondary model + marker for a scenario. It
 // returns a JSON-encoded (quoted, escaped) string literal ready to embed as the
 // "context" value inside a workflow JSON document.
-// jsonQuote renders s as a JSON string literal.
-//
-// Prefer this over %q when interpolating into a JSON document: %q applies Go
-// quoting rules, which diverge from JSON's for non-ASCII and control characters
-// (Go emits \x.. and \u.. forms JSON does not accept). For ASCII test fixtures
-// the two coincide, which is why this went unnoticed — but the document is JSON,
-// so it should be built with a JSON encoder.
-func jsonQuote(s string) string {
-	b, _ := json.Marshal(s)
-	return string(b)
-}
 
 func cbContext(secondaryModel string, marker string) string {
 	inner, _ := json.Marshal(map[string]any{
@@ -78,30 +66,47 @@ func cbContext(secondaryModel string, marker string) string {
 		"secondaryVersion": 1,
 		"marker":           marker,
 	})
-	// json.Marshal of the inner-JSON string yields a fully quoted+escaped
-	// literal (e.g. "\"{\\\"secondaryModel\\\":...}\"") suitable for direct
-	// substitution as a JSON string value.
-	quoted, _ := json.Marshal(string(inner))
-	return string(quoted)
+	return string(inner)
+}
+
+// cbWorkflowDoc marshals a workflow-import document.
+//
+// These documents are built with an encoder rather than a string template on
+// purpose: a template interpolates with %s or %q, and Go's quoting rules are not
+// JSON's — they diverge on non-ASCII and control characters, and %s does not
+// quote at all. Passing Go values through json.Marshal is both correct and what
+// static analysis can verify.
+func cbWorkflowDoc(name string, states map[string]any) string {
+	b, _ := json.Marshal(map[string]any{
+		"importMode": "REPLACE",
+		"workflows": []any{map[string]any{
+			"version": "1.1", "name": name, "initialState": "NONE", "active": true,
+			"states": states,
+		}},
+	})
+	return string(b)
+}
+
+// cbProc builds one calculator-processor entry.
+func cbProc(name, execMode string, ctxValue string, extraConfig map[string]any) map[string]any {
+	cfg := map[string]any{"attachEntity": true, "calculationNodesTags": "", "context": ctxValue}
+	for k, v := range extraConfig {
+		cfg[k] = v
+	}
+	return map[string]any{"type": "calculator", "name": name, "executionMode": execMode, "config": cfg}
 }
 
 // cbPrimaryProcWorkflow builds a NONE→ACTIVE auto-transition workflow whose
 // transition carries a single callback processor with the given name, execution
 // mode, and pass-through context.
 func cbPrimaryProcWorkflow(wfName, procName, execMode, contextValue string) string {
-	return fmt.Sprintf(`{
-		"importMode": "REPLACE",
-		"workflows": [{
-			"version": "1.1", "name": %s, "initialState": "NONE", "active": true,
-			"states": {
-				"NONE":   {"transitions": [{"name": "init", "next": "ACTIVE", "manual": false,
-					"processors": [{"type": "calculator", "name": %s, "executionMode": %s,
-						"config": {"attachEntity": true, "calculationNodesTags": "", "context": %s}}]
-				}]},
-				"ACTIVE": {}
-			}
-		}]
-	}`, jsonQuote(wfName), jsonQuote(procName), jsonQuote(execMode), contextValue)
+	return cbWorkflowDoc(wfName, map[string]any{
+		"NONE": map[string]any{"transitions": []any{map[string]any{
+			"name": "init", "next": "ACTIVE", "manual": false,
+			"processors": []any{cbProc(procName, execMode, contextValue, nil)},
+		}}},
+		"ACTIVE": map[string]any{},
+	})
 }
 
 // cbSetupModel imports + locks a model with the given sample doc, then imports
@@ -306,23 +311,22 @@ func RunCallbackCriteriaReadYourWrites(t *testing.T, fixture BackendFixture) {
 	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
 
 	ctxVal := cbContext(secondary, marker)
-	wf := fmt.Sprintf(`{
-		"importMode": "REPLACE",
-		"workflows": [{
-			"version": "1.1", "name": "cbtj-crit-wf", "initialState": "NONE", "active": true,
-			"states": {
-				"NONE":     {"transitions": [{"name": "init", "next": "ENRICHED", "manual": false,
-					"processors": [{"type": "calculator", "name": "cb-create-secondary", "executionMode": "SYNC",
-						"config": {"attachEntity": true, "calculationNodesTags": "", "context": %s}}]
-				}]},
-				"ENRICHED": {"transitions": [{"name": "approve", "next": "APPROVED", "manual": false,
-					"criterion": {"type": "function", "function": {"name": "cb-criterion-reads",
-						"config": {"attachEntity": true, "calculationNodesTags": "", "context": %s}}}
-				}]},
-				"APPROVED": {}
-			}
-		}]
-	}`, ctxVal, ctxVal)
+	wf := cbWorkflowDoc("cbtj-crit-wf", map[string]any{
+		"NONE": map[string]any{"transitions": []any{map[string]any{
+			"name": "init", "next": "ENRICHED", "manual": false,
+			"processors": []any{cbProc("cb-create-secondary", "SYNC", ctxVal, nil)},
+		}}},
+		"ENRICHED": map[string]any{"transitions": []any{map[string]any{
+			"name": "approve", "next": "APPROVED", "manual": false,
+			"criterion": map[string]any{"type": "function", "function": map[string]any{
+				"name": "cb-criterion-reads",
+				"config": map[string]any{
+					"attachEntity": true, "calculationNodesTags": "", "context": ctxVal,
+				},
+			}},
+		}}},
+		"APPROVED": map[string]any{},
+	})
 	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`, wf)
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
@@ -426,7 +430,10 @@ func RunCallbackEmptyTokenStandalone(t *testing.T, fixture BackendFixture) {
 
 // cbStatusEquals builds a simple search condition matching data.status == value.
 func cbStatusEquals(value string) string {
-	return fmt.Sprintf(`{"type":"simple","jsonPath":"$.status","operatorType":"EQUALS","value":%s}`, jsonQuote(value))
+	b, _ := json.Marshal(map[string]any{
+		"type": "simple", "jsonPath": "$.status", "operatorType": "EQUALS", "value": value,
+	})
+	return string(b)
 }
 
 // RunCallback_CBDPostJoinsTxPost proves that COMMIT_BEFORE_DISPATCH with
@@ -452,21 +459,14 @@ func RunCallback_CBDPostJoinsTxPost(t *testing.T, fixture BackendFixture) {
 	// Build the workflow inline: COMMIT_BEFORE_DISPATCH + startNewTxOnDispatch=true.
 	// cbPrimaryProcWorkflow does not support startNewTxOnDispatch, so inline here.
 	ctxVal := cbContext(secondary, marker)
-	wf := fmt.Sprintf(`{
-		"importMode": "REPLACE",
-		"workflows": [{
-			"version": "1.1", "name": "cbtj-cbd-post-wf", "initialState": "NONE", "active": true,
-			"states": {
-				"NONE":   {"transitions": [{"name": "init", "next": "ACTIVE", "manual": false,
-					"processors": [{"type": "calculator", "name": "cb-create-secondary",
-						"executionMode": "COMMIT_BEFORE_DISPATCH",
-						"config": {"attachEntity": true, "calculationNodesTags": "",
-						           "startNewTxOnDispatch": true, "context": %s}}]
-				}]},
-				"ACTIVE": {}
-			}
-		}]
-	}`, ctxVal)
+	wf := cbWorkflowDoc("cbtj-cbd-post-wf", map[string]any{
+		"NONE": map[string]any{"transitions": []any{map[string]any{
+			"name": "init", "next": "ACTIVE", "manual": false,
+			"processors": []any{cbProc("cb-create-secondary", "COMMIT_BEFORE_DISPATCH", ctxVal,
+				map[string]any{"startNewTxOnDispatch": true})},
+		}}},
+		"ACTIVE": map[string]any{},
+	})
 	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`, wf)
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)

--- a/e2e/parity/multinode/attribution.go
+++ b/e2e/parity/multinode/attribution.go
@@ -1,6 +1,7 @@
 package multinode
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -329,23 +330,29 @@ const attrScheduledWorkflow = `{
 // forwarded to the member-hosting node when driven from any other node).
 // contextValue may be "" for processors that need no pass-through context.
 func attrPrimaryProcWorkflow(wfName, procName, execMode, contextValue string) string {
-	ctxField := ""
+	// Built with an encoder, not a string template. contextValue arrives as a
+	// plain JSON string from cbRouteContext and is encoded here — splicing it
+	// raw would emit a nested object where the DTO expects a string.
+	cfg := map[string]any{"attachEntity": true, "calculationNodesTags": computeMemberTag}
 	if contextValue != "" {
-		ctxField = ", \"context\": " + contextValue
+		cfg["context"] = contextValue
 	}
-	return fmt.Sprintf(`{
+	b, _ := json.Marshal(map[string]any{
 		"importMode": "REPLACE",
-		"workflows": [{
-			"version": "1.1", "name": %q, "initialState": "NONE", "active": true,
-			"states": {
-				"NONE":   {"transitions": [{"name": "init", "next": "ACTIVE", "manual": false,
-					"processors": [{"type": "calculator", "name": %q, "executionMode": %q,
-						"config": {"attachEntity": true, "calculationNodesTags": %q%s}}]
-				}]},
-				"ACTIVE": {}
-			}
-		}]
-	}`, wfName, procName, execMode, computeMemberTag, ctxField)
+		"workflows": []any{map[string]any{
+			"version": "1.1", "name": wfName, "initialState": "NONE", "active": true,
+			"states": map[string]any{
+				"NONE": map[string]any{"transitions": []any{map[string]any{
+					"name": "init", "next": "ACTIVE", "manual": false,
+					"processors": []any{map[string]any{
+						"type": "calculator", "name": procName, "executionMode": execMode, "config": cfg,
+					}},
+				}}},
+				"ACTIVE": map[string]any{},
+			},
+		}},
+	})
+	return string(b)
 }
 
 // --- assertion helpers -------------------------------------------------------

--- a/e2e/parity/multinode/callback_route.go
+++ b/e2e/parity/multinode/callback_route.go
@@ -2,7 +2,6 @@ package multinode
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -38,17 +37,6 @@ import (
 // The token value is never logged or asserted (Gate 3); scenarios observe only
 // entity state and derived data.
 
-// jsonQuote renders s as a JSON string literal.
-//
-// Prefer this over %q when interpolating into a JSON document: %q applies Go
-// quoting rules, which diverge from JSON's for non-ASCII and control characters
-// (Go emits \x.. and \u.. forms JSON does not accept). Duplicated from the
-// parity package rather than exported, to keep the fixture helpers package-local.
-func jsonQuote(s string) string {
-	b, _ := json.Marshal(s)
-	return string(b)
-}
-
 func init() {
 	Register(
 		NamedTest{Name: "Callback_ForwardedDispatch_HTTP", Fn: RunCallback_ForwardedDispatch_HTTP},
@@ -72,8 +60,7 @@ func cbRouteContext(secondaryModel, marker string) string {
 		"secondaryVersion": 1,
 		"marker":           marker,
 	})
-	quoted, _ := json.Marshal(string(inner))
-	return string(quoted)
+	return string(inner)
 }
 
 // cbRouteSecondaryWorkflow is a trivial NONE→STORED workflow (no processors) so a
@@ -94,19 +81,29 @@ const cbRouteSecondaryWorkflow = `{
 // transition carries one callback processor pinned to computeMemberTag, so the
 // dispatch is forwarded to the member-hosting node when driven from any other node.
 func cbRoutePrimaryWorkflow(wfName, procName, contextValue string) string {
-	return fmt.Sprintf(`{
+	// Built with an encoder, not a string template: Go's %s/%q quoting rules
+	// are not JSON's, and the names and context are caller-supplied.
+	b, _ := json.Marshal(map[string]any{
 		"importMode": "REPLACE",
-		"workflows": [{
-			"version": "1.1", "name": %s, "initialState": "NONE", "active": true,
-			"states": {
-				"NONE":   {"transitions": [{"name": "init", "next": "ACTIVE", "manual": false,
-					"processors": [{"type": "calculator", "name": %s, "executionMode": "SYNC",
-						"config": {"attachEntity": true, "calculationNodesTags": %s, "context": %s}}]
-				}]},
-				"ACTIVE": {}
-			}
-		}]
-	}`, jsonQuote(wfName), jsonQuote(procName), jsonQuote(computeMemberTag), contextValue)
+		"workflows": []any{map[string]any{
+			"version": "1.1", "name": wfName, "initialState": "NONE", "active": true,
+			"states": map[string]any{
+				"NONE": map[string]any{"transitions": []any{map[string]any{
+					"name": "init", "next": "ACTIVE", "manual": false,
+					"processors": []any{map[string]any{
+						"type": "calculator", "name": procName, "executionMode": "SYNC",
+						"config": map[string]any{
+							"attachEntity":         true,
+							"calculationNodesTags": computeMemberTag,
+							"context":              contextValue,
+						},
+					}},
+				}}},
+				"ACTIVE": map[string]any{},
+			},
+		}},
+	})
+	return string(b)
 }
 
 // cbRouteSetupModel imports+locks a model with the given sample doc, then imports
@@ -402,7 +399,10 @@ func RunCallback_ForwardedGRPCSearch(t *testing.T, fixture MultiNodeFixture) {
 
 // cbRouteStatusEquals builds a simple search condition matching data.status.
 func cbRouteStatusEquals(value string) string {
-	return fmt.Sprintf(`{"type":"simple","jsonPath":"$.status","operatorType":"EQUALS","value":%s}`, jsonQuote(value))
+	b, _ := json.Marshal(map[string]any{
+		"type": "simple", "jsonPath": "$.status", "operatorType": "EQUALS", "value": value,
+	})
+	return string(b)
 }
 
 // cbRouteSameTxID queries the audit REST endpoint for both entities and


### PR DESCRIPTION
Follow-up to #449, which did not actually clear two of the rules it claimed. My error, caught by CodeQL re-running on #447.

## `go/unsafe-quoting`: 5 alerts became 11

Swapping `%q` for `%s` plus a `jsonQuote` helper made it **worse** — the analyser cannot see that `jsonQuote` escapes, and a bare `%s` in a JSON string position is precisely what the rule looks for.

The actual problem was assembling JSON with string templates at all. The workflow and condition documents are now built from Go maps and marshalled. That is both correct — Go's `%q` quoting rules are not JSON's, diverging on non-ASCII and control characters — and something static analysis can verify.

## `go/impossible-interface-nil-check` persisted

#449 added the `reflect` check but **kept** the `v == nil` guard it was meant to replace. Every switch arm assigns a typed pointer, so the interface is never nil and that comparison is dead code. Removed.

## A regression I introduced and caught

Changing `cbContext` from returning a pre-quoted literal to a plain string broke `attrPrimaryProcWorkflow`, which splices it raw — emitting a nested object where the DTO expects a string. `TestMultiNode/Attribution_ProxiedJoinCascade` failed with `400: cannot unmarshal object into ... config.context of type string`.

That builder is now an encoder too. I audited every other caller: the two in `externalapi/workflow_externalization.go` use a local constant and are unaffected.

Encoding equivalence was checked directly rather than reasoned about — old pre-quote-then-splice and new marshal-a-string produce **byte-identical** output, including for values containing a double quote.

## Verification

`make test-all` (62 packages, exit 0), `make race` (exit 0, 0 data races), `TestMultiNode/Attribution` green, `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016umhV1pCZ5pS1NnzrUZf4K