### PR TITLE
docs(help): correct criteria condition types and lifecycle fields (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **`cyoda help workflows` understated what criteria accept** — the CRITERIA
+  section advertised "all four condition types" (omitting `function`) and three
+  lifecycle fields, so a reader believed valid criteria were invalid. It now
+  lists all five condition types and all six lifecycle fields —
+  `state`, `creationDate`, `lastUpdateTime`, `transitionForLatestSave` (alias
+  `previousTransition`), `transactionId`, `id` — matching `cyoda help search`,
+  which describes the same evaluation kernel. New parity tests pin both topics
+  to `matchLifecycle` and to each other. The async-search description in the
+  OpenAPI document carried the same three-field list and is corrected with it.
+  ([#455](https://github.com/Cyoda-platform/cyoda-go/issues/455))
+
 - **`make dev-*` targets restored** — the dev targets had been broken since the
   root `docker-compose.yml` was deleted while every target still invoked bare
   `docker compose`; `dev-run`/`dev-test` separately sourced a `.env.dev` that

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6700,10 +6700,13 @@ paths:
 
         1. Simple conditions - search within entity data using JSONPath
 
-        2. Lifecycle conditions - search based on entity lifecycle (state,
-        creationDate, previousTransition)
+        2. Lifecycle conditions - search based on entity metadata (state,
+        creationDate, lastUpdateTime, transitionForLatestSave — alias
+        previousTransition, transactionId, id)
 
         3. Group conditions - combine multiple conditions with AND/OR operators
+
+        4. Array conditions - positional matching against array elements
 
 
         Operator Types (Predicates)

--- a/cmd/cyoda/help/condition_docs_parity_test.go
+++ b/cmd/cyoda/help/condition_docs_parity_test.go
@@ -5,72 +5,33 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"sort"
 	"strings"
 	"testing"
 
 	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common/commontest"
 )
 
 // The `workflows` CRITERIA section and the `search` Condition-DSL section
 // describe the same evaluation kernel (predicate.ParseCondition ->
-// match.Match). These guards pin both topics to the source of truth so the
-// two cannot drift apart, or away from the code, again.
+// match.Match). These guards pin both topics to what that kernel accepts, so
+// the two cannot drift apart, or away from the code, again.
+//
+// The lifecycle-field vocabulary is taken from match.matchLifecycle because
+// that is the evaluator the topics describe. Its agreement with
+// search.sortableMetaFields — the allowlist the API boundary and
+// workflow-criterion import validate against, and the documented source of
+// truth for the vocabulary — is pinned separately by
+// TestMetaVocabulary_EvaluatorMatchesAllowlist.
 
 var (
-	// matchLifecycleFunc isolates the body of matchLifecycle in
-	// internal/match/match.go. The body's closing brace is the only "}" at
-	// column 0 after the signature, so the non-greedy match stops there.
-	matchLifecycleFunc = regexp.MustCompile(`(?s)func matchLifecycle\(.*?\n}`)
-	// caseLabel captures each `case "field":` label of that switch — the
-	// canonical lifecycle-field vocabulary.
-	caseLabel = regexp.MustCompile(`case "([A-Za-z]+)":`)
-	// lifecycleAlias captures the `field == "x"` -> `field = "y"` alias
-	// normalisation performed on entry.
-	lifecycleAlias = regexp.MustCompile(`field == "([A-Za-z]+)"\s*\{\s*field = "([A-Za-z]+)"`)
 	// backticked captures each `token` in a markdown span.
 	backticked = regexp.MustCompile("`([A-Za-z]+)`")
 	// searchConditionHeading captures the **XCondition** headings that form
 	// the search topic's condition-type catalogue.
 	searchConditionHeading = regexp.MustCompile(`(?m)^\*\*([A-Za-z]+)Condition\*\*`)
 )
-
-// acceptedLifecycleFields derives the lifecycle (meta) field vocabulary from
-// matchLifecycle: every switch case, plus the alias it normalises on entry.
-func acceptedLifecycleFields(t *testing.T, root string) []string {
-	t.Helper()
-	src, err := os.ReadFile(filepath.Join(root, "internal/match/match.go"))
-	if err != nil {
-		t.Fatalf("read match.go: %v", err)
-	}
-	body := matchLifecycleFunc.Find(src)
-	if body == nil {
-		t.Fatal("matchLifecycle not found in internal/match/match.go")
-	}
-	fields := map[string]bool{}
-	for _, m := range caseLabel.FindAllStringSubmatch(string(body), -1) {
-		fields[m[1]] = true
-	}
-	for _, m := range lifecycleAlias.FindAllStringSubmatch(string(body), -1) {
-		if !fields[m[2]] {
-			t.Errorf("alias %q normalises to %q, which is not a switch case", m[1], m[2])
-		}
-		fields[m[1]] = true
-	}
-	if len(fields) == 0 {
-		t.Fatal("no lifecycle fields extracted from matchLifecycle")
-	}
-	return sortedKeys(fields)
-}
-
-func sortedKeys(m map[string]bool) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
-}
 
 // topicSentence returns the backticked tokens listed after marker in body, up
 // to the end of that sentence. Doc lists are written as a run of `code` spans
@@ -95,7 +56,7 @@ func topicSentence(t *testing.T, body, marker, topic string) []string {
 	if len(seen) == 0 {
 		t.Fatalf("%s: no `code` tokens after %q", topic, marker)
 	}
-	return sortedKeys(seen)
+	return commontest.SortedKeys(seen)
 }
 
 func readTopic(t *testing.T, root, name string) string {
@@ -114,7 +75,7 @@ func readTopic(t *testing.T, root, name string) string {
 // topic must see the same six fields plus the previousTransition alias.
 func TestHelpTopics_LifecycleFieldParity(t *testing.T) {
 	root := repoRoot(t)
-	accepted := acceptedLifecycleFields(t, root)
+	accepted := commontest.MatchLifecycleFields(t)
 
 	workflows := topicSentence(t,
 		readTopic(t, root, "workflows.md"),
@@ -151,7 +112,7 @@ func TestHelpTopics_ConditionTypeParity(t *testing.T) {
 	if len(catalogued) == 0 {
 		t.Fatal("search.md: no **XCondition** headings found")
 	}
-	if want := sortedKeys(catalogued); !reflect.DeepEqual(documented, want) {
+	if want := commontest.SortedKeys(catalogued); !reflect.DeepEqual(documented, want) {
 		t.Errorf("workflows.md lists condition types %v; search.md catalogues %v", documented, want)
 	}
 

--- a/cmd/cyoda/help/condition_docs_parity_test.go
+++ b/cmd/cyoda/help/condition_docs_parity_test.go
@@ -1,0 +1,166 @@
+package help
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+)
+
+// The `workflows` CRITERIA section and the `search` Condition-DSL section
+// describe the same evaluation kernel (predicate.ParseCondition ->
+// match.Match). These guards pin both topics to the source of truth so the
+// two cannot drift apart, or away from the code, again.
+
+var (
+	// matchLifecycleFunc isolates the body of matchLifecycle in
+	// internal/match/match.go. The body's closing brace is the only "}" at
+	// column 0 after the signature, so the non-greedy match stops there.
+	matchLifecycleFunc = regexp.MustCompile(`(?s)func matchLifecycle\(.*?\n}`)
+	// caseLabel captures each `case "field":` label of that switch — the
+	// canonical lifecycle-field vocabulary.
+	caseLabel = regexp.MustCompile(`case "([A-Za-z]+)":`)
+	// lifecycleAlias captures the `field == "x"` -> `field = "y"` alias
+	// normalisation performed on entry.
+	lifecycleAlias = regexp.MustCompile(`field == "([A-Za-z]+)"\s*\{\s*field = "([A-Za-z]+)"`)
+	// backticked captures each `token` in a markdown span.
+	backticked = regexp.MustCompile("`([A-Za-z]+)`")
+	// searchConditionHeading captures the **XCondition** headings that form
+	// the search topic's condition-type catalogue.
+	searchConditionHeading = regexp.MustCompile(`(?m)^\*\*([A-Za-z]+)Condition\*\*`)
+)
+
+// acceptedLifecycleFields derives the lifecycle (meta) field vocabulary from
+// matchLifecycle: every switch case, plus the alias it normalises on entry.
+func acceptedLifecycleFields(t *testing.T, root string) []string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join(root, "internal/match/match.go"))
+	if err != nil {
+		t.Fatalf("read match.go: %v", err)
+	}
+	body := matchLifecycleFunc.Find(src)
+	if body == nil {
+		t.Fatal("matchLifecycle not found in internal/match/match.go")
+	}
+	fields := map[string]bool{}
+	for _, m := range caseLabel.FindAllStringSubmatch(string(body), -1) {
+		fields[m[1]] = true
+	}
+	for _, m := range lifecycleAlias.FindAllStringSubmatch(string(body), -1) {
+		if !fields[m[2]] {
+			t.Errorf("alias %q normalises to %q, which is not a switch case", m[1], m[2])
+		}
+		fields[m[1]] = true
+	}
+	if len(fields) == 0 {
+		t.Fatal("no lifecycle fields extracted from matchLifecycle")
+	}
+	return sortedKeys(fields)
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// topicSentence returns the backticked tokens listed after marker in body, up
+// to the end of that sentence. Doc lists are written as a run of `code` spans
+// terminated by ". " (prose) or by the end of the line (a markdown list item),
+// whichever comes first.
+func topicSentence(t *testing.T, body, marker, topic string) []string {
+	t.Helper()
+	i := strings.Index(body, marker)
+	if i < 0 {
+		t.Fatalf("%s: marker %q not found", topic, marker)
+	}
+	rest := body[i+len(marker):]
+	for _, terminator := range []string{". ", "\n"} {
+		if end := strings.Index(rest, terminator); end >= 0 {
+			rest = rest[:end]
+		}
+	}
+	seen := map[string]bool{}
+	for _, m := range backticked.FindAllStringSubmatch(rest, -1) {
+		seen[m[1]] = true
+	}
+	if len(seen) == 0 {
+		t.Fatalf("%s: no `code` tokens after %q", topic, marker)
+	}
+	return sortedKeys(seen)
+}
+
+func readTopic(t *testing.T, root, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, "cmd/cyoda/help/content", name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// TestHelpTopics_LifecycleFieldParity asserts that the lifecycle-field list in
+// the `workflows` CRITERIA section and in the `search` LifecycleCondition
+// section both match the field vocabulary matchLifecycle actually accepts.
+// A criterion and a search filter share one evaluator, so a reader of either
+// topic must see the same six fields plus the previousTransition alias.
+func TestHelpTopics_LifecycleFieldParity(t *testing.T) {
+	root := repoRoot(t)
+	accepted := acceptedLifecycleFields(t, root)
+
+	workflows := topicSentence(t,
+		readTopic(t, root, "workflows.md"),
+		"`lifecycle` criteria match entity metadata fields:",
+		"workflows.md")
+	if !reflect.DeepEqual(workflows, accepted) {
+		t.Errorf("workflows.md documents lifecycle fields %v; matchLifecycle accepts %v", workflows, accepted)
+	}
+
+	search := topicSentence(t,
+		readTopic(t, root, "search.md"),
+		"- `field`:",
+		"search.md")
+	if !reflect.DeepEqual(search, accepted) {
+		t.Errorf("search.md documents lifecycle fields %v; matchLifecycle accepts %v", search, accepted)
+	}
+}
+
+// TestHelpTopics_ConditionTypeParity asserts the `workflows` CRITERIA section
+// lists exactly the condition types the `search` topic catalogues, and that
+// every one of them is a type ParseCondition accepts.
+func TestHelpTopics_ConditionTypeParity(t *testing.T) {
+	root := repoRoot(t)
+
+	documented := topicSentence(t,
+		readTopic(t, root, "workflows.md"),
+		"condition types are supported:",
+		"workflows.md")
+
+	catalogued := map[string]bool{}
+	for _, m := range searchConditionHeading.FindAllStringSubmatch(readTopic(t, root, "search.md"), -1) {
+		catalogued[strings.ToLower(m[1])] = true
+	}
+	if len(catalogued) == 0 {
+		t.Fatal("search.md: no **XCondition** headings found")
+	}
+	if want := sortedKeys(catalogued); !reflect.DeepEqual(documented, want) {
+		t.Errorf("workflows.md lists condition types %v; search.md catalogues %v", documented, want)
+	}
+
+	for _, typ := range documented {
+		if _, err := predicate.ParseCondition([]byte(`{"type":"` + typ + `"}`)); err != nil {
+			t.Errorf("condition type %q documented but rejected by ParseCondition: %v", typ, err)
+		}
+	}
+	if _, err := predicate.ParseCondition([]byte(`{"type":"no-such-condition"}`)); err == nil {
+		t.Error("ParseCondition accepted an unknown condition type; the acceptance check above proves nothing")
+	}
+}

--- a/cmd/cyoda/help/content/workflows.md
+++ b/cmd/cyoda/help/content/workflows.md
@@ -410,9 +410,9 @@ fire time. Use only for workflows whose cyclicity is intentional.
 
 ## CRITERIA
 
-Criteria on workflows and transitions use the same `Condition` DSL as search. All four condition types are supported: `simple`, `lifecycle`, `group`, `array`. Criteria are evaluated in-memory against the entity's JSON payload and lifecycle metadata.
+Criteria on workflows and transitions use the same `Condition` DSL as search — five condition types are supported: `simple`, `lifecycle`, `group`, `array`, `function`. All but `function` are evaluated in-memory against the entity's JSON payload and lifecycle metadata; a `function` criterion is dispatched to a compute member and must be the whole criterion — one nested inside a `group` fails the evaluation. See `cyoda help search` for the per-type JSON shapes.
 
-`simple` criteria match entity data fields via JSONPath. `lifecycle` criteria match `state`, `creationDate`, or `previousTransition` from entity metadata.
+`simple` criteria match entity data fields via JSONPath. `lifecycle` criteria match entity metadata fields: `state`, `creationDate`, `lastUpdateTime`, `transitionForLatestSave` (alias `previousTransition`), `transactionId`, `id`. `creationDate` and `lastUpdateTime` are temporal — compared chronologically, exactly as in search.
 
 A `null` criterion on a workflow means the workflow matches any entity. A `null` criterion on a transition means the transition always fires (automated) or is always available (manual). When multiple automated transitions are eligible, the engine selects the first one by declaration order whose criterion matches. A `null` criterion matches unconditionally, so a `null`-criterion automated transition must be the last automated transition in declaration order; any automated transitions declared after a `null`-criterion transition are unreachable.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -246,7 +246,7 @@ have changed.
 | Type | Evaluation | Description |
 |------|-----------|-------------|
 | **Simple** | Local | JSONPath expression + operator + value against entity data |
-| **Lifecycle** | Local | Predicate on entity metadata (state, creationDate, previousTransition) |
+| **Lifecycle** | Local | Predicate on entity metadata (state, creationDate, lastUpdateTime, transitionForLatestSave, transactionId, id) |
 | **Group** | Local | AND/OR composition with arbitrary nesting depth |
 | **Array** | Local | Positional matching against array elements |
 | **Function** | Remote | Delegated to external compute node via gRPC CloudEvents |
@@ -444,7 +444,7 @@ above.
 | Type | Description |
 |------|-------------|
 | **Simple** | JSONPath + operator + value against entity data |
-| **Lifecycle** | Predicate on entity metadata (state, creationDate, previousTransition) |
+| **Lifecycle** | Predicate on entity metadata (state, creationDate, lastUpdateTime, transitionForLatestSave, transactionId, id) |
 | **Group** | AND/OR composition with arbitrary nesting |
 | **Array** | Positional matching against array elements |
 | **Function** | Delegated to external compute node via gRPC |

--- a/internal/common/commontest/metavocab.go
+++ b/internal/common/commontest/metavocab.go
@@ -1,0 +1,98 @@
+package commontest
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// The lifecycle (meta) field vocabulary exists in three places that must agree:
+// search.sortableMetaFields (the allowlist the search boundary and
+// workflow-criterion import validate against), match.matchLifecycle's switch
+// (the evaluator both paths ultimately run), and the `workflows` / `search`
+// help topics. internal/match cannot import internal/domain/search — the
+// reverse import already exists — so the evaluator's copy is hand-kept and
+// only a test can hold the three in step. This helper supplies the evaluator's
+// copy, read out of its source, to whichever package is doing the comparing.
+var (
+	// matchLifecycleFunc isolates the body of matchLifecycle. The body's
+	// closing brace is the only "}" at column 0 after the signature, so the
+	// non-greedy match stops there.
+	matchLifecycleFunc = regexp.MustCompile(`(?s)func matchLifecycle\(.*?\n}`)
+	// caseClause captures everything between `case ` and its colon, so a
+	// multi-label clause (`case "a", "b":`) yields both labels rather than
+	// silently matching neither.
+	caseClause = regexp.MustCompile(`case ([^\n:]+):`)
+	// quoted captures each string literal within a case clause.
+	quoted = regexp.MustCompile(`"([^"]*)"`)
+	// lifecycleAlias captures the `field == "x"` -> `field = "y"` alias
+	// normalisation performed on entry.
+	lifecycleAlias = regexp.MustCompile(`field == "([^"]+)"\s*\{\s*field = "([^"]+)"`)
+)
+
+// MatchLifecycleFields returns, sorted, every lifecycle field name
+// match.matchLifecycle accepts: each label of its switch plus each alias it
+// normalises on entry. Derived from the source rather than exercised through
+// the function, so that a field the evaluator gained but nobody documented is
+// visible to the caller instead of being invisible to an enumeration test.
+func MatchLifecycleFields(t *testing.T) []string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join(RepoRoot(t), "internal/match/match.go"))
+	if err != nil {
+		t.Fatalf("read match.go: %v", err)
+	}
+	body := matchLifecycleFunc.Find(src)
+	if body == nil {
+		t.Fatal("matchLifecycle not found in internal/match/match.go")
+	}
+	fields := map[string]bool{}
+	for _, clause := range caseClause.FindAllStringSubmatch(string(body), -1) {
+		for _, label := range quoted.FindAllStringSubmatch(clause[1], -1) {
+			fields[label[1]] = true
+		}
+	}
+	for _, m := range lifecycleAlias.FindAllStringSubmatch(string(body), -1) {
+		if !fields[m[2]] {
+			t.Errorf("alias %q normalises to %q, which is not a switch case", m[1], m[2])
+		}
+		fields[m[1]] = true
+	}
+	if len(fields) == 0 {
+		t.Fatal("no lifecycle fields extracted from matchLifecycle")
+	}
+	return SortedKeys(fields)
+}
+
+// SortedKeys returns the keys of a set in sorted order, for stable comparison
+// and readable failure messages.
+func SortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// RepoRoot walks up from the working directory to the directory holding
+// go.mod. Skips the test if there is none.
+func RepoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(root, "go.mod")); statErr == nil {
+			return root
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			t.Skip("cannot locate repo root; test skipped")
+			return ""
+		}
+		root = parent
+	}
+}

--- a/internal/domain/search/meta_vocabulary_test.go
+++ b/internal/domain/search/meta_vocabulary_test.go
@@ -1,0 +1,34 @@
+package search
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common/commontest"
+)
+
+// TestMetaVocabulary_EvaluatorMatchesAllowlist pins the invariant
+// workflow/validate.go's doc comment asserts but nothing enforced: the meta
+// vocabulary this package validates against (sortableMetaFields, plus the
+// previousTransition alias) is exactly the vocabulary match.matchLifecycle
+// evaluates. internal/match cannot import this package — the reverse import
+// already exists — so the evaluator keeps a hand-written second copy of the
+// switch and only a test can hold the two in step.
+//
+// The two directions fail differently, and both are bugs:
+//   - allowlist ⊃ evaluator: the boundary accepts a field the evaluator then
+//     rejects as unknown, turning a valid-looking condition into a 500.
+//   - evaluator ⊃ allowlist: a field that works in-process is refused at the
+//     API boundary as an unknown meta filter field.
+func TestMetaVocabulary_EvaluatorMatchesAllowlist(t *testing.T) {
+	allowed := map[string]bool{"previousTransition": true}
+	for name := range sortableMetaFields {
+		allowed[name] = true
+	}
+	want := commontest.SortedKeys(allowed)
+
+	got := commontest.MatchLifecycleFields(t)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("matchLifecycle accepts %v; this package's meta allowlist is %v", got, want)
+	}
+}

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -908,6 +908,25 @@ func TestMatchFunctionConditionError(t *testing.T) {
 	}
 }
 
