### PR TITLE
fix(dev): restore the make dev-* targets with a dev-only compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-up dev-down dev-ps dev-logs dev-run dev-test build test test-all test-short-all race clean docker-build docker-push todos check-spi-pin-sync check-codegen check-gofmt repin-plugins
+.PHONY: dev-up dev-down dev-reset dev-ps dev-logs dev-run dev-test build test test-all test-short-all race clean docker-build docker-push todos check-spi-pin-sync check-codegen check-gofmt repin-plugins
 
 # Plugin submodules: each has its own go.mod, so `go test ./...` from the
 # repo root does not recurse into them. The aggregator targets below close
@@ -6,29 +6,43 @@
 PLUGIN_MODULES := plugins/memory plugins/sqlite plugins/postgres
 
 # --- Docker services ---
+#
+# Dev-only PostgreSQL for running cyoda-go on bare metal. Not a provisioning
+# artifact — deploy/docker/compose.yaml is the packaged app (sqlite-backed);
+# this is just the database.
+DEV_COMPOSE := scripts/dev/compose.yaml
+
+# Postgres connection for the dev targets, matching scripts/dev/compose.yaml.
+# Set explicitly rather than via CYODA_PROFILES=postgres: that would read
+# .env.postgres, which is gitignored — on a fresh clone the profile would find
+# nothing and cyoda would fall back to the memory backend silently, which is a
+# worse failure than an error. The compose file is the single source of truth.
+DEV_PG_ENV := CYODA_STORAGE_BACKEND=postgres \
+	CYODA_POSTGRES_URL='postgres://minicyoda:minicyoda@localhost:5432/minicyoda?sslmode=disable' \
+	CYODA_POSTGRES_AUTO_MIGRATE=true
 
 dev-up:                ## Start local services (PostgreSQL)
-	docker compose up -d --wait
+	docker compose -f $(DEV_COMPOSE) up -d --wait
 
 dev-down:              ## Stop local services
-	docker compose down
+	docker compose -f $(DEV_COMPOSE) down
 
 dev-reset:             ## Stop services and delete volumes (fresh start)
-	docker compose down -v
+	docker compose -f $(DEV_COMPOSE) down -v
 
 dev-ps:                ## Show service status
-	docker compose ps
+	docker compose -f $(DEV_COMPOSE) ps
 
 dev-logs:              ## Tail service logs
-	docker compose logs -f
+	docker compose -f $(DEV_COMPOSE) logs -f
 
 # --- Build & Run ---
 
 build:                 ## Build the binary
 	go build -o bin/cyoda ./cmd/cyoda
 
-dev-run: dev-up build  ## Start services + run cyoda with postgres KV
-	set -a && . .env.dev && set +a && ./bin/cyoda
+dev-run: dev-up build  ## Start services + run cyoda against local postgres
+	$(DEV_PG_ENV) ./bin/cyoda
 
 # --- Docker image ---
 
@@ -82,7 +96,7 @@ race:                  ## Run race detector on race-sensitive packages (CI parit
 	go test -race -timeout=15m $$pkgs
 
 dev-test: dev-up       ## Run all tests against local postgres
-	set -a && . .env.dev && set +a && go test ./... -v -count=1
+	$(DEV_PG_ENV) go test ./... -v -count=1
 
 # --- TODOs ---
 

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -8,3 +8,19 @@ artifacts — the canonical artifacts live under `deploy/`.
 - `run-docker-dev.sh` — run cyoda-go + Postgres via docker compose
   for local development, with a fresh JWT signing key and a
   randomized bootstrap client secret per run.
+- `compose.yaml` — PostgreSQL only, for running a locally built
+  cyoda-go against the postgres backend on bare metal. Driven by the
+  `make dev-*` targets; credentials and port match
+  `.env.postgres.example`.
+
+## Running against local PostgreSQL
+
+```
+make dev-up     # start PostgreSQL, wait until healthy
+make dev-run    # build and run cyoda-go against it
+make dev-down   # stop        (dev-reset also deletes the volume)
+```
+
+`deploy/docker/compose.yaml` is a different thing: the packaged
+application in one container, sqlite-backed. Use this file when you want
+to run cyoda-go yourself and only need the database.