+// A FUNCTION criterion is dispatched to a compute member by the engine only
+// when it is the whole criterion; nested inside a group it reaches this
+// evaluator, which has no dispatcher and fails closed rather than silently
+// treating the branch as a non-match. The `workflows` help topic documents
+// this restriction — keep the two in step.
+func TestMatchFunctionConditionNestedInGroupError(t *testing.T) {
+	cond := &predicate.GroupCondition{
+		Operator: "AND",
+		Conditions: []predicate.Condition{
+			&predicate.SimpleCondition{JsonPath: "$.name", OperatorType: "EQUALS", Value: "Alice"},
+			&predicate.FunctionCondition{},
+		},
+	}
+	_, err := Match(cond, sampleData, meta(), sampleTypes)
+	if err == nil {
+		t.Error("expected error for a function condition nested in a group")
+	}
+}
+
 // --- 17. IS_CHANGED → error ---
 
 func TestMatchIsChangedError(t *testing.T) {


### PR DESCRIPTION
Closes #455.

First change on the `release/v0.8.4` milestone branch.

## What was wrong

`cmd/cyoda/help/content/workflows.md` §CRITERIA made two claims narrower than what the engine accepts:

1. **"All four condition types are supported: `simple`, `lifecycle`, `group`, `array`."** — there are five; `function` is supported in criteria and dispatched to a compute member (`engine.evaluateCriterion`). The word *All* made this exhaustive-and-wrong rather than merely incomplete.
2. **lifecycle criteria match `state`, `creationDate`, or `previousTransition`** — `matchLifecycle` accepts six fields, and `previousTransition` is an alias normalised to `transitionForLatestSave`, not the canonical name.

Criteria and search share one evaluation kernel, so the topic disagreed with `cyoda help search`, which already documents both sets correctly. Documentation-only — no engine behaviour was wrong.

## Changes

- **`workflows.md` §CRITERIA** — five condition types; all six lifecycle fields mirroring the `search` topic's wording, with `creationDate`/`lastUpdateTime` marked temporal. Also states how `function` differs: dispatched rather than evaluated in-memory, and valid only as the whole criterion — nested inside a `group` it reaches the in-process evaluator, which fails closed.
- **`cmd/cyoda/help/condition_docs_parity_test.go`** (new) — two guards, in the shape of the existing `TestErrCode_Parity` / env-var source-scan guards:
  - `TestHelpTopics_LifecycleFieldParity` — the field list documented in *both* topics must equal what `matchLifecycle` accepts.
  - `TestHelpTopics_ConditionTypeParity` — the type list in `workflows.md` must equal the `**XCondition**` catalogue in `search.md`, and every documented type must be accepted by `predicate.ParseCondition` (with an unknown-type probe so the acceptance check can't pass vacuously).
- **`internal/domain/search/meta_vocabulary_test.go`** (new) — the lifecycle vocabulary lives in three places and only one pair was guarded. `sortableMetaFields` is the documented source of truth and gates acceptance at the search boundary and at workflow-criterion import; `matchLifecycle`'s switch is a hand-kept second copy, forced by the import direction (`search` → `match`, so `match` cannot import back). `validate.go` asserts in a comment that the two stay identical — nothing enforced it. An allowlist that outgrows the evaluator turns a valid-looking condition into a 500; an evaluator that outgrows the allowlist refuses a field that works in-process. Now pinned.
- **`internal/common/commontest/metavocab.go`** (new) — one extraction of the evaluator's vocabulary, shared by both guards. Reads whole `case` clauses, so a multi-label refactor of the switch keeps the guard honest instead of silently narrowing what it compares.
- **`internal/match/match_test.go`** — pins the newly documented nesting restriction: a `FunctionCondition` inside a `GroupCondition` errors.
- **`api/openapi.yaml`** — the async-search endpoint description carried the identical three-field lifecycle list; corrected, and array conditions added to its predicate list. Prose only, no schema change.
- **`docs/PRD.md`** — same three-field list in two tables; corrected.
- **CHANGELOG** — `[Unreleased] → Fixed`.

## Verification

- Guards were watched failing first: `TestHelpTopics_ConditionTypeParity` reproduced the issue verbatim (`workflows.md lists [array group lifecycle simple]; search.md catalogues [array function group lifecycle simple]`). Each guard was then re-confirmed by perturbation — deleting `id` from the topic, deleting `transactionId` from `sortableMetaFields`, and rewriting the switch to a multi-label `case "transitionForLatestSave", "previousTransition":` (which the guard survives).
- `go vet ./...` clean, `gofmt` clean, `go test ./...` green including `internal/e2e` against real PostgreSQL.

## Note

The self-contradiction the issue reported at `workflows.md:66` ("the same condition types as transition criteria (simple, group, function)") does not exist in the current file — only the two §CRITERIA statements needed fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcbMZuZc3cbxZTevKpeL7w