--- a/scripts/dev/compose.yaml
+++ b/scripts/dev/compose.yaml
@@ -1,0 +1,39 @@
+# Local-development services for running cyoda-go on bare metal.
+#
+# This is NOT a provisioning artifact — canonical ones live under deploy/.
+# deploy/docker/compose.yaml runs the packaged app against sqlite in one
+# container; this file provides the opposite: just the database, so you can
+# build and run cyoda-go yourself against the postgres backend.
+#
+#   make dev-up                          # start (waits for healthy)
+#   CYODA_PROFILES=postgres ./bin/cyoda  # or: make dev-run
+#   make dev-down                        # stop
+#   make dev-reset                       # stop and delete the volume
+#
+# Credentials and port match .env.postgres.example, so the postgres profile
+# connects with no further configuration. Bound to 127.0.0.1 so the database
+# is never reachable off-host.
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: cyoda-dev-postgres
+    environment:
+      POSTGRES_DB: minicyoda
+      POSTGRES_USER: minicyoda
+      POSTGRES_PASSWORD: minicyoda
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    # Required by `docker compose up --wait` in the dev-up target: without a
+    # healthcheck the wait returns as soon as the container starts, before
+    # postgres is accepting connections.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U minicyoda -d minicyoda"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Not release-relevant — nothing here ships in the binary, chart or SPI. Found while smoke-testing v0.8.3, where `make dev-up` failed and the database had to be started by hand.

## What was broken

`0a726f6` ("retire dev-era root artifacts") deleted the root `docker-compose.yml` but left every dev target invoking bare `docker compose`. With no compose file at the repo root, `docker compose config` reports `no configuration file provided: not found` — so `dev-up`, `dev-down`, `dev-reset`, `dev-ps` and `dev-logs` have all been dead since.

Nothing replaced it. `deploy/docker/compose.yaml` is the packaged application in a single container, **sqlite-backed** — not a database for a locally built binary.

`dev-run` and `dev-test` were broken independently: both sourced `.env.dev`, which does not exist and has no `.example`.

## The fix

**`scripts/dev/compose.yaml`** — PostgreSQL only. Credentials and port match `.env.postgres.example`, bound to `127.0.0.1` so it is never reachable off-host, with a healthcheck so `up --wait` actually waits for readiness instead of returning the moment the container starts.

It lives under `scripts/dev/` because that README already declares itself the home for local-dev helpers that are explicitly *not* provisioning artifacts — `deploy/` is for the canonical ones.

**`dev-run`/`dev-test` set the postgres variables explicitly** rather than using `CYODA_PROFILES=postgres`. That profile reads `.env.postgres`, which is **gitignored** — on a fresh clone it would find nothing and cyoda would fall back to the memory backend *silently*, which is worse than the original failure. That is not hypothetical: it happened on my first attempt here, and the fix is why. The compose file stays the single source of truth for the credentials.

Also adds `dev-reset` to `.PHONY`, which it was missing.

## Verification

Exercised at the docker level rather than assumed:

- `docker compose -f scripts/dev/compose.yaml config` — valid
- `up --wait` — container reaches **healthy** before returning
- binary with the target's exact env — `storage backend selected backend=postgres`
- auto-migrate — **12 tables** created
- `down -v` — container and volume removed

One caveat: I could not exercise the `make` wrapper end to end, because `docker` is not resolvable from `make`'s subshell PATH in my sandbox (`which docker` fails there while the tool resolves it another way). The recipes are single `docker compose -f $(DEV_COMPOSE) …` lines and each was run directly, but a reviewer with docker on PATH should confirm `make dev-up && make dev-run` in one go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016umhV1pCZ5pS1NnzrUZf4K