### PR TITLE
test(e2e): goroutine safety and coverage; fix the payload defects it surfaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   The memory and sqlite stores were unaffected, so this was also a backend divergence.
   ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
 
-- **Unpaired UTF-16 surrogates and invalid UTF-8 in an entity payload are now
+- **Unpaired UTF-16 surrogates and invalid UTF-8 in an HTTP entity payload are now
   rejected with 400 on every backend.** Both are accepted by Go's JSON parser and
   rejected by PostgreSQL text/jsonb, so they reached the store and came back as
   **500 SERVER_ERROR** with a support ticket, while memory and sqlite accepted them —
@@ -78,7 +78,9 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   both forms to U+FFFD, so validating the decoded value cannot see them, and
   re-serialising it would store a replacement character the client never sent.
   Correctly paired surrogates, literal emoji and a client-sent U+FFFD remain valid
-  payload content.
+  payload content. Note this covers the HTTP ingress: the gRPC entity API decodes
+  its payload into a Go value before the guard runs, which normalises these two
+  forms away, so they cannot be detected there — tracked separately.
   ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
 
 - **An entity payload containing a NUL (U+0000) is now rejected with 400 on every
@@ -89,7 +91,7 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   payload, making the set of storable values depend on the backend. All entity write
   paths (create, batch-array create, collection create, update, collection update)
   now reject it at the boundary with 400 `BAD_REQUEST`, naming the offending field
-  path. Covered by a cross-backend parity scenario.
+  path. (NUL survives the gRPC ingress's decode, so it is caught there too.) Covered by a cross-backend parity scenario.
   ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
 
 - **A request body with trailing content after a valid JSON value now returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ## [Unreleased]
 
+### Changed
+
+- **A workflow processor's returned data is now governed by the model, exactly as a
+  client's write is.** Previously a processor could write anything at all: content no
+  backend could store (returning **500**), or fields the model does not declare —
+  producing an entity the API would return but then refuse to accept back on a `PUT`,
+  and that the model export did not mention. Returned data now passes the same
+  storability guard and the same schema validation or extension as a client write, so
+  a processor may introduce a new field exactly where the model's `changeLevel` would
+  let a client do so, and not otherwise. When it may not, the transition fails with
+  **400 WORKFLOW_FAILED** and rolls back, leaving neither the entity nor any schema
+  change behind — rather than blaming the caller, who sent nothing invalid.
+
+  **Integrators:** a processor that writes a field outside its model now needs that
+  model's `changeLevel` set, or the field declared in the model. This applies to
+  every ingress that runs a cascade, including scheduled transitions and
+  peer-forwarded dispatch.
+  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
+
 ### Fixed
 
 - **A payload that repeats a name within one object is now rejected with 400.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **A request body with trailing content after a valid JSON value now returns
+  400, not 500.** `POST /entity/{format}/{name}/{version}` accepted a body such as
+  `{"x":1}}}`: the decoder stops at the end of the first JSON value and ignores
+  whatever follows, so the request passed validation while the *original* — still
+  malformed — bytes went on to be persisted, surfacing the client's input error as
+  a storage failure with a support ticket. Entity payload decoding now requires the
+  body to hold exactly one JSON value, matching `json.Unmarshal`.
+  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
+
 - **Point-in-time tests no longer compare two clocks.** `TestParity/GetAllEntitiesAsAt`
   flaked on postgres: it built its `pointInTime` from the test process's clock and
   compared it against version times stamped by the *database* — on a testcontainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **An entity payload containing a NUL (U+0000) is now rejected with 400 on every
+  backend.** `{"name":"a\u0000b"}` is valid JSON and passes schema validation, but
+  PostgreSQL's text and jsonb types cannot represent U+0000 — so the write reached
+  the store and failed there, returning **500 SERVER_ERROR** with a support ticket
+  for what is a client input error. The memory and sqlite stores accepted the same
+  payload, making the set of storable values depend on the backend. All entity write
+  paths (create, batch-array create, collection create, update, collection update)
+  now reject it at the boundary with 400 `BAD_REQUEST`, naming the offending field
+  path. Covered by a cross-backend parity scenario.
+  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
+
 - **A request body with trailing content after a valid JSON value now returns
   400, not 500.** `POST /entity/{format}/{name}/{version}` accepted a body such as
   `{"x":1}}}`: the decoder stops at the end of the first JSON value and ignores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **An empty entity payload no longer makes the entity — and its whole model's
+  listing — permanently unreadable on PostgreSQL.** `{}` was accepted with 200 and
+  then failed every subsequent read with **500 SERVER_ERROR**: not only `GET` of that
+  entity, but `GET /entity/{model}/{version}` for the entire model, because one
+  unreadable row failed the whole listing. Updating a healthy, readable entity to `{}`
+  bricked it the same way. The plugin merges its `_meta` block into the domain data,
+  so `{}` was stored as `{"_meta":…}`; on read `_meta` was removed and nothing
+  remained, leaving no data to decode. An empty payload now round-trips as `{}`, while
+  a DELETED version — which legitimately carries no domain data — still reports none.
+  The memory and sqlite stores were unaffected, so this was also a backend divergence.
+  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
+
+- **Unpaired UTF-16 surrogates and invalid UTF-8 in an entity payload are now
+  rejected with 400 on every backend.** Both are accepted by Go's JSON parser and
+  rejected by PostgreSQL text/jsonb, so they reached the store and came back as
+  **500 SERVER_ERROR** with a support ticket, while memory and sqlite accepted them —
+  the same divergence as the NUL case below. The guard reads the raw request bytes
+  rather than the decoded value, which is load-bearing: Go's decoder silently rewrites
+  both forms to U+FFFD, so validating the decoded value cannot see them, and
+  re-serialising it would store a replacement character the client never sent.
+  Correctly paired surrogates, literal emoji and a client-sent U+FFFD remain valid
+  payload content.
+  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
+
 - **An entity payload containing a NUL (U+0000) is now rejected with 400 on every
   backend.** `{"name":"a\u0000b"}` is valid JSON and passes schema validation, but
   PostgreSQL's text and jsonb types cannot represent U+0000 — so the write reached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **A payload that repeats a name within one object is now rejected with 400.**
+  A duplicated name was read as the *last* occurrence by schema validation, the `GET`
+  response and unique-key computation, and as the *first* by the workflow criterion
+  evaluator, search and grouped statistics — on the same bytes in the same request.
+  An entity created with `{"amount":"not-a-number","amount":5}` was reported by the API
+  as `amount=5` while a criterion `amount == 5` did not fire, leaving it in the wrong
+  workflow state with nothing logged. All three backends were affected, since the
+  criterion runs against the request bytes before any store normalisation. Names
+  repeated in sibling objects, across array elements or at different depths are
+  ordinary JSON and remain accepted. RFC 8259 permits rejecting duplicate names.
+  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
+
+- **A number outside PostgreSQL's `numeric` range is now rejected with 400 instead of
+  failing inside the store.** Beyond 131072 digits before the decimal point or 16383
+  after, the write returned **500 SERVER_ERROR** on postgres while memory and sqlite
+  accepted it. Only reachable on a field that inferred an unbounded numeric type. The
+  check is on the *effective* weight and scale, so `1.5e-16383` is rejected despite
+  having one fraction digit and an in-range exponent, while `0.0001e131075` is accepted
+  because leading zeros are not significant. It is purely lexical — deciding that
+  `1e1000000` is too large never builds a million-digit value.
+  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
+
+- **A processor returning `{"data":null}` no longer panics and leaks a database
+  connection.** The literal `null` is non-empty, so it passed the empty-payload check
+  and then unmarshalled into a *nil map*, and assigning into a nil map panics. The
+  panic was recovered only by the HTTP middleware several packages up, unwinding past
+  the entity service's non-deferred rollback — so the transaction was neither committed
+  nor rolled back and its pooled connection was never returned. Repeated, that exhausts
+  the pool and the node stops serving. The plugin now returns a clean error, so the
+  normal error path runs and the transaction is released.
+  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
+
 - **An empty entity payload no longer makes the entity — and its whole model's
   listing — permanently unreadable on PostgreSQL.** `{}` was accepted with 200 and
   then failed every subsequent read with **500 SERVER_ERROR**: not only `GET` of that

--- a/cmd/cyoda/help/content/errors/WORKFLOW_FAILED.md
+++ b/cmd/cyoda/help/content/errors/WORKFLOW_FAILED.md
@@ -12,7 +12,7 @@ see_also:
 
 ## NAME
 
-WORKFLOW_FAILED — a workflow processor or guard condition returned a failure during entity state transition.
+WORKFLOW_FAILED — a workflow processor or guard condition returned a failure during entity state transition, or returned data the model rejects.
 
 ## SYNOPSIS
 

--- a/cmd/cyoda/help/content/grpc.md
+++ b/cmd/cyoda/help/content/grpc.md
@@ -269,6 +269,8 @@ Client responds with `EntityProcessorCalculationResponse`:
 
 When `success=false`, the workflow engine fails the processor dispatch. When `payload.data` is non-null, the engine replaces the entity's data with the returned value before continuing the workflow.
 
+Returned data is subject to the same checks as a client write: it must be storable, and it must satisfy the model's schema. A processor may introduce a field the model does not declare only where the model's `changeLevel` would allow a client to — otherwise the transition fails with `WORKFLOW_FAILED` and rolls back. The engine holds no privilege here: whatever it stores, the API must be able to accept back.
+
 **Criteria dispatch (server → client):**
 
 Server sends `EntityCriteriaCalculationRequest` when a workflow transition evaluates a `function`-type criterion:

--- a/cmd/cyoda/help/content/grpc.md
+++ b/cmd/cyoda/help/content/grpc.md
@@ -269,7 +269,7 @@ Client responds with `EntityProcessorCalculationResponse`:
 
 When `success=false`, the workflow engine fails the processor dispatch. When `payload.data` is non-null, the engine replaces the entity's data with the returned value before continuing the workflow.
 
-Returned data is subject to the same checks as a client write: it must be storable, and it must satisfy the model's schema. A processor may introduce a field the model does not declare only where the model's `changeLevel` would allow a client to — otherwise the transition fails with `WORKFLOW_FAILED` and rolls back. The engine holds no privilege here: whatever it stores, the API must be able to accept back.
+Returned data is subject to the same checks as an HTTP client write: it must be storable, and it must satisfy the model's schema. A processor may introduce a field the model does not declare only where the model's `changeLevel` would allow a client to — otherwise the transition fails with `WORKFLOW_FAILED` and rolls back. The engine holds no privilege here: whatever it stores, the API must be able to accept back.
 
 **Criteria dispatch (server → client):**
 

--- a/cmd/cyoda/help/content/models.md
+++ b/cmd/cyoda/help/content/models.md
@@ -306,6 +306,8 @@ Transitions:
 
 The `changeLevel` field controls schema evolution on locked models. When set, entity ingestion that introduces new structure triggers an additive schema extension (delta computed via `schema.Diff`, appended via `ModelStore.ExtendSchema`, committed with the entity transaction).
 
+Entity ingestion here includes data returned by a workflow processor, not just data sent by a client. A processor that writes a field the model does not declare needs `changeLevel` set exactly as a client would.
+
 ## ERRORS
 
 - `errors.MODEL_NOT_FOUND` — `404` — model does not exist for the given name and version

--- a/cmd/cyoda/help/content/workflows.md
+++ b/cmd/cyoda/help/content/workflows.md
@@ -139,6 +139,8 @@ The engine enforces a per-state visit limit of 10 by default (configurable via `
 
 ## PROCESSORS
 
+A processor may return modified entity data. That data is governed by the model exactly as a client's write is: it must be storable, and it must satisfy the schema. Introducing a field the model does not declare requires the model's `changeLevel` to permit it; otherwise the transition fails with `WORKFLOW_FAILED` and rolls back, leaving neither the entity nor any schema change behind.
+
 **ProcessorDefinition fields:**
 
 - `type` — string — execution-location axis; see below for valid values

--- a/e2e/parity/attribution.go
+++ b/e2e/parity/attribution.go
@@ -312,8 +312,8 @@ func RunAttributionCascadeJoinedWrite(t *testing.T, fixture BackendFixture) {
 	const primary = "attr-cascade-primary"
 	const marker = "attr-cascade-mark"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
-	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`,
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
+	cbSetupModel(t, c, primary, cbSampleCreateSecondary,
 		cbPrimaryProcWorkflow("attr-cascade-wf", "cb-create-secondary", "SYNC", cbContext(secondary, marker)))
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)

--- a/e2e/parity/callback_txjoin.go
+++ b/e2e/parity/callback_txjoin.go
@@ -109,6 +109,33 @@ func cbPrimaryProcWorkflow(wfName, procName, execMode, contextValue string) stri
 	})
 }
 
+// cbSample* — primary-model samples for the callback scenarios.
+//
+// A callback processor stamps its observations back onto the primary's data,
+// and processor output passes the SAME model checks a client write does: the
+// model must DECLARE every field the processor writes. Each sample therefore
+// seeds the exact field set of the processor the scenario runs, at ZERO VALUE —
+// the sample states the field's type, never the value under test. Seeding
+// (rather than loosening the model's changeLevel) keeps the model strict, so a
+// mistyped field name in a processor still fails loudly instead of silently
+// widening the model and hollowing out the scenario's assertions.
+const (
+	// cbSampleNoWriteback — processors that fail before returning data.
+	cbSampleNoWriteback = `{"name":"Test","amount":10,"status":"new"}`
+	// cbSampleSecondary — the secondary model, written only by clients.
+	cbSampleSecondary = `{"name":"child","amount":1,"status":"new"}`
+	// cbSampleCreateSecondary — cb-create-secondary / cb-grpc-create-secondary.
+	cbSampleCreateSecondary = `{"name":"Test","amount":10,"status":"new","secondaryId":"","secondaryTxId":"","tokenWasEmpty":false}`
+	// cbSampleReadYourWrites — cb-read-your-writes.
+	cbSampleReadYourWrites = `{"name":"Test","amount":10,"status":"new","secondaryId":"","readbackFound":false,"readbackMarker":""}`
+	// cbSampleGRPCSearchRYW — cb-grpc-search-read-your-writes.
+	cbSampleGRPCSearchRYW = `{"name":"Test","amount":10,"status":"new","secondaryId":"","grpcSearchJoinedCount":0,"grpcSearchStandaloneCount":0}`
+	// cbSampleIfMatchUpdate — cb-ifmatch-update.
+	cbSampleIfMatchUpdate = `{"name":"Test","amount":10,"status":"new","secondaryId":"","ifMatchStatus":0,"ifMatchOK":false}`
+	// cbSampleConditionalDelete — cb-conditional-delete.
+	cbSampleConditionalDelete = `{"name":"Test","amount":10,"status":"new","deleteEntityId":"","keepEntityId":"","tokenWasEmpty":false}`
+)
+
 // cbSetupModel imports + locks a model with the given sample doc, then imports
 // the workflow. Unlike setupModelWithWorkflow it takes an explicit sample doc so
 // callers can seed marker-bearing fields.
@@ -143,10 +170,10 @@ func RunCallbackSyncWriteAtomic(t *testing.T, fixture BackendFixture) {
 	const okMarker = "cbtj-atomic-ok"
 	const doomedMarker = "cbtj-atomic-doomed"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
 
 	// --- success branch ---
-	cbSetupModel(t, c, primaryOK, `{"name":"Test","amount":10,"status":"new"}`,
+	cbSetupModel(t, c, primaryOK, cbSampleCreateSecondary,
 		cbPrimaryProcWorkflow("cbtj-atomic-ok-wf", "cb-create-secondary", "SYNC", cbContext(secondary, okMarker)))
 
 	primaryID, err := c.CreateEntity(t, primaryOK, 1, `{"name":"parent","amount":100,"status":"new"}`)
@@ -196,7 +223,7 @@ func RunCallbackSyncWriteAtomic(t *testing.T, fixture BackendFixture) {
 	cbAssertSameTxID(t, c, primaryID, secID)
 
 	// --- failure branch (THE ATOMICITY PROOF) ---
-	cbSetupModel(t, c, primaryFail, `{"name":"Test","amount":10,"status":"new"}`,
+	cbSetupModel(t, c, primaryFail, cbSampleNoWriteback,
 		cbPrimaryProcWorkflow("cbtj-atomic-fail-wf", "cb-create-then-fail", "SYNC", cbContext(secondary, doomedMarker)))
 
 	status, body, err := c.CreateEntityRaw(t, primaryFail, 1, `{"name":"parent2","amount":100,"status":"new"}`)
@@ -231,8 +258,8 @@ func RunCallbackSyncReadYourWrites(t *testing.T, fixture BackendFixture) {
 	const primary = "cbtj-ryw-primary"
 	const marker = "cbtj-ryw-marker"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
-	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`,
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
+	cbSetupModel(t, c, primary, cbSampleReadYourWrites,
 		cbPrimaryProcWorkflow("cbtj-ryw-wf", "cb-read-your-writes", "SYNC", cbContext(secondary, marker)))
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
@@ -268,8 +295,8 @@ func RunCallbackGRPCSearchReadYourWrites(t *testing.T, fixture BackendFixture) {
 	const primary = "cbtj-gsearch-primary"
 	const marker = "cbtj-gsearch-marker"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
-	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`,
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
+	cbSetupModel(t, c, primary, cbSampleGRPCSearchRYW,
 		cbPrimaryProcWorkflow("cbtj-gsearch-wf", "cb-grpc-search-read-your-writes", "SYNC", cbContext(secondary, marker)))
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
@@ -308,7 +335,7 @@ func RunCallbackCriteriaReadYourWrites(t *testing.T, fixture BackendFixture) {
 	const primary = "cbtj-crit-primary"
 	const marker = "cbtj-crit-marker"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
 
 	ctxVal := cbContext(secondary, marker)
 	wf := cbWorkflowDoc("cbtj-crit-wf", map[string]any{
@@ -327,7 +354,7 @@ func RunCallbackCriteriaReadYourWrites(t *testing.T, fixture BackendFixture) {
 		}}},
 		"APPROVED": map[string]any{},
 	})
-	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`, wf)
+	cbSetupModel(t, c, primary, cbSampleCreateSecondary, wf)
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if err != nil {
@@ -359,8 +386,8 @@ func RunCallbackIfMatchUpdate(t *testing.T, fixture BackendFixture) {
 	const primary = "cbtj-ifmatch-primary"
 	const marker = "cbtj-ifmatch-marker"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
-	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`,
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
+	cbSetupModel(t, c, primary, cbSampleIfMatchUpdate,
 		cbPrimaryProcWorkflow("cbtj-ifmatch-wf", "cb-ifmatch-update", "SYNC", cbContext(secondary, marker)))
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
@@ -389,11 +416,11 @@ func RunCallbackEmptyTokenStandalone(t *testing.T, fixture BackendFixture) {
 	const primary = "cbtj-standalone-primary"
 	const marker = "cbtj-standalone"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
 	// COMMIT_BEFORE_DISPATCH default (startNewTxOnDispatch omitted → false):
 	// the dispatcher sends no tx-token, so the processor's callback runs
 	// standalone.
-	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`,
+	cbSetupModel(t, c, primary, cbSampleCreateSecondary,
 		cbPrimaryProcWorkflow("cbtj-standalone-wf", "cb-create-secondary", "COMMIT_BEFORE_DISPATCH", cbContext(secondary, marker)))
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
@@ -454,7 +481,7 @@ func RunCallback_CBDPostJoinsTxPost(t *testing.T, fixture BackendFixture) {
 	const primary = "cbtj-cbd-post-primary"
 	const marker = "cbtj-cbd-post"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
 
 	// Build the workflow inline: COMMIT_BEFORE_DISPATCH + startNewTxOnDispatch=true.
 	// cbPrimaryProcWorkflow does not support startNewTxOnDispatch, so inline here.
@@ -467,7 +494,7 @@ func RunCallback_CBDPostJoinsTxPost(t *testing.T, fixture BackendFixture) {
 		}}},
 		"ACTIVE": map[string]any{},
 	})
-	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`, wf)
+	cbSetupModel(t, c, primary, cbSampleCreateSecondary, wf)
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if err != nil {
@@ -522,8 +549,8 @@ func RunCallback_AsyncNewTxDiscardOnFailure(t *testing.T, fixture BackendFixture
 	const primary = "cbtj-anytx-fail-primary"
 	const marker = "cbtj-anytx-doomed"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
-	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`,
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
+	cbSetupModel(t, c, primary, cbSampleNoWriteback,
 		cbPrimaryProcWorkflow("cbtj-anytx-fail-wf", "cb-create-then-fail", "ASYNC_NEW_TX", cbContext(secondary, marker)))
 
 	// Pipeline must continue — ASYNC_NEW_TX failure is non-fatal → primary succeeds.

--- a/e2e/parity/client/http.go
+++ b/e2e/parity/client/http.go
@@ -133,7 +133,7 @@ func (c *Client) doJSON(t *testing.T, method, path string, body any, out any, op
 // --- Operation methods ---
 //
 // Each method maps to one cyoda HTTP API operation. The methods are
-// added incrementally as parity scenarios need them. Methods that fail
+// added incrementally as parity scenarios need them. Most methods return an error rather than failing the test; older ones that fail
 // (non-2xx status, decode error, transport error) call t.Fatalf with
 // a clear message including the operation name and the response body
 // where applicable.

--- a/e2e/parity/contracts.go
+++ b/e2e/parity/contracts.go
@@ -93,8 +93,10 @@ func RunConcurrentTransitionsDifferentEntities(t *testing.T, fixture BackendFixt
 	const modelVersion = 1
 	const N = 10 // CI-friendly concurrency level
 
-	// Setup with tag-with-foo processor on create transition.
-	if err := c.ImportModel(t, modelName, modelVersion, `{"index":0}`); err != nil {
+	// Setup with tag-with-foo processor on create transition. The sample seeds
+	// a zero-valued "tag" so the model DECLARES the field the processor writes
+	// — processor output passes the same model checks a client write does.
+	if err := c.ImportModel(t, modelName, modelVersion, `{"index":0,"tag":""}`); err != nil {
 		t.Fatalf("ImportModel: %v", err)
 	}
 	if err := c.LockModel(t, modelName, modelVersion); err != nil {

--- a/e2e/parity/criterion_reason.go
+++ b/e2e/parity/criterion_reason.go
@@ -37,7 +37,7 @@ func RunCriterionReasonInlineDefault(t *testing.T, fixture BackendFixture) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, c, modelName, modelVersion, wf)
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfBaseSample, wf)
 
 	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"X","amount":10}`)
 	if err != nil {

--- a/e2e/parity/entity_nul_payload.go
+++ b/e2e/parity/entity_nul_payload.go
@@ -1,0 +1,71 @@
+package parity
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// nulEscapePayload is valid JSON whose "name" string carries a NUL (U+0000)
+// escape. PostgreSQL text/jsonb cannot represent U+0000, while the memory and
+// sqlite stores would accept it — so without a boundary rejection the same
+// request succeeds on one backend and fails on another.
+const nulEscapePayload = "{\"name\":\"a\\u0000b\",\"amount\":1,\"status\":\"active\"}"
+
+// RunEntityNulPayloadRejected asserts that every backend rejects a payload
+// containing U+0000 identically: 400 BAD_REQUEST at the boundary, with nothing
+// persisted. This is the cross-backend half of the contract — the per-write-path
+// coverage lives in internal/e2e/entity_nul_payload_test.go.
+//
+// The failure this guards against is not "postgres errors": it is postgres
+// erroring while memory and sqlite quietly accept, which makes the storable
+// value set backend-dependent.
+func RunEntityNulPayloadRejected(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "entity-nul-payload-test"
+	const modelVersion = 1
+
+	setupSimpleWorkflow(t, c, modelName, modelVersion)
+
+	status, raw, err := c.CreateEntityRaw(t, modelName, modelVersion, nulEscapePayload)
+	if err != nil {
+		t.Fatalf("CreateEntityRaw: %v", err)
+	}
+	if status != http.StatusBadRequest {
+		t.Fatalf("NUL payload: status=%d, want 400 — a value no backend can store must be rejected at the boundary, not deep in the store; body: %s",
+			status, raw)
+	}
+
+	var pd struct {
+		Properties map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &pd); err != nil {
+		t.Fatalf("decode problem detail %q: %v", raw, err)
+	}
+	if got, _ := pd.Properties["errorCode"].(string); got != "BAD_REQUEST" {
+		t.Errorf("errorCode=%q, want BAD_REQUEST; body: %s", got, raw)
+	}
+	// The offending path must be named, and the raw NUL must not be echoed back.
+	if !strings.Contains(string(raw), "name") {
+		t.Errorf("rejection does not name the offending field; body: %s", raw)
+	}
+	if strings.ContainsRune(string(raw), 0) {
+		t.Errorf("response body echoes a raw NUL byte; body: %q", raw)
+	}
+
+	// A clean payload on the same model must still be accepted, so the check
+	// is not rejecting the model outright.
+	okStatus, okRaw, err := c.CreateEntityRaw(t, modelName, modelVersion,
+		`{"name":"Alice","amount":1,"status":"active"}`)
+	if err != nil {
+		t.Fatalf("CreateEntityRaw (clean): %v", err)
+	}
+	if okStatus != http.StatusOK {
+		t.Fatalf("clean payload after rejection: status=%d, want 200; body: %s", okStatus, okRaw)
+	}
+}

--- a/e2e/parity/entity_slice.go
+++ b/e2e/parity/entity_slice.go
@@ -92,8 +92,8 @@ func RunEntityConditionalDeleteInTx(t *testing.T, fixture BackendFixture) {
 	const primary = "cbtj-cdel-primary"
 	const deleteMarker = "cbtj-cdel-delete"
 
-	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
-	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`,
+	cbSetupModel(t, c, secondary, cbSampleSecondary, cbSecondaryWorkflow)
+	cbSetupModel(t, c, primary, cbSampleConditionalDelete,
 		cbPrimaryProcWorkflow("cbtj-cdel-wf", "cb-conditional-delete", "SYNC", cbContext(secondary, deleteMarker)))
 
 	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)

--- a/e2e/parity/entity_unstorable.go
+++ b/e2e/parity/entity_unstorable.go
@@ -1,0 +1,127 @@
+package parity
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// RunEntityUnstorableTextRejected asserts every backend rejects text that no
+// store can persist — an unpaired UTF-16 surrogate escape and a byte sequence
+// that is not valid UTF-8 — identically, with 400 BAD_REQUEST.
+//
+// Both are accepted by Go's JSON parser. PostgreSQL text/jsonb rejects them, so
+// they used to return 500 there while memory and sqlite accepted them, making
+// the storable value set backend-dependent. This scenario is the convergence
+// guard: it fails on all three backends if the boundary check is removed.
+//
+// Note the fix cannot be "decode and re-serialise": Go's decoder rewrites both
+// forms to U+FFFD, so that would silently store a character the client never
+// sent. The guard therefore reads the raw request bytes.
+func RunEntityUnstorableTextRejected(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "entity-unstorable-text-test"
+	const modelVersion = 1
+
+	setupSimpleWorkflow(t, c, modelName, modelVersion)
+
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"lone-high-surrogate", "{\"name\":\"a\\ud800b\",\"amount\":1,\"status\":\"active\"}"},
+		{"lone-low-surrogate", "{\"name\":\"a\\udc00b\",\"amount\":1,\"status\":\"active\"}"},
+		{"invalid-utf8", "{\"name\":\"a\xffb\",\"amount\":1,\"status\":\"active\"}"},
+	}
+
+	for _, tc := range cases {
+		status, raw, err := c.CreateEntityRaw(t, modelName, modelVersion, tc.payload)
+		if err != nil {
+			t.Fatalf("%s: CreateEntityRaw: %v", tc.name, err)
+		}
+		if status != http.StatusBadRequest {
+			t.Errorf("%s: status=%d, want 400 — text no backend can store must be rejected at the boundary; body: %s",
+				tc.name, status, raw)
+			continue
+		}
+		var pd struct {
+			Properties map[string]any `json:"properties"`
+		}
+		if err := json.Unmarshal(raw, &pd); err != nil {
+			t.Errorf("%s: decode problem detail %q: %v", tc.name, raw, err)
+			continue
+		}
+		if got, _ := pd.Properties["errorCode"].(string); got != "BAD_REQUEST" {
+			t.Errorf("%s: errorCode=%q, want BAD_REQUEST; body: %s", tc.name, got, raw)
+		}
+		if strings.ContainsRune(string(raw), 0) {
+			t.Errorf("%s: response body echoes a raw NUL byte; body: %q", tc.name, raw)
+		}
+	}
+
+	// A correctly paired surrogate is ordinary text and must still be accepted,
+	// so the guard is not simply rejecting non-ASCII.
+	okStatus, okRaw, err := c.CreateEntityRaw(t, modelName, modelVersion,
+		"{\"name\":\"a\\ud83d\\ude00b\",\"amount\":1,\"status\":\"active\"}")
+	if err != nil {
+		t.Fatalf("CreateEntityRaw (valid pair): %v", err)
+	}
+	if okStatus != http.StatusOK {
+		t.Fatalf("valid surrogate pair: status=%d, want 200; body: %s", okStatus, okRaw)
+	}
+}
+
+// RunEntityEmptyDocumentRoundTrips asserts an empty payload is storable and
+// readable on every backend, including via the model-wide list.
+//
+// On postgres this used to write successfully and then fail every subsequent
+// read with 500 — for the entity AND for the whole model's list — because the
+// stored document consisted only of the _meta block the plugin merges in, and
+// removing _meta on read left no data to decode. memory and sqlite were
+// unaffected, so this is a backend-divergence guard as much as a regression
+// test.
+func RunEntityEmptyDocumentRoundTrips(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "entity-empty-doc-test"
+	const modelVersion = 1
+
+	setupSimpleWorkflow(t, c, modelName, modelVersion)
+
+	status, raw, err := c.CreateEntityRaw(t, modelName, modelVersion, `{}`)
+	if err != nil {
+		t.Fatalf("CreateEntityRaw({}): %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("create {}: status=%d, want 200; body: %s", status, raw)
+	}
+
+	// The entity itself must be readable.
+	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{}`)
+	if err != nil {
+		t.Fatalf("CreateEntity({}): %v", err)
+	}
+	got, err := c.GetEntity(t, entityID)
+	if err != nil {
+		t.Fatalf("GetEntity on an empty document: %v", err)
+	}
+	if len(got.Data) != 0 {
+		t.Errorf("empty document read back with data %v, want an empty payload", got.Data)
+	}
+
+	// The model-wide list is what a single empty document used to take down:
+	// one unreadable row failed the whole listing, not just its own GET.
+	entities, err := c.ListEntitiesByModel(t, modelName, modelVersion)
+	if err != nil {
+		t.Fatalf("listing a model containing an empty document: %v", err)
+	}
+	if len(entities) == 0 {
+		t.Error("list returned no entities although two empty documents were created")
+	}
+}

--- a/e2e/parity/entity_unstorable.go
+++ b/e2e/parity/entity_unstorable.go
@@ -125,3 +125,101 @@ func RunEntityEmptyDocumentRoundTrips(t *testing.T, fixture BackendFixture) {
 		t.Error("list returned no entities although two empty documents were created")
 	}
 }
+
+// RunEntityNumberOutOfRangeRejected asserts every backend rejects a JSON number
+// that PostgreSQL's numeric type cannot hold, rather than one backend failing
+// inside the store while the others accept it.
+//
+// The model's sample matters: on a plain INTEGER field an over-range literal is
+// rejected earlier by type validation and never reaches storage, so the scenario
+// would pass for the wrong reason. A sample carrying a >64-bit literal makes the
+// field UNBOUND_INTEGER, which is the shape that actually reaches the store.
+func RunEntityNumberOutOfRangeRejected(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "entity-number-range-test"
+	const modelVersion = 1
+
+	if err := c.ImportModel(t, modelName, modelVersion, `{"name":"x","big":1e400,"dec":1e-400,"status":"d"}`); err != nil {
+		t.Fatalf("ImportModel: %v", err)
+	}
+	if err := c.LockModel(t, modelName, modelVersion); err != nil {
+		t.Fatalf("LockModel: %v", err)
+	}
+	if err := c.ImportWorkflow(t, modelName, modelVersion, simpleWorkflowJSON); err != nil {
+		t.Fatalf("ImportWorkflow: %v", err)
+	}
+
+	for _, tc := range []struct{ name, payload string }{
+		{"weight-over", `{"name":"x","big":1e131072,"dec":1,"status":"d"}`},
+		{"scale-over", `{"name":"x","big":1,"dec":1.5e-16383,"status":"d"}`},
+	} {
+		status, raw, err := c.CreateEntityRaw(t, modelName, modelVersion, tc.payload)
+		if err != nil {
+			t.Fatalf("%s: CreateEntityRaw: %v", tc.name, err)
+		}
+		if status != http.StatusBadRequest {
+			t.Errorf("%s: status=%d, want 400 — a number no backend can store must be rejected at the boundary; body: %s",
+				tc.name, status, raw)
+		}
+	}
+
+	// At the limit the number is storable and must still be accepted.
+	okStatus, okRaw, err := c.CreateEntityRaw(t, modelName, modelVersion,
+		`{"name":"x","big":1e131071,"dec":1e-16383,"status":"d"}`)
+	if err != nil {
+		t.Fatalf("CreateEntityRaw (at limit): %v", err)
+	}
+	if okStatus != http.StatusOK {
+		t.Fatalf("number at the storable limit: status=%d, want 200; body: %s", okStatus, okRaw)
+	}
+}
+
+// RunEntityDuplicateKeysRejected asserts every backend rejects a payload that
+// repeats a name within one object.
+//
+// Left accepted, such a payload is read as the LAST occurrence by schema
+// validation and the GET response and as the FIRST by the criterion evaluator
+// and search, so an entity is reported as holding one value while its workflow
+// transition was decided on another. That happens on all three backends — the
+// criterion runs against the client bytes before any store normalisation — so
+// this is a correctness guard, not a storage-format guard.
+func RunEntityDuplicateKeysRejected(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "entity-duplicate-keys-test"
+	const modelVersion = 1
+
+	setupSimpleWorkflow(t, c, modelName, modelVersion)
+
+	status, raw, err := c.CreateEntityRaw(t, modelName, modelVersion,
+		`{"name":"x","amount":"not-a-number","amount":5,"status":"active"}`)
+	if err != nil {
+		t.Fatalf("CreateEntityRaw: %v", err)
+	}
+	if status != http.StatusBadRequest {
+		t.Fatalf("duplicate name: status=%d, want 400 — the value read depends on which subsystem reads it; body: %s",
+			status, raw)
+	}
+	var pd struct {
+		Properties map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &pd); err != nil {
+		t.Fatalf("decode problem detail %q: %v", raw, err)
+	}
+	if got, _ := pd.Properties["errorCode"].(string); got != "BAD_REQUEST" {
+		t.Errorf("errorCode=%q, want BAD_REQUEST; body: %s", got, raw)
+	}
+
+	// A name repeated in a DIFFERENT object is ordinary JSON and must be accepted.
+	okStatus, okRaw, err := c.CreateEntityRaw(t, modelName, modelVersion,
+		`{"name":"x","amount":5,"status":"active"}`)
+	if err != nil {
+		t.Fatalf("CreateEntityRaw (clean): %v", err)
+	}
+	if okStatus != http.StatusOK {
+		t.Fatalf("clean payload: status=%d, want 200; body: %s", okStatus, okRaw)
+	}
+}

--- a/e2e/parity/entity_unstorable.go
+++ b/e2e/parity/entity_unstorable.go
@@ -121,8 +121,8 @@ func RunEntityEmptyDocumentRoundTrips(t *testing.T, fixture BackendFixture) {
 	if err != nil {
 		t.Fatalf("listing a model containing an empty document: %v", err)
 	}
-	if len(entities) == 0 {
-		t.Error("list returned no entities although two empty documents were created")
+	if len(entities) < 2 {
+		t.Errorf("list returned %d entities; two empty documents were created", len(entities))
 	}
 }
 
@@ -213,7 +213,9 @@ func RunEntityDuplicateKeysRejected(t *testing.T, fixture BackendFixture) {
 		t.Errorf("errorCode=%q, want BAD_REQUEST; body: %s", got, raw)
 	}
 
-	// A name repeated in a DIFFERENT object is ordinary JSON and must be accepted.
+	// A clean payload must still be accepted, so the guard is not simply
+	// rejecting the model. (Per-object scoping — the same name in two different
+	// objects — is covered at the unit level, where a nested sample is free.)
 	okStatus, okRaw, err := c.CreateEntityRaw(t, modelName, modelVersion,
 		`{"name":"x","amount":5,"status":"active"}`)
 	if err != nil {

--- a/e2e/parity/externalapi/workflow_externalization.go
+++ b/e2e/parity/externalapi/workflow_externalization.go
@@ -405,7 +405,10 @@ func RunExternalAPI_09_13_ProcessorContextPassesThrough(t *testing.T, fixture pa
 	const modelVersion = 1
 	const contextValue = "premium-role"
 	wf := externalProcessorWorkflowWithContext("ext-ctx-proc-wf", "echo-context-to-field", contextValue)
-	setupExternalModel(t, c, modelName, modelVersion, `{"k":1}`, wf)
+	// The sample seeds a zero-valued "_context" so the model DECLARES the field
+	// echo-context-to-field writes: processor output passes the same model
+	// checks a client write does.
+	setupExternalModel(t, c, modelName, modelVersion, `{"k":1,"_context":""}`, wf)
 
 	id, err := c.CreateEntity(t, modelName, modelVersion, `{"k":1}`)
 	if err != nil {

--- a/e2e/parity/multinode/attribution.go
+++ b/e2e/parity/multinode/attribution.go
@@ -45,6 +45,13 @@ import (
 // the compute tenant) so the causal origin (user) is observably distinct from
 // the member's service identity. The tx-token is never logged/asserted (Gate 3).
 
+// attrSampleCreateSecondary is the cascade primary's model sample, seeding
+// zero-valued declarations for the fields cb-create-secondary stamps back onto
+// the primary. Processor output passes the SAME model checks a client write
+// does, so the model must declare them; seeding rather than loosening the
+// model's changeLevel keeps the model strict.
+const attrSampleCreateSecondary = `{"name":"parent","amount":10,"status":"new","secondaryId":"","secondaryTxId":"","tokenWasEmpty":false}`
+
 func init() {
 	Register(
 		NamedTest{Name: "Attribution_ProxiedJoinCascade", Fn: RunAttribution_ProxiedJoinCascade},
@@ -109,8 +116,8 @@ func RunAttribution_ProxiedJoinCascade(t *testing.T, fixture MultiNodeFixture) {
 
 	const secondary = "attr-mn-casc-secondary"
 	const primary = "attr-mn-casc-primary"
-	cbRouteSetupModel(t, cSetup, secondary, `{"name":"child","amount":1,"status":"new"}`, cbRouteSecondaryWorkflow)
-	cbRouteSetupModel(t, cSetup, primary, `{"name":"parent","amount":10,"status":"new"}`,
+	cbRouteSetupModel(t, cSetup, secondary, cbRouteSampleSecondary, cbRouteSecondaryWorkflow)
+	cbRouteSetupModel(t, cSetup, primary, attrSampleCreateSecondary,
 		attrPrimaryProcWorkflow("attr-mn-casc-wf", "cb-create-secondary", "SYNC",
 			cbRouteContext(secondary, "attr-mn-casc-marker")))
 

--- a/e2e/parity/multinode/callback_route.go
+++ b/e2e/parity/multinode/callback_route.go
@@ -106,6 +106,27 @@ func cbRoutePrimaryWorkflow(wfName, procName, contextValue string) string {
 	return string(b)
 }
 
+// cbRouteSample* — primary-model samples for the cross-node callback scenarios.
+//
+// A callback processor stamps its observations back onto the primary's data,
+// and processor output passes the SAME model checks a client write does: the
+// model must DECLARE every field the processor writes. Each sample therefore
+// seeds the exact field set of the processor the scenario runs, at ZERO VALUE —
+// the sample states the field's type, never the value under test. Seeding
+// (rather than loosening the model's changeLevel) keeps the model strict, so a
+// mistyped field name in a processor still fails loudly instead of silently
+// widening the model and hollowing out the scenario's assertions.
+const (
+	// cbRouteSampleNoWriteback — processors that fail before returning data.
+	cbRouteSampleNoWriteback = `{"name":"Test","amount":10,"status":"new"}`
+	// cbRouteSampleSecondary — the secondary model, written only by clients.
+	cbRouteSampleSecondary = `{"name":"child","amount":1,"status":"new"}`
+	// cbRouteSampleCreateSecondary — cb-create-secondary / cb-grpc-create-secondary.
+	cbRouteSampleCreateSecondary = `{"name":"Test","amount":10,"status":"new","secondaryId":"","secondaryTxId":"","tokenWasEmpty":false}`
+	// cbRouteSampleGRPCSearchForward — cb-grpc-search-forward.
+	cbRouteSampleGRPCSearchForward = `{"name":"Test","amount":10,"status":"new","secondaryId":"","tokenWasEmpty":false,"grpcForwardSearchCount":0}`
+)
+
 // cbRouteSetupModel imports+locks a model with the given sample doc, then imports
 // the workflow. Setup is routed through node 0 (any node works — the model store
 // is cluster-shared).
@@ -154,10 +175,10 @@ func RunCallback_ForwardedDispatch_HTTP(t *testing.T, fixture MultiNodeFixture) 
 	const okMarker = "cbroute-http-ok"
 	const doomedMarker = "cbroute-http-doomed"
 
-	cbRouteSetupModel(t, cSetup, secondary, `{"name":"child","amount":1,"status":"new"}`, cbRouteSecondaryWorkflow)
-	cbRouteSetupModel(t, cSetup, primaryOK, `{"name":"Test","amount":10,"status":"new"}`,
+	cbRouteSetupModel(t, cSetup, secondary, cbRouteSampleSecondary, cbRouteSecondaryWorkflow)
+	cbRouteSetupModel(t, cSetup, primaryOK, cbRouteSampleCreateSecondary,
 		cbRoutePrimaryWorkflow("cbroute-http-ok-wf", "cb-create-secondary", cbRouteContext(secondary, okMarker)))
-	cbRouteSetupModel(t, cSetup, primaryFail, `{"name":"Test","amount":10,"status":"new"}`,
+	cbRouteSetupModel(t, cSetup, primaryFail, cbRouteSampleNoWriteback,
 		cbRoutePrimaryWorkflow("cbroute-http-fail-wf", "cb-create-then-fail", cbRouteContext(secondary, doomedMarker)))
 
 	// OWNER = node 1 (no local compute member → dispatch forwards to node 0).
@@ -266,10 +287,10 @@ func RunCallback_ForwardedDispatch_GRPC(t *testing.T, fixture MultiNodeFixture) 
 	const okMarker = "cbroute-grpc-ok"
 	const doomedMarker = "cbroute-grpc-doomed"
 
-	cbRouteSetupModel(t, cSetup, secondary, `{"name":"child","amount":1,"status":"new"}`, cbRouteSecondaryWorkflow)
-	cbRouteSetupModel(t, cSetup, primaryOK, `{"name":"Test","amount":10,"status":"new"}`,
+	cbRouteSetupModel(t, cSetup, secondary, cbRouteSampleSecondary, cbRouteSecondaryWorkflow)
+	cbRouteSetupModel(t, cSetup, primaryOK, cbRouteSampleCreateSecondary,
 		cbRoutePrimaryWorkflow("cbroute-grpc-ok-wf", "cb-grpc-create-secondary", cbRouteContext(secondary, okMarker)))
-	cbRouteSetupModel(t, cSetup, primaryFail, `{"name":"Test","amount":10,"status":"new"}`,
+	cbRouteSetupModel(t, cSetup, primaryFail, cbRouteSampleNoWriteback,
 		cbRoutePrimaryWorkflow("cbroute-grpc-fail-wf", "cb-grpc-create-then-fail", cbRouteContext(secondary, doomedMarker)))
 
 	// OWNER = node 1 (no local compute member → dispatch forwards to node 0).
@@ -370,8 +391,8 @@ func RunCallback_ForwardedGRPCSearch(t *testing.T, fixture MultiNodeFixture) {
 	const primary = "cbroute-gsearch-primary"
 	const marker = "cbroute-gsearch-marker"
 
-	cbRouteSetupModel(t, cSetup, secondary, `{"name":"child","amount":1,"status":"new"}`, cbRouteSecondaryWorkflow)
-	cbRouteSetupModel(t, cSetup, primary, `{"name":"Test","amount":10,"status":"new"}`,
+	cbRouteSetupModel(t, cSetup, secondary, cbRouteSampleSecondary, cbRouteSecondaryWorkflow)
+	cbRouteSetupModel(t, cSetup, primary, cbRouteSampleGRPCSearchForward,
 		cbRoutePrimaryWorkflow("cbroute-gsearch-wf", "cb-grpc-search-forward", cbRouteContext(secondary, marker)))
 
 	// OWNER = node 1 (no local compute member → dispatch forwards to node 0).

--- a/e2e/parity/multinode/cbd_tx_pinning.go
+++ b/e2e/parity/multinode/cbd_tx_pinning.go
@@ -85,7 +85,10 @@ func RunWorkflowProc_CBD_TxPostPinnedToHomeNode(t *testing.T, fixture MultiNodeF
 	const modelName = "cbd-tx-pinning"
 	const modelVersion = 1
 
-	if err := cSetup.ImportModel(t, modelName, modelVersion, `{"name":"Test","amount":10,"status":"new"}`); err != nil {
+	// The sample seeds a zero-valued "tag" so the model DECLARES the field the
+	// cascade's tag-with-foo processor writes — processor output passes the same
+	// model checks a client write does.
+	if err := cSetup.ImportModel(t, modelName, modelVersion, `{"name":"Test","amount":10,"status":"new","tag":""}`); err != nil {
 		t.Fatalf("ImportModel: %v", err)
 	}
 	if err := cSetup.LockModel(t, modelName, modelVersion); err != nil {

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 220 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 221 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -53,6 +53,7 @@ var allTests = []NamedTest{
 
 	// Phase 4a — entity CRUD (Task 4a.2)
 	{"EntityCreateAndGet", RunEntityCreateAndGet},
+	{"EntityNulPayloadRejected", RunEntityNulPayloadRejected},
 	{"EntityDelete", RunEntityDelete},
 	{"EntityListByModel", RunEntityListByModel},
 	{"EntityMetaShape", RunEntityMetaShape},

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 223 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 225 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -56,6 +56,8 @@ var allTests = []NamedTest{
 	{"EntityNulPayloadRejected", RunEntityNulPayloadRejected},
 	{"EntityUnstorableTextRejected", RunEntityUnstorableTextRejected},
 	{"EntityEmptyDocumentRoundTrips", RunEntityEmptyDocumentRoundTrips},
+	{"EntityNumberOutOfRangeRejected", RunEntityNumberOutOfRangeRejected},
+	{"EntityDuplicateKeysRejected", RunEntityDuplicateKeysRejected},
 	{"EntityDelete", RunEntityDelete},
 	{"EntityListByModel", RunEntityListByModel},
 	{"EntityMetaShape", RunEntityMetaShape},

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 221 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 223 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -54,6 +54,8 @@ var allTests = []NamedTest{
 	// Phase 4a — entity CRUD (Task 4a.2)
 	{"EntityCreateAndGet", RunEntityCreateAndGet},
 	{"EntityNulPayloadRejected", RunEntityNulPayloadRejected},
+	{"EntityUnstorableTextRejected", RunEntityUnstorableTextRejected},
+	{"EntityEmptyDocumentRoundTrips", RunEntityEmptyDocumentRoundTrips},
 	{"EntityDelete", RunEntityDelete},
 	{"EntityListByModel", RunEntityListByModel},
 	{"EntityMetaShape", RunEntityMetaShape},

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 220
+const wantParityScenarioCount = 221
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 223
+const wantParityScenarioCount = 225
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 221
+const wantParityScenarioCount = 223
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/e2e/parity/search.go
+++ b/e2e/parity/search.go
@@ -27,7 +27,7 @@ const searchWorkflowJSON = `{
 // workflow (with a manual "approve" transition).
 func setupSearchModel(t *testing.T, c *client.Client, modelName string, modelVersion int) {
 	t.Helper()
-	setupModelWithWorkflow(t, c, modelName, modelVersion, searchWorkflowJSON)
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfBaseSample, searchWorkflowJSON)
 }
 
 // RunSearchSimpleCondition creates 3 entities with different statuses,
@@ -386,7 +386,7 @@ func RunWorkflowCriteriaSelectingWorkflow(t *testing.T, fixture BackendFixture) 
 			}
 		]
 	}`
-	setupModelWithWorkflow(t, c, modelName, modelVersion, wf)
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfBaseSample, wf)
 
 	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Test","amount":50,"status":"new"}`)
 	if err != nil {

--- a/e2e/parity/search_sort.go
+++ b/e2e/parity/search_sort.go
@@ -31,7 +31,7 @@ const sortMatchAll = `{"type":"group","operator":"AND","conditions":[]}`
 // attaches the simple sort workflow (NONE→CREATED, no manual transitions).
 func setupSortModel(t *testing.T, c *client.Client, modelName string, modelVersion int) {
 	t.Helper()
-	setupModelWithWorkflow(t, c, modelName, modelVersion, sortSimpleWorkflowJSON)
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfBaseSample, sortSimpleWorkflowJSON)
 }
 
 // setupSortModelWithSample is like setupSortModel but accepts a custom sample

--- a/e2e/parity/workflow_proc.go
+++ b/e2e/parity/workflow_proc.go
@@ -6,13 +6,30 @@ import (
 	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
 )
 
-// setupModelWithWorkflow imports a model, locks it, and imports the given
-// workflow JSON. This is the parity equivalent of the internal/e2e helper
-// with the same name.
-func setupModelWithWorkflow(t *testing.T, c *client.Client, modelName string, modelVersion int, workflowJSON string) {
+// wfBaseSample is the plain model sample used by scenarios whose workflow has
+// no processor writing entity data back.
+const wfBaseSample = `{"name":"Test","amount":10,"status":"new"}`
+
+// wfTaggedSample is wfBaseSample plus a zero-valued "tag" field.
+//
+// A processor's returned data passes the SAME model checks a client write does,
+// so a model must DECLARE every field its processors stamp. The "tag-with-foo"
+// processor writes data.tag, hence the seed. The value is the zero value on
+// purpose: the sample declares the field's type without asserting a value, and
+// keeping the model strict means a mistyped field name in a processor still
+// fails loudly instead of silently widening the model.
+const wfTaggedSample = `{"name":"Test","amount":10,"status":"new","tag":""}`
+
+// setupModelWithWorkflow imports a model from sampleDoc, locks it, and imports
+// the given workflow JSON. This is the parity equivalent of the internal/e2e
+// helper with the same name.
+//
+// sampleDoc is explicit rather than hard-coded because the model must declare
+// the fields the workflow's processors write back (see wfTaggedSample).
+func setupModelWithWorkflow(t *testing.T, c *client.Client, modelName string, modelVersion int, sampleDoc, workflowJSON string) {
 	t.Helper()
 
-	if err := c.ImportModel(t, modelName, modelVersion, `{"name":"Test","amount":10,"status":"new"}`); err != nil {
+	if err := c.ImportModel(t, modelName, modelVersion, sampleDoc); err != nil {
 		t.Fatalf("ImportModel: %v", err)
 	}
 	if err := c.LockModel(t, modelName, modelVersion); err != nil {
@@ -46,7 +63,7 @@ func RunWorkflowProcessorChainOnCreation(t *testing.T, fixture BackendFixture) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, c, modelName, modelVersion, wf)
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfTaggedSample, wf)
 
 	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Test","amount":10,"status":"new"}`)
 	if err != nil {
@@ -92,7 +109,7 @@ func RunWorkflowCriteriaMatch(t *testing.T, fixture BackendFixture) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, c, modelName, modelVersion, wf)
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfBaseSample, wf)
 
 	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Test","amount":10,"status":"new"}`)
 	if err != nil {
@@ -132,7 +149,7 @@ func RunWorkflowCriteriaNoMatch(t *testing.T, fixture BackendFixture) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, c, modelName, modelVersion, wf)
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfBaseSample, wf)
 
 	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Test","amount":10,"status":"new"}`)
 	if err != nil {
@@ -178,7 +195,7 @@ func RunWorkflowMultiStateCascade(t *testing.T, fixture BackendFixture) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, c, modelName, modelVersion, wf)
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfTaggedSample, wf)
 
 	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Test","amount":10,"status":"new"}`)
 	if err != nil {
@@ -229,7 +246,7 @@ func RunWorkflowManualTransition(t *testing.T, fixture BackendFixture) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, c, modelName, modelVersion, wf)
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfTaggedSample, wf)
 
 	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Test","amount":10,"status":"new"}`)
 	if err != nil {

--- a/internal/domain/entity/decode_json_test.go
+++ b/internal/domain/entity/decode_json_test.go
@@ -1,0 +1,72 @@
+package entity
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDecodeJSONPreservingNumbers_RejectsTrailingContent pins the boundary
+// contract: a request body must be exactly one JSON value. json.Decoder.Decode
+// stops at the end of the first value and ignores whatever follows, so without
+// an explicit end-of-stream check a body like `{"x":1}}}` parses "successfully"
+// — and the raw bytes that get persisted then differ from the value that was
+// validated, surfacing as a 500 from storage instead of a 400 at the boundary.
+func TestDecodeJSONPreservingNumbers_RejectsTrailingContent(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid: exactly one JSON value, optionally surrounded by whitespace.
+		{"object", `{"x":1}`, false},
+		{"array", `[1,2,3]`, false},
+		{"string", `"hello"`, false},
+		{"number", `42`, false},
+		{"null", `null`, false},
+		{"leading-whitespace", "  \n\t" + `{"x":1}`, false},
+		{"trailing-whitespace", `{"x":1}` + "  \n\t", false},
+
+		// Invalid: more than one value, or junk after the first.
+		{"trailing-braces", `{"x":1}}}`, true},
+		{"two-objects", `{"x":1}{"y":2}`, true},
+		{"object-then-garbage", `{"x":1} nonsense`, true},
+		{"array-then-object", `[1,2] {"y":2}`, true},
+		{"number-then-number", `1 2`, true},
+
+		// Invalid: not a complete JSON value at all.
+		{"truncated", `{"x":1`, true},
+		{"not-json", `this is not json`, true},
+		{"empty", ``, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v any
+			err := decodeJSONPreservingNumbers([]byte(tc.input), &v)
+			if tc.wantErr && err == nil {
+				t.Fatalf("decode(%q) = nil error; want an error", tc.input)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("decode(%q) = %v; want no error", tc.input, err)
+			}
+		})
+	}
+}
+
+// TestDecodeJSONPreservingNumbers_KeepsNumberPrecision guards the property the
+// helper exists for in the first place, so the trailing-content check cannot
+// regress it.
+func TestDecodeJSONPreservingNumbers_KeepsNumberPrecision(t *testing.T) {
+	const big = `{"n":123456789012345678901234567890.123456789}`
+	var v map[string]any
+	if err := decodeJSONPreservingNumbers([]byte(big), &v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	n, ok := v["n"].(json.Number)
+	if !ok {
+		t.Fatalf("v[n] is %T, want json.Number — UseNumber lost", v["n"])
+	}
+	if n.String() != "123456789012345678901234567890.123456789" {
+		t.Errorf("n = %s; precision lost", n.String())
+	}
+}

--- a/internal/domain/entity/handler.go
+++ b/internal/domain/entity/handler.go
@@ -9,7 +9,6 @@ import (
 	"mime"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/google/uuid"
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -17,7 +16,7 @@ import (
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	genapi "github.com/cyoda-platform/cyoda-go/api"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
-	"github.com/cyoda-platform/cyoda-go/internal/domain/model/importer"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/ingest"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/pagination"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
@@ -27,48 +26,6 @@ import (
 
 // maxEntityBodySize is the maximum allowed request body size for entity operations (10 MB).
 const maxEntityBodySize = 10 * 1024 * 1024
-
-// errInternalSchema tags schema-processing errors inside validateOrExtend
-// that represent internal failures (codec decode/encode, Diff computation,
-// plugin-layer ExtendSchema write) rather than client-contract violations.
-// The handler classifier uses errors.Is to route these to 5xx with a
-// logged ticket. Using a sentinel rather than string-matching the wrap
-// messages makes classification robust to future wording changes — the
-// prior string-match classifier would have silently shifted a renamed
-// "failed to extend schema" to 4xx.
-var errInternalSchema = errors.New("internal schema processing failure")
-
-// incompatibleTypeError is the typed validation failure surfaced when at
-// least one ValidationError carries ErrKindIncompatibleType (the
-// dictionary-aligned "wrong DataType" signal — Cloud's
-// FoundIncompatibleTypeWithEntityModelException).
-//
-// Rendered by classifyValidateOrExtendErr into a 400 INCOMPATIBLE_TYPE
-// AppError with Props {fieldPath, expectedType, actualType} so SDKs can
-// branch on the precondition without scraping the message string.
-type incompatibleTypeError struct {
-	path          string
-	expectedTypes []schema.DataType
-	actualType    schema.DataType
-	message       string
-	entityName    string // populated by enrichWithModelRef post-validation
-	entityVersion string // populated by enrichWithModelRef post-validation
-}
-
-func (e *incompatibleTypeError) Error() string { return e.message }
-
-// enrichWithModelRef threads model identification (entity name, version)
-// onto an *incompatibleTypeError so the classifier can render those Props
-// alongside the validator-supplied (path, expected/actualType). For all
-// other error types the input is returned unchanged.
-func enrichWithModelRef(err error, ref spi.ModelRef) error {
-	var incompatErr *incompatibleTypeError
-	if errors.As(err, &incompatErr) {
-		incompatErr.entityName = ref.EntityName
-		incompatErr.entityVersion = ref.ModelVersion
-	}
-	return err
-}
 
 // maxStatesFilterSize bounds the cardinality of the user-supplied ?states= query
 // parameter on stats-by-state endpoints. Without this cap, an oversized list would
@@ -165,86 +122,6 @@ func (h *Handler) rollbackOwned(ctx context.Context, txID string, owned bool) {
 // contend on a single "models" row — the hot-row regression that
 // ModelStore.Save would otherwise produce under REPEATABLE READ.
 // Returns an error on validation or extension failure.
-func (h *Handler) validateOrExtend(ctx context.Context, modelStore spi.ModelStore, desc *spi.ModelDescriptor, parsedData any) error {
-	modelNode, err := schema.Unmarshal(desc.Schema)
-	if err != nil {
-		return fmt.Errorf("%w: failed to unmarshal model schema: %w", errInternalSchema, err)
-	}
-
-	if desc.ChangeLevel == "" {
-		errs := schema.Validate(modelNode, parsedData)
-		if len(errs) > 0 {
-			return enrichWithModelRef(validationErrorsToError(errs), desc.Ref)
-		}
-		return nil
-	}
-
-	incomingModel, err := importer.Walk(parsedData)
-	if err != nil {
-		return fmt.Errorf("failed to walk data: %w", err)
-	}
-	extended, err := schema.Extend(modelNode, incomingModel, desc.ChangeLevel)
-	if err != nil {
-		// Polymorphic-slot rejections cannot be resolved by raising ChangeLevel
-		// and so must not wear the "change level violation" prefix — the phrase
-		// misleads clients into tuning a setting that wouldn't help.
-		if errors.Is(err, schema.ErrPolymorphicSlot) {
-			return err
-		}
-		return fmt.Errorf("change level violation: %w", err)
-	}
-
-	// Guard: if any unique key field would become non-scalar in the extended
-	// schema, reject the write now. This catches the null-only-leaf → object/array
-	// widening case (a TYPE-level change permitted by Structural ChangeLevel)
-	// that would otherwise surface as an opaque Diff "kind change" 5xx. The
-	// unique keys were valid when declared; the schema extension must not
-	// silently invalidate them.
-	if len(desc.UniqueKeys) > 0 {
-		if vErr := schema.ValidateUniqueKeys(extended, desc.UniqueKeys); vErr != nil {
-			var de *schema.UniqueKeyDefError
-			if errors.As(vErr, &de) {
-				return common.Operational(http.StatusUnprocessableEntity, common.ErrCodeInvalidUniqueKeyDefinition,
-					"schema change would invalidate a composite unique key: "+de.Reason)
-			}
-			return fmt.Errorf("%w: re-validate unique keys: %w", errInternalSchema, vErr)
-		}
-	}
-
-	// Compute the additive delta. Diff returns (nil, nil) when the
-	// extension is a semantic no-op, which is the common case on
-	// every entity write.
-	delta, err := schema.Diff(modelNode, extended)
-	if err != nil {
-		return fmt.Errorf("%w: failed to compute schema delta: %w", errInternalSchema, err)
-	}
-	if delta == nil {
-		return nil
-	}
-	// Append to the extension log via the plugin. Participates in the
-	// ambient entity transaction so visibility is commit-bound.
-	if err := modelStore.ExtendSchema(ctx, desc.Ref, delta); err != nil {
-		return fmt.Errorf("%w: failed to extend schema: %w", errInternalSchema, err)
-	}
-	return nil
-}
-
-// validateStrict validates parsedData against the model schema WITHOUT
-// extending it. PATCH uses this: a sparse delta must never widen the tenant's
-// model (a stray/typo'd key is rejected, not absorbed). Mirrors the
-// ChangeLevel=="" branch of validateOrExtend.
-func (h *Handler) validateStrict(desc *spi.ModelDescriptor, parsedData any) error {
-	modelNode, err := schema.Unmarshal(desc.Schema)
-	if err != nil {
-		return fmt.Errorf("%w: failed to unmarshal model schema: %w", errInternalSchema, err)
-	}
-	errs := schema.Validate(modelNode, parsedData)
-	if len(errs) > 0 {
-		return enrichWithModelRef(validationErrorsToError(errs), desc.Ref)
-	}
-	return nil
-}
-
 // ValidateWithRefresh runs strict schema validation with a bounded
 // refresh-on-stale safety net. One refresh attempt, only on unknown-
 // schema-element errors — the signal that our cached schema is behind
@@ -256,68 +133,27 @@ func (h *Handler) ValidateWithRefresh(ctx context.Context, modelStore spi.ModelS
 	if err != nil {
 		return err
 	}
-	errs := validateDescriptor(desc, data)
+	errs := ingest.ValidateDescriptor(desc, data)
 	if errs == nil {
 		return nil
 	}
 	if !schema.HasUnknownSchemaElement(errs) {
-		return validationErrorsToError(errs)
+		return ingest.ValidationErrorsToError(errs)
 	}
 	refresher, ok := modelStore.(interface {
 		RefreshAndGet(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error)
 	})
 	if !ok {
-		return validationErrorsToError(errs) // plugin has no cache
+		return ingest.ValidationErrorsToError(errs) // plugin has no cache
 	}
 	freshDesc, rErr := refresher.RefreshAndGet(ctx, ref)
 	if rErr != nil {
 		return rErr
 	}
-	if errs2 := validateDescriptor(freshDesc, data); errs2 != nil {
-		return validationErrorsToError(errs2)
+	if errs2 := ingest.ValidateDescriptor(freshDesc, data); errs2 != nil {
+		return ingest.ValidationErrorsToError(errs2)
 	}
 	return nil
-}
-
-// validateDescriptor unmarshals desc.Schema and runs schema.Validate.
-// Returns nil on success, or a []ValidationError on failure (including
-// a descriptive entry if desc itself is malformed or nil).
-func validateDescriptor(desc *spi.ModelDescriptor, data any) []schema.ValidationError {
-	if desc == nil {
-		return []schema.ValidationError{{Message: "nil descriptor"}}
-	}
-	node, err := schema.Unmarshal(desc.Schema)
-	if err != nil {
-		return []schema.ValidationError{{Message: fmt.Sprintf("unmarshal schema: %v", err)}}
-	}
-	return schema.Validate(node, data)
-}
-
-// validationErrorsToError converts a []ValidationError to a single error,
-// preserving the concatenation style used by validateOrExtend.
-//
-// When at least one entry classifies as ErrKindIncompatibleType (the
-// dictionary-aligned "wrong DataType" signal), the function returns a
-// typed *incompatibleTypeError carrying the first such entry's structured
-// fields so classifyValidateOrExtendErr can render INCOMPATIBLE_TYPE Props
-// without scraping the message string. Other validation errors fall back
-// to the generic "validation failed: ..." wrap, classified as
-// BAD_REQUEST downstream.
-func validationErrorsToError(errs []schema.ValidationError) error {
-	msgs := make([]string, len(errs))
-	for i, e := range errs {
-		msgs[i] = e.Error()
-	}
-	joined := fmt.Sprintf("validation failed: %s", strings.Join(msgs, "; "))
-	if first := schema.FirstIncompatibleType(errs); first != nil {
-		return &incompatibleTypeError{
-			path:          first.Path,
-			expectedTypes: first.ExpectedTypes,
-			actualType:    first.ActualType,
-			message:       joined,
-		}
-	}
-	return fmt.Errorf("%s", joined)
 }
 
 // classifyValidateOrExtendErr determines whether a validateOrExtend error is
@@ -327,10 +163,10 @@ func validationErrorsToError(errs []schema.ValidationError) error {
 // in the wrap strings:
 //
 //   - ErrPolymorphicSlot      → 4xx POLYMORPHIC_SLOT (client normalizes payload)
-//   - *incompatibleTypeError  → 4xx INCOMPATIBLE_TYPE with structured Props
+//   - *ingest.IncompatibleTypeError  → 4xx INCOMPATIBLE_TYPE with structured Props
 //     (fieldPath, expectedType, actualType) — Cloud's
 //     FoundIncompatibleTypeWithEntityModelException equivalent
-//   - errInternalSchema       → 5xx with logged ticket (codec/diff/store failure)
+//   - ingest.ErrInternalSchema       → 5xx with logged ticket (codec/diff/store failure)
 //   - anything else           → 4xx BAD_REQUEST (change-level violation,
 //     other validation failure, malformed walk input)
 func classifyValidateOrExtendErr(err error) *common.AppError {
@@ -343,28 +179,28 @@ func classifyValidateOrExtendErr(err error) *common.AppError {
 	if errors.Is(err, schema.ErrPolymorphicSlot) {
 		return common.Operational(http.StatusBadRequest, common.ErrCodePolymorphicSlot, err.Error())
 	}
-	var incompatErr *incompatibleTypeError
+	var incompatErr *ingest.IncompatibleTypeError
 	if errors.As(err, &incompatErr) {
 		appErr := common.Operational(http.StatusBadRequest, common.ErrCodeIncompatibleType, err.Error())
-		expected := make([]string, len(incompatErr.expectedTypes))
-		for i, dt := range incompatErr.expectedTypes {
+		expected := make([]string, len(incompatErr.ExpectedTypes))
+		for i, dt := range incompatErr.ExpectedTypes {
 			expected[i] = dt.String()
 		}
 		props := map[string]any{
-			"fieldPath":    incompatErr.path,
+			"fieldPath":    incompatErr.Path,
 			"expectedType": expected,
-			"actualType":   incompatErr.actualType.String(),
+			"actualType":   incompatErr.ActualType.String(),
 		}
-		if incompatErr.entityName != "" {
-			props["entityName"] = incompatErr.entityName
+		if incompatErr.EntityName != "" {
+			props["entityName"] = incompatErr.EntityName
 		}
-		if incompatErr.entityVersion != "" {
-			props["entityVersion"] = incompatErr.entityVersion
+		if incompatErr.EntityVersion != "" {
+			props["entityVersion"] = incompatErr.EntityVersion
 		}
 		appErr.Props = props
 		return appErr
 	}
-	if errors.Is(err, errInternalSchema) {
+	if errors.Is(err, ingest.ErrInternalSchema) {
 		return common.Internal("failed to process model schema", err)
 	}
 	return common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, err.Error())

--- a/internal/domain/entity/handler_polymorphic_test.go
+++ b/internal/domain/entity/handler_polymorphic_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/ingest"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 )
 
@@ -59,7 +60,7 @@ func TestClassifyValidateOrExtendErr_ChangeLevelViolation_StillGetsBadRequest(t 
 }
 
 // TestClassifyValidateOrExtendErr_InternalSentinel_Is5xx — an error
-// wrapping errInternalSchema (codec/diff/store failures in validateOrExtend)
+// wrapping ingest.ErrInternalSchema (codec/diff/store failures in validateOrExtend)
 // classifies as 5xx regardless of its message text. This is the contract
 // that replaces the prior fragile string-matching classifier: if a future
 // refactor renames a wrap like "failed to compute schema delta" to
@@ -76,19 +77,19 @@ func TestClassifyValidateOrExtendErr_InternalSentinel_Is5xx(t *testing.T) {
 				// A message deliberately NOT matching the prior string-
 				// matching patterns; would have been mis-routed to 4xx
 				// under the old classifier.
-				return fmt.Errorf("%w: schema codec: unmarshal: %w", errInternalSchema, fmt.Errorf("unexpected end of input"))
+				return fmt.Errorf("%w: schema codec: unmarshal: %w", ingest.ErrInternalSchema, fmt.Errorf("unexpected end of input"))
 			},
 		},
 		{
 			name: "plugin-layer extend failure wrapped with sentinel",
 			makeErr: func() error {
-				return fmt.Errorf("%w: failed to extend schema: %w", errInternalSchema, fmt.Errorf("pgx: connection refused"))
+				return fmt.Errorf("%w: failed to extend schema: %w", ingest.ErrInternalSchema, fmt.Errorf("pgx: connection refused"))
 			},
 		},
 		{
 			name: "diff failure wrapped with sentinel",
 			makeErr: func() error {
-				return fmt.Errorf("%w: failed to compute schema delta: %w", errInternalSchema, fmt.Errorf("unexpected node kind"))
+				return fmt.Errorf("%w: failed to compute schema delta: %w", ingest.ErrInternalSchema, fmt.Errorf("unexpected node kind"))
 			},
 		},
 	}
@@ -106,7 +107,7 @@ func TestClassifyValidateOrExtendErr_InternalSentinel_Is5xx(t *testing.T) {
 }
 
 // TestClassifyValidateOrExtendErr_UntaggedError_Is4xx — an error NOT
-// wrapping either ErrPolymorphicSlot or errInternalSchema classifies as
+// wrapping either ErrPolymorphicSlot or ingest.ErrInternalSchema classifies as
 // 4xx BAD_REQUEST. Represents e.g. a change-level violation, a validation
 // failure, or an importer.Walk error from malformed user input — all
 // client-contract issues, not server faults.
@@ -132,11 +133,11 @@ func TestClassifyValidateOrExtendErr_UntaggedError_Is4xx(t *testing.T) {
 // Wires the cyoda-go response to Cloud's
 // FoundIncompatibleTypeWithEntityModelException dictionary class.
 func TestClassifyValidateOrExtendErr_IncompatibleType_GetsSpecificCode(t *testing.T) {
-	underlying := &incompatibleTypeError{
-		path:          "price",
-		expectedTypes: []schema.DataType{schema.Integer},
-		actualType:    schema.Double,
-		message:       "validation failed: price: value of type DOUBLE is not compatible with [INTEGER]",
+	underlying := &ingest.IncompatibleTypeError{
+		Path:          "price",
+		ExpectedTypes: []schema.DataType{schema.Integer},
+		ActualType:    schema.Double,
+		Message:       "validation failed: price: value of type DOUBLE is not compatible with [INTEGER]",
 	}
 
 	appErr := classifyValidateOrExtendErr(underlying)

--- a/internal/domain/entity/handler_validate_or_extend_test.go
+++ b/internal/domain/entity/handler_validate_or_extend_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/ingest"
+
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
@@ -74,7 +76,6 @@ func descriptorWithChangeLevel(t *testing.T, node *schema.ModelNode, cl spi.Chan
 }
 
 func TestValidateOrExtend_NoChangeLevel_ValidatesOnly(t *testing.T) {
-	h := &Handler{}
 	node := schema.NewObjectNode()
 	node.SetChild("name", schema.NewLeafNode(schema.String))
 	desc := descriptorWithChangeLevel(t, node, spi.ChangeLevel(""))
@@ -84,7 +85,7 @@ func TestValidateOrExtend_NoChangeLevel_ValidatesOnly(t *testing.T) {
 	if err := json.Unmarshal([]byte(`{"name":"alice"}`), &data); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
-	if err := h.validateOrExtend(context.Background(), ms, desc, data); err != nil {
+	if err := ingest.ValidateOrExtend(context.Background(), ms, desc, data); err != nil {
 		t.Fatalf("validateOrExtend: %v", err)
 	}
 	if ms.extendCalls != 0 || ms.saveCalls != 0 {
@@ -94,7 +95,6 @@ func TestValidateOrExtend_NoChangeLevel_ValidatesOnly(t *testing.T) {
 }
 
 func TestValidateOrExtend_NoChangeLevel_UnknownField_Fails(t *testing.T) {
-	h := &Handler{}
 	node := schema.NewObjectNode()
 	node.SetChild("name", schema.NewLeafNode(schema.String))
 	desc := descriptorWithChangeLevel(t, node, spi.ChangeLevel(""))
@@ -104,14 +104,13 @@ func TestValidateOrExtend_NoChangeLevel_UnknownField_Fails(t *testing.T) {
 	if err := json.Unmarshal([]byte(`{"name":"a","email":"b@c.d"}`), &data); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
-	err := h.validateOrExtend(context.Background(), ms, desc, data)
+	err := ingest.ValidateOrExtend(context.Background(), ms, desc, data)
 	if err == nil || !strings.Contains(err.Error(), "validation failed") {
 		t.Errorf("expected validation failure, got %v", err)
 	}
 }
 
 func TestValidateOrExtend_ChangeLevel_NoDelta_NoExtendCall(t *testing.T) {
-	h := &Handler{}
 	node := schema.NewObjectNode()
 	node.SetChild("name", schema.NewLeafNode(schema.String))
 	desc := descriptorWithChangeLevel(t, node, spi.ChangeLevelStructural)
@@ -122,7 +121,7 @@ func TestValidateOrExtend_ChangeLevel_NoDelta_NoExtendCall(t *testing.T) {
 	if err := json.Unmarshal([]byte(`{"name":"alice"}`), &data); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
-	if err := h.validateOrExtend(context.Background(), ms, desc, data); err != nil {
+	if err := ingest.ValidateOrExtend(context.Background(), ms, desc, data); err != nil {
 		t.Fatalf("validateOrExtend: %v", err)
 	}
 	if ms.extendCalls != 0 {
@@ -134,7 +133,6 @@ func TestValidateOrExtend_ChangeLevel_NoDelta_NoExtendCall(t *testing.T) {
 }
 
 func TestValidateOrExtend_ChangeLevel_NewField_CallsExtendSchema(t *testing.T) {
-	h := &Handler{}
 	node := schema.NewObjectNode()
 	node.SetChild("name", schema.NewLeafNode(schema.String))
 	desc := descriptorWithChangeLevel(t, node, spi.ChangeLevelStructural)
@@ -144,7 +142,7 @@ func TestValidateOrExtend_ChangeLevel_NewField_CallsExtendSchema(t *testing.T) {
 	if err := json.Unmarshal([]byte(`{"name":"alice","email":"a@b.c"}`), &data); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
-	if err := h.validateOrExtend(context.Background(), ms, desc, data); err != nil {
+	if err := ingest.ValidateOrExtend(context.Background(), ms, desc, data); err != nil {
 		t.Fatalf("validateOrExtend: %v", err)
 	}
 	if ms.extendCalls != 1 {
@@ -182,7 +180,6 @@ func descriptorWithChangeLevelAndKeys(t *testing.T, node *schema.ModelNode, cl s
 // Structural ChangeLevel), validateOrExtend rejects the write with 422
 // INVALID_UNIQUE_KEY_DEFINITION rather than silently widening the schema.
 func TestValidateOrExtend_WideningKeyedNullLeaf_Returns422(t *testing.T) {
-	h := &Handler{}
 
 	// score is initially a null-only leaf (nullable marker).
 	// A unique key on $.score is valid at declaration time (it is a scalar leaf).
@@ -199,7 +196,7 @@ func TestValidateOrExtend_WideningKeyedNullLeaf_Returns422(t *testing.T) {
 	data := map[string]any{
 		"score": map[string]any{"sub": "val"},
 	}
-	err := h.validateOrExtend(context.Background(), ms, desc, data)
+	err := ingest.ValidateOrExtend(context.Background(), ms, desc, data)
 	if err == nil {
 		t.Fatal("expected error for key-field widening, got nil")
 	}
@@ -219,7 +216,6 @@ func TestValidateOrExtend_WideningKeyedNullLeaf_Returns422(t *testing.T) {
 // a normal additive extension (new field added, keyed field untouched) is
 // accepted and ExtendSchema is called exactly once.
 func TestValidateOrExtend_AddNewField_NotTouchingKeyedField_Succeeds(t *testing.T) {
-	h := &Handler{}
 
 	node := schema.NewObjectNode()
 	node.SetChild("score", schema.NewLeafNode(schema.Null))
@@ -235,7 +231,7 @@ func TestValidateOrExtend_AddNewField_NotTouchingKeyedField_Succeeds(t *testing.
 		"score":    nil,
 		"category": "sports",
 	}
-	if err := h.validateOrExtend(context.Background(), ms, desc, data); err != nil {
+	if err := ingest.ValidateOrExtend(context.Background(), ms, desc, data); err != nil {
 		t.Fatalf("validateOrExtend unexpected error: %v", err)
 	}
 	if ms.extendCalls != 1 {

--- a/internal/domain/entity/mergepatch.go
+++ b/internal/domain/entity/mergepatch.go
@@ -3,6 +3,8 @@ package entity
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/ingest"
 )
 
 // mergeMergePatch applies an RFC 7386 JSON Merge Patch (the already-parsed
@@ -11,7 +13,7 @@ import (
 func mergeMergePatch(existing json.RawMessage, patch any) (any, error) {
 	var target any
 	if len(existing) > 0 {
-		if err := decodeJSONPreservingNumbers(existing, &target); err != nil {
+		if err := ingest.DecodeJSONPreservingNumbers(existing, &target); err != nil {
 			return nil, fmt.Errorf("failed to decode stored entity data: %w", err)
 		}
 	}

--- a/internal/domain/entity/mergepatch_test.go
+++ b/internal/domain/entity/mergepatch_test.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/ingest"
 )
 
 func mustParse(t *testing.T, s string) any {
 	t.Helper()
 	var v any
-	if err := decodeJSONPreservingNumbers([]byte(s), &v); err != nil {
+	if err := ingest.DecodeJSONPreservingNumbers([]byte(s), &v); err != nil {
 		t.Fatalf("parse %q: %v", s, err)
 	}
 	return v
@@ -40,10 +42,10 @@ func TestApplyMergePatch_RFC7386_AppendixA(t *testing.T) {
 				t.Fatalf("marshal got: %v", err)
 			}
 			var gotN, wantN any
-			if err := decodeJSONPreservingNumbers(gotBytes, &gotN); err != nil {
+			if err := ingest.DecodeJSONPreservingNumbers(gotBytes, &gotN); err != nil {
 				t.Fatalf("decode got: %v", err)
 			}
-			if err := decodeJSONPreservingNumbers([]byte(tc.want), &wantN); err != nil {
+			if err := ingest.DecodeJSONPreservingNumbers([]byte(tc.want), &wantN); err != nil {
 				t.Fatalf("decode want: %v", err)
 			}
 			if !reflect.DeepEqual(gotN, wantN) {

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -260,7 +260,7 @@ func (h *Handler) CreateEntity(ctx context.Context, input CreateEntityInput) (*E
 		return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "unsupported format")
 	}
 
-	if err := rejectUnstorablePayload(parsedData); err != nil {
+	if err := rejectUnstorablePayload(bodyBytes); err != nil {
 		return nil, err
 	}
 
@@ -1151,7 +1151,7 @@ func (h *Handler) CreateEntityCollection(ctx context.Context, items []Collection
 			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
 				fmt.Sprintf("item %d: invalid JSON payload", i))
 		}
-		if err := rejectUnstorablePayload(parsedData); err != nil {
+		if err := rejectUnstorablePayload(payloadBytes); err != nil {
 			return nil, prefixItemErr(err, i)
 		}
 
@@ -1375,7 +1375,7 @@ func (h *Handler) updateEntityCore(ctx context.Context, input UpdateEntityInput,
 		return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "unsupported format")
 	}
 
-	if err := rejectUnstorablePayload(parsedData); err != nil {
+	if err := rejectUnstorablePayload(bodyBytes); err != nil {
 		return nil, err
 	}
 
@@ -1705,7 +1705,7 @@ func (h *Handler) UpdateEntityCollection(ctx context.Context, items []UpdateColl
 			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
 				fmt.Sprintf("item %d: invalid JSON payload", i))
 		}
-		if err := rejectUnstorablePayload(data); err != nil {
+		if err := rejectUnstorablePayload([]byte(item.Payload)); err != nil {
 			return nil, prefixItemErr(err, i)
 		}
 		parsed = append(parsed, parsedItem{

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -1992,6 +1992,9 @@ func classifyWorkflowError(err error) *common.AppError {
 	if errors.Is(err, contract.ErrNoMatchingMember) {
 		return common.Operational(http.StatusServiceUnavailable, common.ErrCodeNoComputeMemberForTag, err.Error()).AsRetryable()
 	}
+	if errors.Is(err, wfengine.ErrProcessorOutputInfra) {
+		return common.Internal("processor output check failed", err)
+	}
 	if errors.Is(err, wfengine.ErrCommitBeforeDispatchInfra) {
 		return common.Internal("workflow segment boundary failed", err)
 	}

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -433,7 +433,7 @@ func (h *Handler) GetEntity(ctx context.Context, input GetOneEntityInput) (*Enti
 
 	// Parse entity data to any for response
 	var data any
-	if err := ingest.DecodeJSONPreservingNumbers(ent.Data, &data); err != nil {
+	if err := ingest.DecodeStoredJSON(ent.Data, &data); err != nil {
 		return nil, common.Internal("failed to parse entity data", err)
 	}
 
@@ -1054,7 +1054,7 @@ func (h *Handler) ListEntities(ctx context.Context, entityName string, modelVers
 	result := make([]EntityEnvelope, 0, len(pageSlice))
 	for _, ent := range pageSlice {
 		var data any
-		if err := ingest.DecodeJSONPreservingNumbers(ent.Data, &data); err != nil {
+		if err := ingest.DecodeStoredJSON(ent.Data, &data); err != nil {
 			return nil, common.Internal("failed to parse entity data", err)
 		}
 

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"sort"
@@ -21,32 +20,11 @@ import (
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/contract"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/importer"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/ingest"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/pagination"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
 	wfengine "github.com/cyoda-platform/cyoda-go/internal/domain/workflow"
 )
-
-// decodeJSONPreservingNumbers is the precision-preserving counterpart to
-// json.Unmarshal: numeric leaves arrive as json.Number rather than float64,
-// so callers can choose Int64()/Float64()/string preservation. Mirrors
-// importer.ParseJSON's UseNumber() behavior.
-//
-// Like json.Unmarshal (and unlike a bare Decoder.Decode), data must hold
-// exactly one JSON value. Decode alone stops at the end of the first value and
-// silently ignores the rest, so a body such as `{"x":1}}}` would parse as
-// `{"x":1}` while the original bytes — still malformed — went on to be
-// persisted, turning a client input error into a 500 from storage.
-func decodeJSONPreservingNumbers(data []byte, v any) error {
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.UseNumber()
-	if err := dec.Decode(v); err != nil {
-		return err
-	}
-	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
-		return fmt.Errorf("unexpected content after top-level JSON value")
-	}
-	return nil
-}
 
 // --- Input/Output types ---
 
@@ -243,7 +221,7 @@ func (h *Handler) CreateEntity(ctx context.Context, input CreateEntityInput) (*E
 	var parsedData any
 	switch input.Format {
 	case "JSON":
-		if err := decodeJSONPreservingNumbers(bodyBytes, &parsedData); err != nil {
+		if err := ingest.DecodeJSONPreservingNumbers(bodyBytes, &parsedData); err != nil {
 			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid JSON")
 		}
 	case "XML":
@@ -260,12 +238,12 @@ func (h *Handler) CreateEntity(ctx context.Context, input CreateEntityInput) (*E
 		return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "unsupported format")
 	}
 
-	if err := rejectUnstorablePayload(bodyBytes); err != nil {
+	if err := ingest.RejectUnstorable(bodyBytes); err != nil {
 		return nil, err
 	}
 
 	// Validate or extend model schema
-	if err := h.validateOrExtend(ctx, modelStore, desc, parsedData); err != nil {
+	if err := ingest.ValidateOrExtend(ctx, modelStore, desc, parsedData); err != nil {
 		return nil, classifyValidateOrExtendErr(err)
 	}
 
@@ -455,7 +433,7 @@ func (h *Handler) GetEntity(ctx context.Context, input GetOneEntityInput) (*Enti
 
 	// Parse entity data to any for response
 	var data any
-	if err := decodeJSONPreservingNumbers(ent.Data, &data); err != nil {
+	if err := ingest.DecodeJSONPreservingNumbers(ent.Data, &data); err != nil {
 		return nil, common.Internal("failed to parse entity data", err)
 	}
 
@@ -1076,7 +1054,7 @@ func (h *Handler) ListEntities(ctx context.Context, entityName string, modelVers
 	result := make([]EntityEnvelope, 0, len(pageSlice))
 	for _, ent := range pageSlice {
 		var data any
-		if err := decodeJSONPreservingNumbers(ent.Data, &data); err != nil {
+		if err := ingest.DecodeJSONPreservingNumbers(ent.Data, &data); err != nil {
 			return nil, common.Internal("failed to parse entity data", err)
 		}
 
@@ -1147,16 +1125,16 @@ func (h *Handler) CreateEntityCollection(ctx context.Context, items []Collection
 		// Parse payload
 		var parsedData any
 		payloadBytes := []byte(item.Payload)
-		if err := decodeJSONPreservingNumbers(payloadBytes, &parsedData); err != nil {
+		if err := ingest.DecodeJSONPreservingNumbers(payloadBytes, &parsedData); err != nil {
 			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
 				fmt.Sprintf("item %d: invalid JSON payload", i))
 		}
-		if err := rejectUnstorablePayload(payloadBytes); err != nil {
-			return nil, prefixItemErr(err, i)
+		if err := ingest.RejectUnstorable(payloadBytes); err != nil {
+			return nil, ingest.PrefixItemErr(err, i)
 		}
 
 		// Validate or extend model schema
-		if err := h.validateOrExtend(ctx, modelStore, desc, parsedData); err != nil {
+		if err := ingest.ValidateOrExtend(ctx, modelStore, desc, parsedData); err != nil {
 			return nil, classifyValidateOrExtendErr(err)
 		}
 
@@ -1358,7 +1336,7 @@ func (h *Handler) updateEntityCore(ctx context.Context, input UpdateEntityInput,
 	var parsedData any
 	switch input.Format {
 	case "JSON":
-		if err := decodeJSONPreservingNumbers(bodyBytes, &parsedData); err != nil {
+		if err := ingest.DecodeJSONPreservingNumbers(bodyBytes, &parsedData); err != nil {
 			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid JSON")
 		}
 	case "XML":
@@ -1375,7 +1353,7 @@ func (h *Handler) updateEntityCore(ctx context.Context, input UpdateEntityInput,
 		return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "unsupported format")
 	}
 
-	if err := rejectUnstorablePayload(bodyBytes); err != nil {
+	if err := ingest.RejectUnstorable(bodyBytes); err != nil {
 		return nil, err
 	}
 
@@ -1431,12 +1409,12 @@ func (h *Handler) updateEntityCore(ctx context.Context, input UpdateEntityInput,
 	// Validate the (possibly merged) result. PATCH validates strictly and never
 	// extends the model; PUT may extend per the model's ChangeLevel.
 	if opts.strictValidate {
-		if vErr := h.validateStrict(desc, parsedData); vErr != nil {
+		if vErr := ingest.ValidateStrict(desc, parsedData); vErr != nil {
 			h.rollbackOwned(txCtx, txID, owned)
 			return nil, classifyValidateOrExtendErr(vErr)
 		}
 	} else {
-		if vErr := h.validateOrExtend(txCtx, modelStore, desc, parsedData); vErr != nil {
+		if vErr := ingest.ValidateOrExtend(txCtx, modelStore, desc, parsedData); vErr != nil {
 			h.rollbackOwned(txCtx, txID, owned)
 			return nil, classifyValidateOrExtendErr(vErr)
 		}
@@ -1701,12 +1679,12 @@ func (h *Handler) UpdateEntityCollection(ctx context.Context, items []UpdateColl
 				fmt.Sprintf("item %d: missing id", i))
 		}
 		var data any
-		if err := decodeJSONPreservingNumbers([]byte(item.Payload), &data); err != nil {
+		if err := ingest.DecodeJSONPreservingNumbers([]byte(item.Payload), &data); err != nil {
 			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
 				fmt.Sprintf("item %d: invalid JSON payload", i))
 		}
-		if err := rejectUnstorablePayload([]byte(item.Payload)); err != nil {
-			return nil, prefixItemErr(err, i)
+		if err := ingest.RejectUnstorable([]byte(item.Payload)); err != nil {
+			return nil, ingest.PrefixItemErr(err, i)
 		}
 		parsed = append(parsed, parsedItem{
 			id:         item.EntityID,
@@ -1786,7 +1764,7 @@ func (h *Handler) UpdateEntityCollection(ctx context.Context, items []UpdateColl
 		// its keys to the next item; spi.WithUniqueKeys overwrites any prior value.
 		currentCtx = spi.WithUniqueKeys(currentCtx, desc.UniqueKeys)
 
-		if err := h.validateOrExtend(currentCtx, modelStore, desc, item.parsedData); err != nil {
+		if err := ingest.ValidateOrExtend(currentCtx, modelStore, desc, item.parsedData); err != nil {
 			h.rollbackOwned(currentCtx, currentTxID, owned)
 			return nil, classifyValidateOrExtendErr(err)
 		}

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"sort"
@@ -29,10 +30,22 @@ import (
 // json.Unmarshal: numeric leaves arrive as json.Number rather than float64,
 // so callers can choose Int64()/Float64()/string preservation. Mirrors
 // importer.ParseJSON's UseNumber() behavior.
+//
+// Like json.Unmarshal (and unlike a bare Decoder.Decode), data must hold
+// exactly one JSON value. Decode alone stops at the end of the first value and
+// silently ignores the rest, so a body such as `{"x":1}}}` would parse as
+// `{"x":1}` while the original bytes — still malformed — went on to be
+// persisted, turning a client input error into a 500 from storage.
 func decodeJSONPreservingNumbers(data []byte, v any) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
-	return dec.Decode(v)
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("unexpected content after top-level JSON value")
+	}
+	return nil
 }
 
 // --- Input/Output types ---

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -260,6 +260,10 @@ func (h *Handler) CreateEntity(ctx context.Context, input CreateEntityInput) (*E
 		return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "unsupported format")
 	}
 
+	if err := rejectUnstorablePayload(parsedData); err != nil {
+		return nil, err
+	}
+
 	// Validate or extend model schema
 	if err := h.validateOrExtend(ctx, modelStore, desc, parsedData); err != nil {
 		return nil, classifyValidateOrExtendErr(err)
@@ -1147,6 +1151,9 @@ func (h *Handler) CreateEntityCollection(ctx context.Context, items []Collection
 			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
 				fmt.Sprintf("item %d: invalid JSON payload", i))
 		}
+		if err := rejectUnstorablePayload(parsedData); err != nil {
+			return nil, prefixItemErr(err, i)
+		}
 
 		// Validate or extend model schema
 		if err := h.validateOrExtend(ctx, modelStore, desc, parsedData); err != nil {
@@ -1366,6 +1373,10 @@ func (h *Handler) updateEntityCore(ctx context.Context, input UpdateEntityInput,
 		}
 	default:
 		return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "unsupported format")
+	}
+
+	if err := rejectUnstorablePayload(parsedData); err != nil {
+		return nil, err
 	}
 
 	// Begin a fresh tx, or PARTICIPATE in a joined tx already on ctx (#287).
@@ -1693,6 +1704,9 @@ func (h *Handler) UpdateEntityCollection(ctx context.Context, items []UpdateColl
 		if err := decodeJSONPreservingNumbers([]byte(item.Payload), &data); err != nil {
 			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
 				fmt.Sprintf("item %d: invalid JSON payload", i))
+		}
+		if err := rejectUnstorablePayload(data); err != nil {
+			return nil, prefixItemErr(err, i)
 		}
 		parsed = append(parsed, parsedItem{
 			id:         item.EntityID,

--- a/internal/domain/entity/service_test.go
+++ b/internal/domain/entity/service_test.go
@@ -368,7 +368,7 @@ func flattenStatsByState(stats []entity.EntityStatByState) map[string]int64 {
 // decodeJSONResponseUseNumber decodes an HTTP response body using
 // json.Decoder.UseNumber() so numeric leaves arrive as json.Number and
 // the test can assert exact literal preservation. Mirrors the
-// production helper entity.ingest.DecodeJSONPreservingNumbers (unexported).
+// production helper ingest.DecodeJSONPreservingNumbers.
 // Keep the two in sync when changing numeric-decode policy.
 func decodeJSONResponseUseNumber(t *testing.T, body []byte, v any) {
 	t.Helper()

--- a/internal/domain/entity/service_test.go
+++ b/internal/domain/entity/service_test.go
@@ -368,7 +368,7 @@ func flattenStatsByState(stats []entity.EntityStatByState) map[string]int64 {
 // decodeJSONResponseUseNumber decodes an HTTP response body using
 // json.Decoder.UseNumber() so numeric leaves arrive as json.Number and
 // the test can assert exact literal preservation. Mirrors the
-// production helper entity.decodeJSONPreservingNumbers (unexported).
+// production helper entity.ingest.DecodeJSONPreservingNumbers (unexported).
 // Keep the two in sync when changing numeric-decode policy.
 func decodeJSONResponseUseNumber(t *testing.T, body []byte, v any) {
 	t.Helper()
@@ -470,7 +470,7 @@ func TestUpdateEntity_PreservesLargeIntPrecision(t *testing.T) {
 // dedicated collection-create path (POST /entity/{format} with an array
 // of {model, payload} items) preserves integer literals >2^53 exactly.
 // Spec Section 6.4: this exercises the CreateEntityCollection JSON-array
-// parsing path (service.go decodeJSONPreservingNumbers call), which is
+// parsing path (service.go ingest.DecodeJSONPreservingNumbers call), which is
 // distinct from the single-create path covered by
 // TestCreateEntity_PreservesLargeIntPrecision.
 func TestCollectionCreate_PreservesLargeIntPrecision(t *testing.T) {

--- a/internal/domain/entity/storable_duplicate_test.go
+++ b/internal/domain/entity/storable_duplicate_test.go
@@ -1,0 +1,66 @@
+package entity
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRejectUnstorablePayload_DuplicateKeys pins the rejection of duplicate
+// object names.
+//
+// A duplicated key is read differently by different parts of the system, on the
+// same bytes in the same request: schema validation, the GET response and
+// unique-key computation use encoding/json, which keeps the LAST occurrence,
+// while the workflow criterion evaluator, search and grouped statistics use
+// gjson, which keeps the FIRST. Measured consequence: an entity created with
+// {"amount":"not-a-number","amount":5} is reported by the API as amount=5 while
+// the criterion `amount == 5` does not fire, leaving the entity in the wrong
+// workflow state with nothing logged.
+//
+// RFC 8259 says object names SHOULD be unique and explicitly permits rejecting
+// input where they are not. Rejecting removes the ambiguity rather than
+// silently picking a winner.
+func TestRejectUnstorablePayload_DuplicateKeys(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  string
+		wantPath string // "" means accepted
+	}{
+		{name: "no duplicates", payload: `{"a":1,"b":2}`},
+		{name: "same name in sibling objects is fine", payload: `{"x":{"a":1},"y":{"a":2}}`},
+		{name: "same name at different depths is fine", payload: `{"a":{"a":{"a":1}}}`},
+		{name: "same name across array elements is fine", payload: `{"xs":[{"a":1},{"a":2}]}`},
+		{name: "empty object", payload: `{}`},
+		{name: "repeated values are not repeated keys", payload: `{"a":1,"b":1}`},
+
+		{name: "top-level duplicate", payload: `{"a":1,"a":2}`, wantPath: "a"},
+		{name: "the measured corruption case", payload: `{"amount":"not-a-number","amount":5}`, wantPath: "amount"},
+		{name: "duplicate nested", payload: `{"outer":{"k":1,"k":2}}`, wantPath: "outer.k"},
+		{name: "duplicate inside an array element", payload: `{"xs":[{"ok":1},{"k":1,"k":2}]}`, wantPath: "xs[1].k"},
+		{name: "three occurrences", payload: `{"a":1,"a":2,"a":3}`, wantPath: "a"},
+		{name: "duplicate with differing types", payload: `{"a":{"n":1},"a":[1]}`, wantPath: "a"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := rejectUnstorablePayload([]byte(tc.payload))
+
+			if tc.wantPath == "" {
+				if err != nil {
+					t.Fatalf("payload %s rejected but has no duplicate names: %v", tc.payload, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("payload %s accepted; the duplicate name %q makes it read differently by different subsystems",
+					tc.payload, tc.wantPath)
+			}
+			if !strings.Contains(err.Error(), tc.wantPath) {
+				t.Errorf("error %q does not name the duplicated key %q", err, tc.wantPath)
+			}
+			if !strings.Contains(err.Error(), "more than once") {
+				t.Errorf("error %q does not explain that the name appears more than once", err)
+			}
+		})
+	}
+}

--- a/internal/domain/entity/storable_number_test.go
+++ b/internal/domain/entity/storable_number_test.go
@@ -1,0 +1,117 @@
+package entity
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCheckJSONNumberToken pins the storability bound for JSON numbers.
+//
+// PostgreSQL's numeric type — which jsonb parses every JSON number into — holds
+// at most 131072 digits before the decimal point and 16383 after. Past either
+// limit the write fails inside the store with SQLSTATE 22003, so the payload
+// arrives as a 500 for what is a client input error, while memory and sqlite
+// accept it.
+//
+// The bound is on the EFFECTIVE weight and scale, not on the digits as written,
+// and that distinction is the whole difficulty:
+//
+//   - 1e131071 fits; 1e131072 does not — the exponent moves the weight.
+//   - 12e131071 does NOT fit: two integer digits plus the exponent is 131073.
+//   - 1.5e-16383 does NOT fit, despite having a single fraction digit and an
+//     exponent inside the limit — the exponent moves the scale too.
+//   - 0.0001e131075 DOES fit: leading zeros are not significant, so the value
+//     is really 1e131071.
+//   - A zero coefficient is exempt from the weight limit (0e999999999 is just
+//     zero) but NOT from the scale limit.
+func TestCheckJSONNumberToken(t *testing.T) {
+	cases := []struct {
+		literal string
+		wantBad bool
+	}{
+		// --- ordinary values ---
+		{"0", false},
+		{"-1", false},
+		{"1.5", false},
+		{"123456789012345678901234567890.123456789", false},
+		{"1e400", false},
+		{"-1.5e-400", false},
+		{"1E+3", false},
+
+		// --- weight boundary ---
+		{"1e131071", false},
+		{"1e131072", true},
+		{"1e1000000", true},
+		{"12e131071", true},      // 2 int digits + exp = 131073
+		{"-12e131071", true},     // sign must not change the count
+		{"0.0001e131075", false}, // leading zeros not significant -> 1e131071
+		{"0.0001e131076", true},
+
+		// --- scale boundary ---
+		{"1e-16383", false},
+		{"1e-16384", true},
+		{"1.5e-16383", true}, // 1 fraction digit, |exp| in range, still overflows
+		{"1.5e-16382", false},
+		{"10e-16384", true},         // value is 1e-16383 but scale is computed lexically
+		{"1.00000000e-16383", true}, // trailing zeros count toward scale
+
+		// --- zero coefficient ---
+		{"0e999999999", false}, // exempt from the weight limit
+		{"0e-999999999", true}, // NOT exempt from the scale limit
+		{"0.0", false},
+
+		// --- must not allocate or hang on absurd exponents ---
+		{"1e99999999999999999999", true},
+		{"1e-99999999999999999999", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.literal, func(t *testing.T) {
+			reason := checkJSONNumberToken([]byte(tc.literal))
+			if tc.wantBad && reason == "" {
+				t.Fatalf("%s accepted; PostgreSQL numeric cannot hold it", tc.literal)
+			}
+			if !tc.wantBad && reason != "" {
+				t.Fatalf("%s rejected (%s); it is storable", tc.literal, reason)
+			}
+		})
+	}
+}
+
+// TestRejectUnstorablePayload_Numbers checks the guard reaches numbers wherever
+// they sit in the document, and reports the field path like the other reasons.
+func TestRejectUnstorablePayload_Numbers(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  string
+		wantPath string
+	}{
+		{"top-level field", `{"big":1e1000000}`, "big"},
+		{"nested", `{"outer":{"inner":1e1000000}}`, "outer.inner"},
+		{"in an array", `{"xs":[1,1e1000000]}`, "xs[1]"},
+		{"bare number payload", `1e1000000`, "(root)"},
+		{"scale overflow", `{"d":1.5e-16383}`, "d"},
+
+		{"ordinary number accepted", `{"n":1.5}`, ""},
+		{"large but storable accepted", `{"n":1e131071}`, ""},
+		{"precision preserved value accepted", `{"n":123456789012345678901234567890.123456789}`, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := rejectUnstorablePayload([]byte(tc.payload))
+			if tc.wantPath == "" {
+				if err != nil {
+					t.Fatalf("payload %s rejected but is storable: %v", tc.payload, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("payload %s accepted but is not storable", tc.payload)
+			}
+			if !strings.Contains(err.Error(), tc.wantPath) {
+				t.Errorf("error %q does not name the offending path %q", err, tc.wantPath)
+			}
+		})
+	}
+}

--- a/internal/domain/entity/storable_payload.go
+++ b/internal/domain/entity/storable_payload.go
@@ -1,10 +1,10 @@
 package entity
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"unicode/utf8"
 
@@ -14,9 +14,24 @@ import (
 // Reasons a payload cannot be stored. Kept as distinct sentences so the
 // rejection tells the caller what to change.
 const (
-	reasonNul       = "contains a NUL character (U+0000), which cannot be stored"
-	reasonSurrogate = "contains an unpaired UTF-16 surrogate escape, which is not storable text"
-	reasonNotUTF8   = "is not valid UTF-8"
+	reasonNul          = "contains a NUL character (U+0000), which cannot be stored"
+	reasonSurrogate    = "contains an unpaired UTF-16 surrogate escape, which is not storable text"
+	reasonNotUTF8      = "is not valid UTF-8"
+	reasonDuplicateKey = "appears more than once in the same object, so different parts of the system would read different values for it"
+	reasonNumWeight    = "is a number with too many digits before the decimal point to be stored"
+	reasonNumScale     = "is a number with too many digits after the decimal point to be stored"
+)
+
+// Limits of PostgreSQL's numeric type, which jsonb parses every JSON number
+// into. Past either, the write fails inside the store rather than at the
+// boundary.
+const (
+	maxNumericWeightDigits = 131072
+	maxNumericScaleDigits  = 16383
+	// maxExponentMagnitude saturates exponent accumulation. Any exponent this
+	// large already breaches both limits, so clamping cannot change a verdict —
+	// it only stops a 20-digit exponent from overflowing the accumulator.
+	maxExponentMagnitude = 1 << 40
 )
 
 // rejectUnstorablePayload rejects an entity payload that no supported backend
@@ -65,13 +80,13 @@ func unstorableErr(path, reason string) error {
 }
 
 // findUnstorable walks the raw JSON structure, returning the path and reason of
-// the first unstorable string it finds. Object keys are visited in sorted order
-// so the reported path is deterministic.
+// the first unstorable content it finds. Object members are visited in document
+// order.
 //
 // Values are kept as json.RawMessage so each string is examined exactly as the
-// client wrote it. Object KEYS are the one exception — decoding an object hands
-// back keys as Go strings, already normalised — so a key is only checked for
-// NUL, which survives decoding. A surrogate in a key is not detectable here.
+// client wrote it. Object KEYS are the one exception — the decoder hands them
+// back as Go strings, already normalised — so a key is only checked for NUL,
+// which survives decoding. A surrogate in a key is not detectable here.
 func findUnstorable(raw json.RawMessage, path string) (string, string, bool) {
 	trimmed := trimJSONSpace(raw)
 	if len(trimmed) == 0 {
@@ -80,26 +95,43 @@ func findUnstorable(raw json.RawMessage, path string) (string, string, bool) {
 
 	switch trimmed[0] {
 	case '{':
-		var obj map[string]json.RawMessage
-		if json.Unmarshal(trimmed, &obj) != nil {
-			return "", "", false // malformed JSON is rejected by the decoder, not here
+		// Read members with a token decoder rather than into a map. A map would
+		// collapse duplicate names before they could be seen, and would lose
+		// document order; the decoder gives ordered members, each value still as
+		// raw bytes.
+		dec := json.NewDecoder(bytes.NewReader(trimmed))
+		if _, err := dec.Token(); err != nil { // opening brace
+			return "", "", false
 		}
-		keys := make([]string, 0, len(obj))
-		for k := range obj {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			child := k
-			if path != "" {
-				child = path + "." + k
+		seen := make(map[string]struct{})
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return "", "", false // malformed JSON is the decoder's rejection, not ours
 			}
-			for _, r := range k {
+			key, ok := keyTok.(string)
+			if !ok {
+				return "", "", false
+			}
+			child := key
+			if path != "" {
+				child = path + "." + key
+			}
+			for _, r := range key {
 				if r == 0 {
 					return child, reasonNul, true
 				}
 			}
-			if p, reason, found := findUnstorable(obj[k], child); found {
+			if _, dup := seen[key]; dup {
+				return child, reasonDuplicateKey, true
+			}
+			seen[key] = struct{}{}
+
+			var val json.RawMessage
+			if err := dec.Decode(&val); err != nil {
+				return "", "", false
+			}
+			if p, reason, found := findUnstorable(val, child); found {
 				return p, reason, true
 			}
 		}
@@ -117,9 +149,105 @@ func findUnstorable(raw json.RawMessage, path string) (string, string, bool) {
 		if reason := checkJSONStringToken(trimmed); reason != "" {
 			return path, reason, true
 		}
+	default:
+		// A number token. true/false/null start with t/f/n, so a leading digit
+		// or minus sign is unambiguous.
+		if c := trimmed[0]; c == '-' || (c >= '0' && c <= '9') {
+			if reason := checkJSONNumberToken(trimmed); reason != "" {
+				return path, reason, true
+			}
+		}
 	}
 	return "", "", false
 }
+
+// checkJSONNumberToken reports whether a raw JSON number literal is outside the
+// range PostgreSQL's numeric type can hold.
+//
+// The check is on effective weight and scale rather than on the digits as
+// written, because the exponent moves both: 1.5e-16383 has a single fraction
+// digit and an in-range exponent yet still overflows the scale, and 12e131071
+// overflows the weight that 1e131071 does not. Leading zeros are not
+// significant, so 0.0001e131075 is really 1e131071 and fits.
+//
+// It is purely lexical and allocates nothing — materialising 1e1000000 would
+// mean building a million-digit value to decide it is too big.
+func checkJSONNumberToken(tok []byte) string {
+	i := 0
+	if i < len(tok) && (tok[i] == '-' || tok[i] == '+') {
+		i++
+	}
+	intStart := i
+	for i < len(tok) && isDigit(tok[i]) {
+		i++
+	}
+	intEnd := i
+
+	fracStart, fracEnd := i, i
+	if i < len(tok) && tok[i] == '.' {
+		i++
+		fracStart = i
+		for i < len(tok) && isDigit(tok[i]) {
+			i++
+		}
+		fracEnd = i
+	}
+
+	var exp int64
+	if i < len(tok) && (tok[i] == 'e' || tok[i] == 'E') {
+		i++
+		neg := false
+		if i < len(tok) && (tok[i] == '+' || tok[i] == '-') {
+			neg = tok[i] == '-'
+			i++
+		}
+		var v int64
+		for i < len(tok) && isDigit(tok[i]) {
+			if v <= maxExponentMagnitude {
+				v = v*10 + int64(tok[i]-'0')
+			}
+			i++
+		}
+		if v > maxExponentMagnitude {
+			v = maxExponentMagnitude
+		}
+		if neg {
+			v = -v
+		}
+		exp = v
+	}
+
+	intDigits := int64(intEnd - intStart)
+	fracDigits := int64(fracEnd - fracStart)
+
+	// Scale: digits that end up to the right of the point. Counted lexically,
+	// so trailing zeros bite — 1.00000000e-16383 really does overflow.
+	if fracDigits-exp > maxNumericScaleDigits {
+		return reasonNumScale
+	}
+
+	// Weight: digits to the left of the point, ignoring leading zeros. A zero
+	// coefficient has no weight at all however large the exponent.
+	leadingZeros, allZero := int64(0), true
+	for _, r := range [2][2]int{{intStart, intEnd}, {fracStart, fracEnd}} {
+		for j := r[0]; j < r[1]; j++ {
+			if tok[j] != '0' {
+				allZero = false
+				break
+			}
+			leadingZeros++
+		}
+		if !allZero {
+			break
+		}
+	}
+	if !allZero && intDigits-leadingZeros+exp > maxNumericWeightDigits {
+		return reasonNumWeight
+	}
+	return ""
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
 
 // checkJSONStringToken inspects a raw JSON string token (quotes included) for
 // content no backend can store. It walks escapes properly, so a literal

--- a/internal/domain/entity/storable_payload.go
+++ b/internal/domain/entity/storable_payload.go
@@ -1,0 +1,86 @@
+package entity
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+)
+
+// rejectUnstorablePayload rejects a decoded entity payload that no supported
+// backend can persist.
+//
+// The only such value today is U+0000: PostgreSQL's text and jsonb types
+// cannot represent a NUL, so a body whose string carries a \u0000 escape —
+// syntactically valid JSON that passes schema validation — used to reach the
+// store and fail there, surfacing a client input error as a 500 with a
+// support ticket. It is a 400.
+//
+// Rejecting at the boundary rather than classifying the storage error also
+// keeps the backends on one contract: memory and sqlite would otherwise accept
+// a payload postgres refuses, which is a divergence, not a tolerance.
+func rejectUnstorablePayload(v any) error {
+	path, found := findNulString(v, "")
+	if !found {
+		return nil
+	}
+	if path == "" {
+		path = "(root)"
+	}
+	return common.Operational(
+		http.StatusBadRequest,
+		common.ErrCodeBadRequest,
+		fmt.Sprintf("payload field %q contains a NUL character (U+0000), which cannot be stored", path),
+	)
+}
+
+// prefixItemErr restates an operational error against the collection item it
+// came from, so a batch rejection says which element was at fault.
+func prefixItemErr(err error, i int) error {
+	appErr, ok := err.(*common.AppError)
+	if !ok {
+		return err
+	}
+	restated := common.Operational(appErr.Status, appErr.Code, fmt.Sprintf("item %d: %s", i, appErr.Message))
+	restated.Props = appErr.Props
+	return restated
+}
+
+// findNulString returns the JSON path of the first object key or string value
+// containing U+0000. Keys are visited in sorted order so the reported path is
+// deterministic for a given payload.
+func findNulString(v any, path string) (string, bool) {
+	switch t := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			child := k
+			if path != "" {
+				child = path + "." + k
+			}
+			if strings.ContainsRune(k, 0) {
+				return child, true
+			}
+			if p, ok := findNulString(t[k], child); ok {
+				return p, true
+			}
+		}
+	case []any:
+		for i, elem := range t {
+			if p, ok := findNulString(elem, fmt.Sprintf("%s[%d]", path, i)); ok {
+				return p, true
+			}
+		}
+	case string:
+		if strings.ContainsRune(t, 0) {
+			return path, true
+		}
+	}
+	return "", false
+}

--- a/internal/domain/entity/storable_payload.go
+++ b/internal/domain/entity/storable_payload.go
@@ -1,39 +1,203 @@
 package entity
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
-	"strings"
+	"strconv"
+	"unicode/utf8"
 
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 )
 
-// rejectUnstorablePayload rejects a decoded entity payload that no supported
-// backend can persist.
+// Reasons a payload cannot be stored. Kept as distinct sentences so the
+// rejection tells the caller what to change.
+const (
+	reasonNul       = "contains a NUL character (U+0000), which cannot be stored"
+	reasonSurrogate = "contains an unpaired UTF-16 surrogate escape, which is not storable text"
+	reasonNotUTF8   = "is not valid UTF-8"
+)
+
+// rejectUnstorablePayload rejects an entity payload that no supported backend
+// can persist, before it reaches a store.
 //
-// The only such value today is U+0000: PostgreSQL's text and jsonb types
-// cannot represent a NUL, so a body whose string carries a \u0000 escape —
-// syntactically valid JSON that passes schema validation — used to reach the
-// store and fail there, surfacing a client input error as a 500 with a
-// support ticket. It is a 400.
+// PostgreSQL's text and jsonb types cannot represent U+0000, an unpaired
+// UTF-16 surrogate, or a byte sequence that is not valid UTF-8. All three are
+// accepted by Go's JSON parser, so without this guard they reached the store
+// and failed there — returning 500 with a support ticket for what is a client
+// input error — while the memory and sqlite stores accepted them, making the
+// set of storable values depend on which backend served the request.
 //
-// Rejecting at the boundary rather than classifying the storage error also
-// keeps the backends on one contract: memory and sqlite would otherwise accept
-// a payload postgres refuses, which is a divergence, not a tolerance.
-func rejectUnstorablePayload(v any) error {
-	path, found := findNulString(v, "")
-	if !found {
-		return nil
+// It operates on the RAW request bytes, not the decoded value, and that is
+// load-bearing rather than stylistic: Go's decoder silently rewrites both
+// unpaired surrogates and invalid UTF-8 to U+FFFD, so by the time a value is
+// decoded a mangled surrogate is indistinguishable from a client legitimately
+// sending U+FFFD. Rejecting on the decoded value would therefore be impossible
+// for two of the three cases, and re-serialising the decoded value — the other
+// obvious fix — would silently store a replacement character the client never
+// sent, which is exactly the substituted-value outcome
+// .claude/rules/correctness-over-availability.md forbids.
+func rejectUnstorablePayload(raw []byte) error {
+	// Whole-document check first. Invalid UTF-8 has no meaningful JSON path —
+	// the bytes may not even parse as text — so it is reported against the
+	// document rather than a field.
+	if !utf8.Valid(raw) {
+		return unstorableErr("(payload)", reasonNotUTF8)
 	}
-	if path == "" {
-		path = "(root)"
+	if path, reason, found := findUnstorable(raw, ""); found {
+		if path == "" {
+			path = "(root)"
+		}
+		return unstorableErr(path, reason)
 	}
+	return nil
+}
+
+func unstorableErr(path, reason string) error {
 	return common.Operational(
 		http.StatusBadRequest,
 		common.ErrCodeBadRequest,
-		fmt.Sprintf("payload field %q contains a NUL character (U+0000), which cannot be stored", path),
+		// %q so a control byte in a key or value is never echoed raw into the
+		// response body.
+		fmt.Sprintf("payload field %q %s", path, reason),
 	)
+}
+
+// findUnstorable walks the raw JSON structure, returning the path and reason of
+// the first unstorable string it finds. Object keys are visited in sorted order
+// so the reported path is deterministic.
+//
+// Values are kept as json.RawMessage so each string is examined exactly as the
+// client wrote it. Object KEYS are the one exception — decoding an object hands
+// back keys as Go strings, already normalised — so a key is only checked for
+// NUL, which survives decoding. A surrogate in a key is not detectable here.
+func findUnstorable(raw json.RawMessage, path string) (string, string, bool) {
+	trimmed := trimJSONSpace(raw)
+	if len(trimmed) == 0 {
+		return "", "", false
+	}
+
+	switch trimmed[0] {
+	case '{':
+		var obj map[string]json.RawMessage
+		if json.Unmarshal(trimmed, &obj) != nil {
+			return "", "", false // malformed JSON is rejected by the decoder, not here
+		}
+		keys := make([]string, 0, len(obj))
+		for k := range obj {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			child := k
+			if path != "" {
+				child = path + "." + k
+			}
+			for _, r := range k {
+				if r == 0 {
+					return child, reasonNul, true
+				}
+			}
+			if p, reason, found := findUnstorable(obj[k], child); found {
+				return p, reason, true
+			}
+		}
+	case '[':
+		var arr []json.RawMessage
+		if json.Unmarshal(trimmed, &arr) != nil {
+			return "", "", false
+		}
+		for i, elem := range arr {
+			if p, reason, found := findUnstorable(elem, fmt.Sprintf("%s[%d]", path, i)); found {
+				return p, reason, true
+			}
+		}
+	case '"':
+		if reason := checkJSONStringToken(trimmed); reason != "" {
+			return path, reason, true
+		}
+	}
+	return "", "", false
+}
+
+// checkJSONStringToken inspects a raw JSON string token (quotes included) for
+// content no backend can store. It walks escapes properly, so a literal
+// backslash sequence such as `a\\u0000b` — six ordinary characters, not an
+// escape — is correctly left alone.
+func checkJSONStringToken(tok []byte) string {
+	for i := 0; i < len(tok); {
+		c := tok[i]
+		if c == 0 {
+			return reasonNul
+		}
+		if c != '\\' {
+			i++
+			continue
+		}
+		if i+1 >= len(tok) {
+			break
+		}
+		if tok[i+1] != 'u' {
+			// A two-character escape (\\ \" \/ \b \f \n \r \t). Consuming both
+			// bytes is what keeps `\\uXXXX` from being read as an escape.
+			i += 2
+			continue
+		}
+		r, ok := parseHex4(tok, i+2)
+		if !ok {
+			i += 2
+			continue
+		}
+		switch {
+		case r == 0:
+			return reasonNul
+		case r >= 0xD800 && r <= 0xDBFF:
+			// High surrogate — valid only when immediately followed by a low
+			// surrogate escape.
+			if lo, ok := parseHex4(tok, i+8); ok && i+7 < len(tok) &&
+				tok[i+6] == '\\' && tok[i+7] == 'u' && lo >= 0xDC00 && lo <= 0xDFFF {
+				i += 12
+				continue
+			}
+			return reasonSurrogate
+		case r >= 0xDC00 && r <= 0xDFFF:
+			// Low surrogate with no preceding high surrogate: a paired one is
+			// consumed above, so reaching here means it is unpaired.
+			return reasonSurrogate
+		}
+		i += 6
+	}
+	return ""
+}
+
+// parseHex4 reads the four hex digits at off, reporting whether they are present
+// and well-formed.
+func parseHex4(b []byte, off int) (rune, bool) {
+	if off+4 > len(b) {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(string(b[off:off+4]), 16, 32)
+	if err != nil {
+		return 0, false
+	}
+	return rune(v), true
+}
+
+// trimJSONSpace strips the whitespace JSON permits around a value.
+func trimJSONSpace(b []byte) []byte {
+	start, end := 0, len(b)
+	for start < end && isJSONSpace(b[start]) {
+		start++
+	}
+	for end > start && isJSONSpace(b[end-1]) {
+		end--
+	}
+	return b[start:end]
+}
+
+func isJSONSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 }
 
 // prefixItemErr restates an operational error against the collection item it
@@ -46,41 +210,4 @@ func prefixItemErr(err error, i int) error {
 	restated := common.Operational(appErr.Status, appErr.Code, fmt.Sprintf("item %d: %s", i, appErr.Message))
 	restated.Props = appErr.Props
 	return restated
-}
-
-// findNulString returns the JSON path of the first object key or string value
-// containing U+0000. Keys are visited in sorted order so the reported path is
-// deterministic for a given payload.
-func findNulString(v any, path string) (string, bool) {
-	switch t := v.(type) {
-	case map[string]any:
-		keys := make([]string, 0, len(t))
-		for k := range t {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			child := k
-			if path != "" {
-				child = path + "." + k
-			}
-			if strings.ContainsRune(k, 0) {
-				return child, true
-			}
-			if p, ok := findNulString(t[k], child); ok {
-				return p, true
-			}
-		}
-	case []any:
-		for i, elem := range t {
-			if p, ok := findNulString(elem, fmt.Sprintf("%s[%d]", path, i)); ok {
-				return p, true
-			}
-		}
-	case string:
-		if strings.ContainsRune(t, 0) {
-			return path, true
-		}
-	}
-	return "", false
 }

--- a/internal/domain/entity/storable_payload_test.go
+++ b/internal/domain/entity/storable_payload_test.go
@@ -1,0 +1,79 @@
+package entity
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+)
+
+// TestRejectUnstorablePayload pins the boundary rule for U+0000. PostgreSQL
+// text/jsonb cannot represent a NUL, so a payload carrying one is a client
+// input error the boundary must reject — not a storage failure that surfaces
+// as a 500 with a support ticket. Rejecting it here also keeps memory and
+// sqlite, which would happily accept it, on the same contract as postgres.
+func TestRejectUnstorablePayload(t *testing.T) {
+	const nul = "\x00"
+
+	cases := []struct {
+		name     string
+		payload  any
+		wantPath string // "" means the payload must be accepted
+	}{
+		{"plain object", map[string]any{"name": "ok", "amount": "1"}, ""},
+		{"empty object", map[string]any{}, ""},
+		{"nil", nil, ""},
+		{"other control chars are storable", map[string]any{"name": "a\tb\nc"}, ""},
+		{"escaped-looking text is not a NUL", map[string]any{"name": "a\\u0000b"}, ""},
+
+		{"nul in a top-level string", map[string]any{"name": "a" + nul + "b"}, "name"},
+		{"nul in a nested string", map[string]any{
+			"outer": map[string]any{"inner": nul},
+		}, "outer.inner"},
+		{"nul in an array element", map[string]any{
+			"tags": []any{"ok", "bad" + nul},
+		}, "tags[1]"},
+		{"nul in a nested array of objects", map[string]any{
+			"items": []any{
+				map[string]any{"sku": "ok"},
+				map[string]any{"sku": nul + "x"},
+			},
+		}, "items[1].sku"},
+		{"nul in an object key", map[string]any{"bad" + nul + "key": "v"}, "bad" + nul + "key"},
+		{"bare string payload", "a" + nul, "(root)"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := rejectUnstorablePayload(tc.payload)
+
+			if tc.wantPath == "" {
+				if err != nil {
+					t.Fatalf("payload rejected but should be accepted: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("payload accepted but should be rejected (expected path %q)", tc.wantPath)
+			}
+			appErr, ok := err.(*common.AppError)
+			if !ok {
+				t.Fatalf("error is %T, want *common.AppError", err)
+			}
+			if appErr.Status != http.StatusBadRequest {
+				t.Errorf("status=%d, want 400", appErr.Status)
+			}
+			if appErr.Code != common.ErrCodeBadRequest {
+				t.Errorf("code=%q, want %q", appErr.Code, common.ErrCodeBadRequest)
+			}
+			// The path is rendered with %q so a control byte in a key is never
+			// echoed raw into the response body (output sanitization).
+			if want := strconv.Quote(tc.wantPath); !strings.Contains(appErr.Message, want) {
+				t.Errorf("message %q does not name the offending path %s", appErr.Message, want)
+			}
+		})
+	}
+}

--- a/internal/domain/entity/storable_payload_test.go
+++ b/internal/domain/entity/storable_payload_test.go
@@ -9,55 +9,74 @@ import (
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 )
 
-// TestRejectUnstorablePayload pins the boundary rule for U+0000. PostgreSQL
-// text/jsonb cannot represent a NUL, so a payload carrying one is a client
-// input error the boundary must reject — not a storage failure that surfaces
-// as a 500 with a support ticket. Rejecting it here also keeps memory and
-// sqlite, which would happily accept it, on the same contract as postgres.
+// TestRejectUnstorablePayload pins the boundary rule for values no supported
+// backend can persist: U+0000, unpaired UTF-16 surrogates, and byte sequences
+// that are not valid UTF-8. All three are accepted by Go's JSON parser but
+// rejected by PostgreSQL text/jsonb, so without this guard they surfaced as a
+// 500 with a support ticket on postgres and were silently accepted on memory
+// and sqlite.
+//
+// The guard reads RAW bytes deliberately — see rejectUnstorablePayload's doc
+// comment. The "already-mangled" cases below are what make that necessary.
 func TestRejectUnstorablePayload(t *testing.T) {
-	const nul = "\x00"
-
 	cases := []struct {
 		name     string
-		payload  any
+		payload  string
 		wantPath string // "" means the payload must be accepted
+		wantWord string // a distinguishing word from the expected reason
 	}{
-		{"plain object", map[string]any{"name": "ok", "amount": "1"}, ""},
-		{"empty object", map[string]any{}, ""},
-		{"nil", nil, ""},
-		{"other control chars are storable", map[string]any{"name": "a\tb\nc"}, ""},
-		{"escaped-looking text is not a NUL", map[string]any{"name": "a\\u0000b"}, ""},
+		// --- storable ---
+		{name: "plain object", payload: `{"name":"ok","amount":1}`},
+		{name: "empty object", payload: `{}`},
+		{name: "empty array", payload: `[]`},
+		{name: "nested", payload: `{"a":{"b":["x",{"c":"y"}]}}`},
+		{name: "other control chars", payload: `{"name":"a\tb\nc"}`},
+		{name: "escaped quote and backslash", payload: `{"name":"a\"b\\c"}`},
+		{name: "valid surrogate pair (emoji)", payload: `{"name":"a😀b"}`},
+		{name: "non-ascii escape", payload: `{"name":"café"}`},
+		{name: "literal utf8 non-ascii", payload: `{"name":"café"}`},
+		{name: "client-sent replacement char", payload: "{\"name\":\"a\ufffdb\"}"},
+		{name: "numbers and null", payload: `{"a":1e400,"b":null,"c":true}`},
+		{name: "leading/trailing space", payload: "  {\"name\":\"ok\"}  "},
 
-		{"nul in a top-level string", map[string]any{"name": "a" + nul + "b"}, "name"},
-		{"nul in a nested string", map[string]any{
-			"outer": map[string]any{"inner": nul},
-		}, "outer.inner"},
-		{"nul in an array element", map[string]any{
-			"tags": []any{"ok", "bad" + nul},
-		}, "tags[1]"},
-		{"nul in a nested array of objects", map[string]any{
-			"items": []any{
-				map[string]any{"sku": "ok"},
-				map[string]any{"sku": nul + "x"},
-			},
-		}, "items[1].sku"},
-		{"nul in an object key", map[string]any{"bad" + nul + "key": "v"}, "bad" + nul + "key"},
-		{"bare string payload", "a" + nul, "(root)"},
+		// A literal backslash followed by u0000 is six ordinary characters, not
+		// an escape. The escape walker must not mistake it for one.
+		{name: "literal backslash then u0000", payload: `{"name":"a\\u0000b"}`},
+		{name: "literal backslash then ud800", payload: `{"name":"a\\ud800b"}`},
+
+		// --- unstorable: NUL ---
+		{name: "nul escape in value", payload: `{"name":"a\u0000b"}`, wantPath: "name", wantWord: "NUL"},
+		{name: "nul nested", payload: `{"outer":{"inner":"\u0000"}}`, wantPath: "outer.inner", wantWord: "NUL"},
+		{name: "nul in array element", payload: `{"tags":["ok","bad\u0000"]}`, wantPath: "tags[1]", wantWord: "NUL"},
+		{name: "nul in nested array of objects", payload: `{"items":[{"sku":"ok"},{"sku":"\u0000x"}]}`, wantPath: "items[1].sku", wantWord: "NUL"},
+		{name: "nul in object key", payload: "{\"bad\\u0000key\":\"v\"}", wantPath: "bad\x00key", wantWord: "NUL"},
+		{name: "bare string payload", payload: `"a\u0000"`, wantPath: "(root)", wantWord: "NUL"},
+
+		// --- unstorable: unpaired surrogate ---
+		{name: "lone high surrogate", payload: `{"name":"a\ud800b"}`, wantPath: "name", wantWord: "surrogate"},
+		{name: "lone low surrogate", payload: `{"name":"a\udc00b"}`, wantPath: "name", wantWord: "surrogate"},
+		{name: "high surrogate at end", payload: `{"name":"ab\udbff"}`, wantPath: "name", wantWord: "surrogate"},
+		{name: "high followed by non-surrogate escape", payload: `{"name":"\ud800A"}`, wantPath: "name", wantWord: "surrogate"},
+		{name: "surrogate nested in array", payload: `{"t":["ok","\udfff"]}`, wantPath: "t[1]", wantWord: "surrogate"},
+
+		// --- unstorable: invalid UTF-8 ---
+		{name: "raw invalid utf8", payload: "{\"name\":\"a\xffb\"}", wantPath: "(payload)", wantWord: "UTF-8"},
+		{name: "truncated utf8 sequence", payload: "{\"name\":\"a\xe2\x82\"}", wantPath: "(payload)", wantWord: "UTF-8"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := rejectUnstorablePayload(tc.payload)
+			err := rejectUnstorablePayload([]byte(tc.payload))
 
 			if tc.wantPath == "" {
 				if err != nil {
-					t.Fatalf("payload rejected but should be accepted: %v", err)
+					t.Fatalf("payload %q rejected but should be accepted: %v", tc.payload, err)
 				}
 				return
 			}
 
 			if err == nil {
-				t.Fatalf("payload accepted but should be rejected (expected path %q)", tc.wantPath)
+				t.Fatalf("payload %q accepted but should be rejected (expected path %q)", tc.payload, tc.wantPath)
 			}
 			appErr, ok := err.(*common.AppError)
 			if !ok {
@@ -70,10 +89,29 @@ func TestRejectUnstorablePayload(t *testing.T) {
 				t.Errorf("code=%q, want %q", appErr.Code, common.ErrCodeBadRequest)
 			}
 			// The path is rendered with %q so a control byte in a key is never
-			// echoed raw into the response body (output sanitization).
+			// echoed raw into the response body.
 			if want := strconv.Quote(tc.wantPath); !strings.Contains(appErr.Message, want) {
 				t.Errorf("message %q does not name the offending path %s", appErr.Message, want)
 			}
+			if !strings.Contains(appErr.Message, tc.wantWord) {
+				t.Errorf("message %q does not explain the reason (expected to mention %q)", appErr.Message, tc.wantWord)
+			}
 		})
+	}
+}
+
+// TestRejectUnstorablePayload_MalformedJSONIsNotOurJob asserts the guard stays
+// silent on syntactically broken input. Malformed JSON is the decoder's
+// rejection to make, with its own message; the guard must not pre-empt it with
+// a confusing "unstorable" error.
+func TestRejectUnstorablePayload_MalformedJSONIsNotOurJob(t *testing.T) {
+	// A RAW (unescaped) NUL byte inside a string literal belongs here rather
+	// than with the unstorable cases: JSON forbids unescaped control
+	// characters, so the decoder rejects the body before the guard sees it.
+	// The caller still gets a 400, just from the decoder's message.
+	for _, payload := range []string{`{"a":`, `not json`, ``, `{`, `[1,`, "{\"name\":\"a\x00b\"}"} {
+		if err := rejectUnstorablePayload([]byte(payload)); err != nil {
+			t.Errorf("payload %q: guard returned %v; malformed JSON is the decoder's rejection", payload, err)
+		}
 	}
 }

--- a/internal/domain/model/ingest/decode.go
+++ b/internal/domain/model/ingest/decode.go
@@ -29,3 +29,17 @@ func DecodeJSONPreservingNumbers(data []byte, v any) error {
 	}
 	return nil
 }
+
+// DecodeStoredJSON decodes bytes that are already in the store.
+//
+// Deliberately NOT DecodeJSONPreservingNumbers: that one requires the input to
+// hold exactly one JSON value, which is the right rule for a request body but
+// the wrong one for stored data. A row written by an earlier build could carry
+// trailing content, and rejecting it on read would turn a historical write
+// defect into a permanent 500 — on the entity and, because one bad row fails a
+// listing, on its whole model.
+func DecodeStoredJSON(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	return dec.Decode(v)
+}

--- a/internal/domain/model/ingest/decode.go
+++ b/internal/domain/model/ingest/decode.go
@@ -1,0 +1,31 @@
+package ingest
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// DecodeJSONPreservingNumbers is the precision-preserving counterpart to
+// json.Unmarshal: numeric leaves arrive as json.Number rather than float64,
+// so callers can choose Int64()/Float64()/string preservation. Mirrors
+// importer.ParseJSON's UseNumber() behavior.
+//
+// Like json.Unmarshal (and unlike a bare Decoder.Decode), data must hold
+// exactly one JSON value. Decode alone stops at the end of the first value and
+// silently ignores the rest, so a body such as `{"x":1}}}` would parse as
+// `{"x":1}` while the original bytes — still malformed — went on to be
+// persisted, turning a client input error into a 500 from storage.
+func DecodeJSONPreservingNumbers(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("unexpected content after top-level JSON value")
+	}
+	return nil
+}

--- a/internal/domain/model/ingest/decode_test.go
+++ b/internal/domain/model/ingest/decode_test.go
@@ -70,3 +70,27 @@ func TestDecodeJSONPreservingNumbers_KeepsNumberPrecision(t *testing.T) {
 		t.Errorf("n = %s; precision lost", n.String())
 	}
 }
+
+// TestDecodeStoredJSON_ToleratesTrailingContent pins the split between the two
+// decoders.
+//
+// The ingress decoder requires exactly one JSON value. The read decoder must
+// not: a row written by an earlier build could carry trailing content, and
+// rejecting it on read would turn a historical write defect into a permanent
+// 500 — on that entity and, because one unreadable row fails a listing, on its
+// whole model.
+func TestDecodeStoredJSON_ToleratesTrailingContent(t *testing.T) {
+	const stored = `{"x":1}}}`
+
+	if err := DecodeJSONPreservingNumbers([]byte(stored), new(any)); err == nil {
+		t.Error("ingress decoder accepted trailing content; it must reject it")
+	}
+
+	var v map[string]any
+	if err := DecodeStoredJSON([]byte(stored), &v); err != nil {
+		t.Fatalf("read decoder rejected stored data: %v — this makes the row, and its model listing, unreadable", err)
+	}
+	if v["x"] != json.Number("1") {
+		t.Errorf("v[x] = %v, want 1", v["x"])
+	}
+}

--- a/internal/domain/model/ingest/decode_test.go
+++ b/internal/domain/model/ingest/decode_test.go
@@ -1,4 +1,4 @@
-package entity
+package ingest
 
 import (
 	"encoding/json"
@@ -42,7 +42,7 @@ func TestDecodeJSONPreservingNumbers_RejectsTrailingContent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var v any
-			err := decodeJSONPreservingNumbers([]byte(tc.input), &v)
+			err := DecodeJSONPreservingNumbers([]byte(tc.input), &v)
 			if tc.wantErr && err == nil {
 				t.Fatalf("decode(%q) = nil error; want an error", tc.input)
 			}
@@ -59,7 +59,7 @@ func TestDecodeJSONPreservingNumbers_RejectsTrailingContent(t *testing.T) {
 func TestDecodeJSONPreservingNumbers_KeepsNumberPrecision(t *testing.T) {
 	const big = `{"n":123456789012345678901234567890.123456789}`
 	var v map[string]any
-	if err := decodeJSONPreservingNumbers([]byte(big), &v); err != nil {
+	if err := DecodeJSONPreservingNumbers([]byte(big), &v); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	n, ok := v["n"].(json.Number)

--- a/internal/domain/model/ingest/storable.go
+++ b/internal/domain/model/ingest/storable.go
@@ -1,4 +1,4 @@
-package entity
+package ingest
 
 import (
 	"bytes"
@@ -34,7 +34,7 @@ const (
 	maxExponentMagnitude = 1 << 40
 )
 
-// rejectUnstorablePayload rejects an entity payload that no supported backend
+// RejectUnstorable rejects an entity payload that no supported backend
 // can persist, before it reaches a store.
 //
 // PostgreSQL's text and jsonb types cannot represent U+0000, an unpaired
@@ -53,7 +53,7 @@ const (
 // obvious fix — would silently store a replacement character the client never
 // sent, which is exactly the substituted-value outcome
 // .claude/rules/correctness-over-availability.md forbids.
-func rejectUnstorablePayload(raw []byte) error {
+func RejectUnstorable(raw []byte) error {
 	// Whole-document check first. Invalid UTF-8 has no meaningful JSON path —
 	// the bytes may not even parse as text — so it is reported against the
 	// document rather than a field.
@@ -328,9 +328,9 @@ func isJSONSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 }
 
-// prefixItemErr restates an operational error against the collection item it
+// PrefixItemErr restates an operational error against the collection item it
 // came from, so a batch rejection says which element was at fault.
-func prefixItemErr(err error, i int) error {
+func PrefixItemErr(err error, i int) error {
 	appErr, ok := err.(*common.AppError)
 	if !ok {
 		return err

--- a/internal/domain/model/ingest/storable.go
+++ b/internal/domain/model/ingest/storable.go
@@ -94,16 +94,16 @@ func unstorableErr(path, reason string) error {
 // the first unstorable content it finds. Object members are visited in document
 // order.
 //
-// Values are kept as json.RawMessage so each string is examined exactly as the
-// client wrote it. Object KEYS are the one exception — the decoder hands them
-// back as Go strings, already normalised — so a key is only checked for NUL,
-// which survives decoding. A surrogate in a key is not detectable here.
+// Every string — object keys included — is examined as the client wrote it,
+// which is why the scan works on byte offsets rather than decoded values. The
+// decoded form of a key is used only for duplicate comparison and for the
+// reported path, never for judging its content.
 func findUnstorable(raw []byte, path string) (string, string, bool) {
-	var segs []pathSeg
+	st := make([]pathSeg, 0, 64)
 	if path != "" {
-		segs = append(segs, pathSeg{key: path})
+		st = append(st, pathSeg{key: path})
 	}
-	p, r, found, _ := scanValue(raw, 0, segs, 0)
+	p, r, found, _ := scanValue(raw, 0, &st, 0)
 	return p, r, found
 }
 
@@ -111,6 +111,14 @@ func findUnstorable(raw []byte, path string) (string, string, bool) {
 // than an accumulated string: building the string at every node would itself be
 // quadratic in depth, which is the cost this scanner exists to avoid. The string
 // is rendered only when something is actually rejected.
+//
+// The stack is threaded by POINTER and pushed/popped, not derived per node. An
+// earlier version passed `append(segs, seg)` to each child, which looks
+// harmless but re-runs growslice for every sibling whenever len == cap at that
+// depth — copying the whole path stack each time. That reintroduced the
+// O(size x depth) blowup this scanner was written to remove, just relocated
+// from the subtree into the path: a 7.8 MB well-formed payload allocated 1.45 TB
+// and took nearly four minutes, and was then accepted.
 type pathSeg struct {
 	key   string
 	idx   int
@@ -126,6 +134,10 @@ func renderPath(segs []pathSeg) string {
 		}
 		if b.Len() > 0 {
 			b.WriteByte('.')
+		}
+		if s.key == "" {
+			b.WriteString(`""`) // an empty name, not the document root
+			continue
 		}
 		b.WriteString(s.key)
 	}
@@ -149,7 +161,7 @@ const maxScanDepth = 10000
 // product of size and depth: the 10 MB body limit bounds only size.
 //
 // This version allocates only a per-object key set, and only for objects.
-func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool, int) {
+func scanValue(b []byte, i int, st *[]pathSeg, depth int) (string, string, bool, int) {
 	i = skipJSONSpace(b, i)
 	if i >= len(b) {
 		return "", "", false, i
@@ -163,6 +175,8 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 	case '{':
 		i++
 		seen := make(map[string]struct{})
+		*st = append(*st, pathSeg{})
+		defer func() { *st = (*st)[:len(*st)-1] }()
 		for {
 			i = skipJSONSpace(b, i)
 			if i >= len(b) {
@@ -188,14 +202,14 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 			if !kok {
 				return "", "", false, len(b)
 			}
-			child := append(segs, pathSeg{key: key})
+			(*st)[len(*st)-1] = pathSeg{key: key}
 			// The key's RAW bytes, so an unpaired surrogate or a NUL escape in a
 			// key is caught. Decoding the key first would normalise both away.
 			if reason := checkJSONStringToken(keyRaw); reason != "" {
-				return renderPath(child), reason, true, i
+				return renderPath(*st), reason, true, i
 			}
 			if _, dup := seen[key]; dup {
-				return renderPath(child), reasonDuplicateKey, true, i
+				return renderPath(*st), reasonDuplicateKey, true, i
 			}
 			seen[key] = struct{}{}
 
@@ -207,7 +221,7 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 			var p, r string
 			var found bool
 			before := i
-			p, r, found, i = scanValue(b, i, child, depth+1)
+			p, r, found, i = scanValue(b, i, st, depth+1)
 			if found {
 				return p, r, true, i
 			}
@@ -219,6 +233,8 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 	case '[':
 		i++
 		idx := 0
+		*st = append(*st, pathSeg{isIdx: true})
+		defer func() { *st = (*st)[:len(*st)-1] }()
 		for {
 			i = skipJSONSpace(b, i)
 			if i >= len(b) {
@@ -233,8 +249,9 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 			}
 			var p, r string
 			var found bool
+			(*st)[len(*st)-1] = pathSeg{idx: idx, isIdx: true}
 			before := i
-			p, r, found, i = scanValue(b, i, append(segs, pathSeg{idx: idx, isIdx: true}), depth+1)
+			p, r, found, i = scanValue(b, i, st, depth+1)
 			if found {
 				return p, r, true, i
 			}
@@ -250,7 +267,7 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 			return "", "", false, len(b)
 		}
 		if reason := checkJSONStringToken(b[i:end]); reason != "" {
-			return renderPath(segs), reason, true, end
+			return renderPath(*st), reason, true, end
 		}
 		return "", "", false, end
 
@@ -264,7 +281,7 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 		}
 		if c := b[i]; c == '-' || (c >= '0' && c <= '9') {
 			if reason := checkJSONNumberToken(b[i:end]); reason != "" {
-				return renderPath(segs), reason, true, end
+				return renderPath(*st), reason, true, end
 			}
 		}
 		return "", "", false, end
@@ -373,6 +390,14 @@ func checkJSONNumberToken(tok []byte) string {
 		exp = v
 	}
 
+	// Only a syntactically complete JSON number gets a range verdict. A token
+	// like `1e1000000x` is a syntax error, and reporting it as "too many digits"
+	// would send the caller looking in the wrong place. The decoder rejects it
+	// a moment later with an accurate message.
+	if i != len(tok) || intEnd == intStart {
+		return ""
+	}
+
 	intDigits := int64(intEnd - intStart)
 	fracDigits := int64(fracEnd - fracStart)
 
@@ -473,18 +498,6 @@ func parseHex4(b []byte, off int) (rune, bool) {
 		return 0, false
 	}
 	return rune(v), true
-}
-
-// trimJSONSpace strips the whitespace JSON permits around a value.
-func trimJSONSpace(b []byte) []byte {
-	start, end := 0, len(b)
-	for start < end && isJSONSpace(b[start]) {
-		start++
-	}
-	for end > start && isJSONSpace(b[end-1]) {
-		end--
-	}
-	return b[start:end]
 }
 
 func isJSONSpace(c byte) bool {

--- a/internal/domain/model/ingest/storable.go
+++ b/internal/domain/model/ingest/storable.go
@@ -1,11 +1,11 @@
 package ingest
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/cyoda-platform/cyoda-go/internal/common"
@@ -28,6 +28,9 @@ const (
 const (
 	maxNumericWeightDigits = 131072
 	maxNumericScaleDigits  = 16383
+	// PostgreSQL bounds the exponent itself, whatever the coefficient: a zero
+	// coefficient has no weight, but 0e2000000000 still overflows on input.
+	maxNumericExponent = 1073741823
 	// maxExponentMagnitude saturates exponent accumulation. Any exponent this
 	// large already breaches both limits, so clamping cannot change a verdict —
 	// it only stops a 20-digit exponent from overflowing the accumulator.
@@ -69,7 +72,15 @@ func RejectUnstorable(raw []byte) error {
 	return nil
 }
 
+// maxReportedPathLen bounds the field path echoed back. The path comes from the
+// caller's own document, so an oversized key would otherwise inflate both the
+// response body and the log line WriteError emits for every operational error.
+const maxReportedPathLen = 200
+
 func unstorableErr(path, reason string) error {
+	if len(path) > maxReportedPathLen {
+		path = path[:maxReportedPathLen] + "…(truncated)"
+	}
 	return common.Operational(
 		http.StatusBadRequest,
 		common.ErrCodeBadRequest,
@@ -87,78 +98,209 @@ func unstorableErr(path, reason string) error {
 // client wrote it. Object KEYS are the one exception — the decoder hands them
 // back as Go strings, already normalised — so a key is only checked for NUL,
 // which survives decoding. A surrogate in a key is not detectable here.
-func findUnstorable(raw json.RawMessage, path string) (string, string, bool) {
-	trimmed := trimJSONSpace(raw)
-	if len(trimmed) == 0 {
-		return "", "", false
+func findUnstorable(raw []byte, path string) (string, string, bool) {
+	var segs []pathSeg
+	if path != "" {
+		segs = append(segs, pathSeg{key: path})
+	}
+	p, r, found, _ := scanValue(raw, 0, segs, 0)
+	return p, r, found
+}
+
+// pathSeg is one step of a JSON path. The scan carries a stack of these rather
+// than an accumulated string: building the string at every node would itself be
+// quadratic in depth, which is the cost this scanner exists to avoid. The string
+// is rendered only when something is actually rejected.
+type pathSeg struct {
+	key   string
+	idx   int
+	isIdx bool
+}
+
+func renderPath(segs []pathSeg) string {
+	var b strings.Builder
+	for _, s := range segs {
+		if s.isIdx {
+			fmt.Fprintf(&b, "[%d]", s.idx)
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('.')
+		}
+		b.WriteString(s.key)
+	}
+	return b.String()
+}
+
+// maxScanDepth caps nesting. encoding/json refuses to decode deeper than this
+// anyway, so a document beyond it is rejected by the decoder regardless; the cap
+// exists so the scan itself can never be driven into unbounded recursion.
+const maxScanDepth = 10000
+
+// scanValue examines the JSON value starting at i and returns the offset just
+// past it, along with the first unstorable content found inside.
+//
+// It scans in place. An earlier version re-parsed each subtree once per nesting
+// level — json.Unmarshal into []json.RawMessage copies every element, and a
+// json.Decoder per object level copies every member — which made the walk
+// O(size × depth) in both time and allocation. Measured on the version this
+// replaces: a 21 KB payload nested 9999 deep took 1.1 s and allocated 1.76 GiB,
+// an ~85,000x amplification on one authenticated request. Nothing bounds the
+// product of size and depth: the 10 MB body limit bounds only size.
+//
+// This version allocates only a per-object key set, and only for objects.
+func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool, int) {
+	i = skipJSONSpace(b, i)
+	if i >= len(b) {
+		return "", "", false, i
+	}
+	if depth > maxScanDepth {
+		// Deeper than any decoder will accept; let the decoder reject it.
+		return "", "", false, len(b)
 	}
 
-	switch trimmed[0] {
+	switch b[i] {
 	case '{':
-		// Read members with a token decoder rather than into a map. A map would
-		// collapse duplicate names before they could be seen, and would lose
-		// document order; the decoder gives ordered members, each value still as
-		// raw bytes.
-		dec := json.NewDecoder(bytes.NewReader(trimmed))
-		if _, err := dec.Token(); err != nil { // opening brace
-			return "", "", false
-		}
+		i++
 		seen := make(map[string]struct{})
-		for dec.More() {
-			keyTok, err := dec.Token()
-			if err != nil {
-				return "", "", false // malformed JSON is the decoder's rejection, not ours
+		for {
+			i = skipJSONSpace(b, i)
+			if i >= len(b) {
+				return "", "", false, i
 			}
-			key, ok := keyTok.(string)
+			if b[i] == '}' {
+				return "", "", false, i + 1
+			}
+			if b[i] == ',' {
+				i++
+				continue
+			}
+			if b[i] != '"' {
+				return "", "", false, len(b) // malformed; the decoder rejects it
+			}
+			keyStart := i
+			keyEnd, ok := scanString(b, i)
 			if !ok {
-				return "", "", false
+				return "", "", false, len(b)
 			}
-			child := key
-			if path != "" {
-				child = path + "." + key
+			keyRaw := b[keyStart:keyEnd]
+			key, kok := unquoteJSONKey(keyRaw)
+			if !kok {
+				return "", "", false, len(b)
 			}
-			for _, r := range key {
-				if r == 0 {
-					return child, reasonNul, true
-				}
+			child := append(segs, pathSeg{key: key})
+			// The key's RAW bytes, so an unpaired surrogate or a NUL escape in a
+			// key is caught. Decoding the key first would normalise both away.
+			if reason := checkJSONStringToken(keyRaw); reason != "" {
+				return renderPath(child), reason, true, i
 			}
 			if _, dup := seen[key]; dup {
-				return child, reasonDuplicateKey, true
+				return renderPath(child), reasonDuplicateKey, true, i
 			}
 			seen[key] = struct{}{}
 
-			var val json.RawMessage
-			if err := dec.Decode(&val); err != nil {
-				return "", "", false
+			i = skipJSONSpace(b, keyEnd)
+			if i >= len(b) || b[i] != ':' {
+				return "", "", false, len(b)
 			}
-			if p, reason, found := findUnstorable(val, child); found {
-				return p, reason, true
+			i++
+			var p, r string
+			var found bool
+			p, r, found, i = scanValue(b, i, child, depth+1)
+			if found {
+				return p, r, true, i
 			}
 		}
+
 	case '[':
-		var arr []json.RawMessage
-		if json.Unmarshal(trimmed, &arr) != nil {
-			return "", "", false
-		}
-		for i, elem := range arr {
-			if p, reason, found := findUnstorable(elem, fmt.Sprintf("%s[%d]", path, i)); found {
-				return p, reason, true
+		i++
+		idx := 0
+		for {
+			i = skipJSONSpace(b, i)
+			if i >= len(b) {
+				return "", "", false, i
 			}
+			if b[i] == ']' {
+				return "", "", false, i + 1
+			}
+			if b[i] == ',' {
+				i++
+				continue
+			}
+			var p, r string
+			var found bool
+			p, r, found, i = scanValue(b, i, append(segs, pathSeg{idx: idx, isIdx: true}), depth+1)
+			if found {
+				return p, r, true, i
+			}
+			idx++
 		}
+
 	case '"':
-		if reason := checkJSONStringToken(trimmed); reason != "" {
-			return path, reason, true
+		end, ok := scanString(b, i)
+		if !ok {
+			return "", "", false, len(b)
 		}
+		if reason := checkJSONStringToken(b[i:end]); reason != "" {
+			return renderPath(segs), reason, true, end
+		}
+		return "", "", false, end
+
 	default:
-		// A number token. true/false/null start with t/f/n, so a leading digit
-		// or minus sign is unambiguous.
-		if c := trimmed[0]; c == '-' || (c >= '0' && c <= '9') {
-			if reason := checkJSONNumberToken(trimmed); reason != "" {
-				return path, reason, true
+		end := scanScalar(b, i)
+		if c := b[i]; c == '-' || (c >= '0' && c <= '9') {
+			if reason := checkJSONNumberToken(b[i:end]); reason != "" {
+				return renderPath(segs), reason, true, end
 			}
+		}
+		return "", "", false, end
+	}
+}
+
+// scanString returns the offset just past the string token starting at i
+// (which must be the opening quote), honouring escapes.
+func scanString(b []byte, i int) (int, bool) {
+	if i >= len(b) || b[i] != '"' {
+		return 0, false
+	}
+	for j := i + 1; j < len(b); j++ {
+		switch b[j] {
+		case '\\':
+			j++ // skip the escaped byte; \uXXXX's digits are ordinary bytes here
+		case '"':
+			return j + 1, true
 		}
 	}
-	return "", "", false
+	return 0, false
+}
+
+// scanScalar returns the offset just past a number, true, false or null.
+func scanScalar(b []byte, i int) int {
+	for j := i; j < len(b); j++ {
+		switch b[j] {
+		case ',', '}', ']', ' ', '\t', '\n', '\r':
+			return j
+		}
+	}
+	return len(b)
+}
+
+// unquoteJSONKey decodes a raw key token to the string the rest of the system
+// will see, for duplicate detection and path reporting.
+func unquoteJSONKey(raw []byte) (string, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// skipJSONSpace advances past the whitespace JSON permits.
+func skipJSONSpace(b []byte, i int) int {
+	for i < len(b) && isJSONSpace(b[i]) {
+		i++
+	}
+	return i
 }
 
 // checkJSONNumberToken reports whether a raw JSON number literal is outside the
@@ -220,6 +362,12 @@ func checkJSONNumberToken(tok []byte) string {
 	intDigits := int64(intEnd - intStart)
 	fracDigits := int64(fracEnd - fracStart)
 
+	// The exponent alone, before any coefficient reasoning: PostgreSQL rejects
+	// a literal past this even when the coefficient is zero.
+	if exp > maxNumericExponent || exp < -maxNumericExponent {
+		return reasonNumWeight
+	}
+
 	// Scale: digits that end up to the right of the point. Counted lexically,
 	// so trailing zeros bite — 1.00000000e-16383 really does overflow.
 	if fracDigits-exp > maxNumericScaleDigits {
@@ -227,7 +375,8 @@ func checkJSONNumberToken(tok []byte) string {
 	}
 
 	// Weight: digits to the left of the point, ignoring leading zeros. A zero
-	// coefficient has no weight at all however large the exponent.
+	// coefficient has no weight, however large the exponent — within the
+	// exponent bound checked above.
 	leadingZeros, allZero := int64(0), true
 	for _, r := range [2][2]int{{intStart, intEnd}, {fracStart, fracEnd}} {
 		for j := r[0]; j < r[1]; j++ {

--- a/internal/domain/model/ingest/storable.go
+++ b/internal/domain/model/ingest/storable.go
@@ -206,9 +206,13 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 			i++
 			var p, r string
 			var found bool
+			before := i
 			p, r, found, i = scanValue(b, i, child, depth+1)
 			if found {
 				return p, r, true, i
+			}
+			if i <= before {
+				return "", "", false, len(b) // no progress: malformed
 			}
 		}
 
@@ -229,9 +233,13 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 			}
 			var p, r string
 			var found bool
+			before := i
 			p, r, found, i = scanValue(b, i, append(segs, pathSeg{idx: idx, isIdx: true}), depth+1)
 			if found {
 				return p, r, true, i
+			}
+			if i <= before {
+				return "", "", false, len(b) // no progress: malformed
 			}
 			idx++
 		}
@@ -248,6 +256,12 @@ func scanValue(b []byte, i int, segs []pathSeg, depth int) (string, string, bool
 
 	default:
 		end := scanScalar(b, i)
+		if end <= i {
+			// b[i] cannot start a value — a mismatched '}' or ']', or a stray
+			// byte. The document is malformed and the decoder will reject it;
+			// stop rather than re-examine the same offset forever.
+			return "", "", false, len(b)
+		}
 		if c := b[i]; c == '-' || (c >= '0' && c <= '9') {
 			if reason := checkJSONNumberToken(b[i:end]); reason != "" {
 				return renderPath(segs), reason, true, end

--- a/internal/domain/model/ingest/storable_duplicate_test.go
+++ b/internal/domain/model/ingest/storable_duplicate_test.go
@@ -1,4 +1,4 @@
-package entity
+package ingest
 
 import (
 	"strings"
@@ -43,7 +43,7 @@ func TestRejectUnstorablePayload_DuplicateKeys(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := rejectUnstorablePayload([]byte(tc.payload))
+			err := RejectUnstorable([]byte(tc.payload))
 
 			if tc.wantPath == "" {
 				if err != nil {

--- a/internal/domain/model/ingest/storable_fuzz_test.go
+++ b/internal/domain/model/ingest/storable_fuzz_test.go
@@ -1,0 +1,94 @@
+package ingest
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// FuzzRejectUnstorable exercises the in-place scanner against arbitrary input.
+//
+// The scanner is hand-written and reads bytes the client controls, so the
+// properties worth pinning are the ones a parser gets wrong: it must always
+// terminate, never panic, and never disagree with a straightforward reference
+// walk about whether a well-formed document contains a NUL.
+//
+// NUL is the reference property because it is the one condition that survives
+// Go's decoder intact — unpaired surrogates and invalid UTF-8 are rewritten to
+// U+FFFD on decode, which is exactly why the scanner reads raw bytes and why a
+// decoded-value reference cannot check those two.
+func FuzzRejectUnstorable(f *testing.F) {
+	seeds := []string{
+		`{}`, `[]`, `null`, `1`, `"s"`, `true`,
+		`{"a":1,"b":[1,2,{"c":"d"}]}`,
+		`{"a":""}`,
+		`{"a":"\ud800"}`,
+		`{"a":"😀"}`,
+		`{"a":1,"a":2}`,
+		`{"a":1e1000000}`,
+		`{"a":"x\\y","b":"q\"r"}`,
+		`  {  "a"  :  [ 1 , 2 ]  }  `,
+		`{"":""}`,
+		`[[[[[[[[[[]]]]]]]]]]`,
+		`{"a":{"b":{"c":{"d":1}}}}`,
+		"{\"a\":\"\xff\"}",
+		`{"a":-0.0e-0}`,
+		`{"a":`,
+		`}`,
+		`"unterminated`,
+		`{"a":"\`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Must not panic and must terminate. The test framework's own timeout
+		// catches non-termination.
+		err := RejectUnstorable(data)
+
+		// Beyond that, only well-formed documents have a checkable meaning.
+		var v any
+		if json.Unmarshal(data, &v) != nil {
+			return
+		}
+
+		// A well-formed document that is valid UTF-8 and contains no NUL rune
+		// and no duplicate-looking construct must not be rejected FOR a NUL.
+		if err != nil && strings.Contains(err.Error(), "NUL") {
+			if !containsNulRune(v) {
+				t.Fatalf("rejected for a NUL that the decoded value does not contain: %q -> %v", data, err)
+			}
+		}
+
+		// The converse: a decoded NUL must always be caught. (Only meaningful
+		// when the input is valid UTF-8; otherwise the whole-document UTF-8
+		// check fires first and reports a different reason.)
+		if utf8.Valid(data) && containsNulRune(v) && err == nil {
+			t.Fatalf("accepted a document whose decoded value contains U+0000: %q", data)
+		}
+	})
+}
+
+// containsNulRune reports whether any string in the decoded value contains
+// U+0000, walking keys as well as values.
+func containsNulRune(v any) bool {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, child := range t {
+			if strings.ContainsRune(k, 0) || containsNulRune(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range t {
+			if containsNulRune(child) {
+				return true
+			}
+		}
+	case string:
+		return strings.ContainsRune(t, 0)
+	}
+	return false
+}

--- a/internal/domain/model/ingest/storable_number_test.go
+++ b/internal/domain/model/ingest/storable_number_test.go
@@ -1,4 +1,4 @@
-package entity
+package ingest
 
 import (
 	"strings"
@@ -99,7 +99,7 @@ func TestRejectUnstorablePayload_Numbers(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := rejectUnstorablePayload([]byte(tc.payload))
+			err := RejectUnstorable([]byte(tc.payload))
 			if tc.wantPath == "" {
 				if err != nil {
 					t.Fatalf("payload %s rejected but is storable: %v", tc.payload, err)

--- a/internal/domain/model/ingest/storable_number_test.go
+++ b/internal/domain/model/ingest/storable_number_test.go
@@ -56,7 +56,13 @@ func TestCheckJSONNumberToken(t *testing.T) {
 		{"1.00000000e-16383", true}, // trailing zeros count toward scale
 
 		// --- zero coefficient ---
-		{"0e999999999", false}, // exempt from the weight limit
+		// A zero coefficient has no weight, but PostgreSQL still bounds the
+		// exponent itself: 0e2000000000 overflows on input.
+		{"0e999999999", false},
+		{"0e1073741823", false},
+		{"0e1073741824", true},
+		{"0e2000000000", true},
+		{"-0e2000000000", true},
 		{"0e-999999999", true}, // NOT exempt from the scale limit
 		{"0.0", false},
 

--- a/internal/domain/model/ingest/storable_scale_test.go
+++ b/internal/domain/model/ingest/storable_scale_test.go
@@ -60,3 +60,57 @@ func TestRejectUnstorable_DeepNestingStillFindsContent(t *testing.T) {
 		}
 	}
 }
+
+// TestRejectUnstorable_CostIsIndependentOfDepth pins the second half of the
+// scaling property, which the depth-only test above cannot see.
+//
+// The first fix removed per-level subtree copying but left the path stack being
+// derived per node via append. At any depth where len == cap, that re-runs
+// growslice for EVERY sibling and copies the whole stack — reintroducing the
+// same O(size x depth) blowup, relocated. It was invisible to every test here
+// because they are all small, and it only bites at Go's slice-growth depths
+// (1, 2, 4, 8, 16, 35, 71, ... 6912, 8960).
+//
+// Measured on the version this guards against: a 7.8 MB well-formed payload
+// allocated 1.45 TB and took ~4 minutes — and was then ACCEPTED, so nothing
+// downstream cut it short.
+//
+// The property is that the same number of bytes costs about the same whether it
+// is flat or deeply nested. 8960 is chosen because it is one of the slice-growth
+// depths, i.e. the worst case.
+func TestRejectUnstorable_CostIsIndependentOfDepth(t *testing.T) {
+	const depth = 8960
+	const elems = 20000
+
+	flat := []byte("[" + strings.Repeat("1,", elems) + "1]")
+	nested := []byte(strings.Repeat("[", depth) + "[" + strings.Repeat("1,", elems) + "1]" +
+		strings.Repeat("]", depth))
+
+	measure := func(b []byte) (time.Duration, float64) {
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		start := time.Now()
+		if err := RejectUnstorable(b); err != nil {
+			t.Fatalf("payload is storable, guard rejected it: %v", err)
+		}
+		d := time.Since(start)
+		runtime.ReadMemStats(&after)
+		return d, float64(after.TotalAlloc-before.TotalAlloc) / (1 << 20)
+	}
+
+	flatTime, flatMiB := measure(flat)
+	nestedTime, nestedMiB := measure(nested)
+	t.Logf("flat   %d bytes: %s, %.1f MiB", len(flat), flatTime, flatMiB)
+	t.Logf("nested %d bytes at depth %d: %s, %.1f MiB", len(nested), depth, nestedTime, nestedMiB)
+
+	// Generous factors: this catches a return to depth-multiplied cost, it does
+	// not police micro-timings.
+	if nestedMiB > flatMiB*8+16 {
+		t.Errorf("nesting multiplied allocation: flat %.1f MiB vs nested %.1f MiB — "+
+			"the path stack is being copied per sibling again", flatMiB, nestedMiB)
+	}
+	if nestedTime > flatTime*20+50*time.Millisecond {
+		t.Errorf("nesting multiplied CPU: flat %s vs nested %s", flatTime, nestedTime)
+	}
+}

--- a/internal/domain/model/ingest/storable_scale_test.go
+++ b/internal/domain/model/ingest/storable_scale_test.go
@@ -1,0 +1,62 @@
+package ingest
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRejectUnstorable_ScalesWithSizeNotSizeTimesDepth pins the cost of the
+// guard against a deeply nested payload.
+//
+// An earlier version re-parsed each subtree once per nesting level, making the
+// walk O(size × depth) in time and allocation. A 21 KB body nested 9999 deep
+// took 1.1s and allocated 1.76 GiB — roughly 85,000x amplification on a single
+// authenticated request, on every entity write path. Nothing bounds that
+// product: the 10 MB body limit bounds size only, and nesting is capped at
+// 10000 by encoding/json.
+//
+// The scan is now in place, so cost is proportional to the payload, not to the
+// payload times its depth. The bounds below are deliberately loose — they are
+// there to catch a return to quadratic behaviour, not to police micro-timings.
+func TestRejectUnstorable_ScalesWithSizeNotSizeTimesDepth(t *testing.T) {
+	const depth = 9999
+	leaf := `"` + strings.Repeat("x", 1024) + `"`
+	payload := []byte(strings.Repeat("[", depth) + leaf + strings.Repeat("]", depth))
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	start := time.Now()
+
+	if err := RejectUnstorable(payload); err != nil {
+		t.Fatalf("payload is storable, guard rejected it: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	runtime.ReadMemStats(&after)
+	allocMiB := float64(after.TotalAlloc-before.TotalAlloc) / (1 << 20)
+
+	t.Logf("%d bytes at depth %d: %s, %.1f MiB allocated", len(payload), depth, elapsed, allocMiB)
+
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("took %s for a %d-byte payload — cost is scaling with depth again", elapsed, len(payload))
+	}
+	if allocMiB > 50 {
+		t.Errorf("allocated %.1f MiB for a %d-byte payload — the scan is copying subtrees again",
+			allocMiB, len(payload))
+	}
+}
+
+// TestRejectUnstorable_DeepNestingStillFindsContent guards the depth cap from
+// being used as a bypass: content inside a deeply nested payload must still be
+// found, up to the point the decoder itself refuses to parse.
+func TestRejectUnstorable_DeepNestingStillFindsContent(t *testing.T) {
+	for _, depth := range []int{1, 10, 500, 5000} {
+		payload := []byte(strings.Repeat("[", depth) + `"a\u0000b"` + strings.Repeat("]", depth))
+		if err := RejectUnstorable(payload); err == nil {
+			t.Errorf("depth %d: NUL nested this deep was not found", depth)
+		}
+	}
+}

--- a/internal/domain/model/ingest/storable_test.go
+++ b/internal/domain/model/ingest/storable_test.go
@@ -51,6 +51,8 @@ func TestRejectUnstorablePayload(t *testing.T) {
 		{name: "nul in nested array of objects", payload: `{"items":[{"sku":"ok"},{"sku":"\u0000x"}]}`, wantPath: "items[1].sku", wantWord: "NUL"},
 		{name: "nul in object key", payload: "{\"bad\\u0000key\":\"v\"}", wantPath: "bad\x00key", wantWord: "NUL"},
 		{name: "bare string payload", payload: `"a\u0000"`, wantPath: "(root)", wantWord: "NUL"},
+		{name: "raw nul byte in a value", payload: "{\"name\":\"a\x00b\"}", wantPath: "name", wantWord: "NUL"},
+		{name: "unpaired surrogate in an object KEY", payload: `{"a\ud800b":1}`, wantPath: "a\ufffdb", wantWord: "surrogate"},
 
 		// --- unstorable: unpaired surrogate ---
 		{name: "lone high surrogate", payload: `{"name":"a\ud800b"}`, wantPath: "name", wantWord: "surrogate"},
@@ -105,11 +107,12 @@ func TestRejectUnstorablePayload(t *testing.T) {
 // rejection to make, with its own message; the guard must not pre-empt it with
 // a confusing "unstorable" error.
 func TestRejectUnstorablePayload_MalformedJSONIsNotOurJob(t *testing.T) {
-	// A RAW (unescaped) NUL byte inside a string literal belongs here rather
-	// than with the unstorable cases: JSON forbids unescaped control
-	// characters, so the decoder rejects the body before the guard sees it.
-	// The caller still gets a 400, just from the decoder's message.
-	for _, payload := range []string{`{"a":`, `not json`, ``, `{`, `[1,`, "{\"name\":\"a\x00b\"}"} {
+	// A RAW (unescaped) NUL byte is deliberately NOT in this list. JSON forbids
+	// unescaped control characters, so the decoder rejects such a body before
+	// the guard runs in production — but the in-place scanner does see it, and
+	// naming the NUL is more useful than the decoder's "invalid character"
+	// message, so it is covered with the other NUL cases above.
+	for _, payload := range []string{`{"a":`, `not json`, ``, `{`, `[1,`} {
 		if err := RejectUnstorable([]byte(payload)); err != nil {
 			t.Errorf("payload %q: guard returned %v; malformed JSON is the decoder's rejection", payload, err)
 		}

--- a/internal/domain/model/ingest/storable_test.go
+++ b/internal/domain/model/ingest/storable_test.go
@@ -1,4 +1,4 @@
-package entity
+package ingest
 
 import (
 	"net/http"
@@ -16,7 +16,7 @@ import (
 // 500 with a support ticket on postgres and were silently accepted on memory
 // and sqlite.
 //
-// The guard reads RAW bytes deliberately — see rejectUnstorablePayload's doc
+// The guard reads RAW bytes deliberately — see RejectUnstorable's doc
 // comment. The "already-mangled" cases below are what make that necessary.
 func TestRejectUnstorablePayload(t *testing.T) {
 	cases := []struct {
@@ -66,7 +66,7 @@ func TestRejectUnstorablePayload(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := rejectUnstorablePayload([]byte(tc.payload))
+			err := RejectUnstorable([]byte(tc.payload))
 
 			if tc.wantPath == "" {
 				if err != nil {
@@ -110,7 +110,7 @@ func TestRejectUnstorablePayload_MalformedJSONIsNotOurJob(t *testing.T) {
 	// characters, so the decoder rejects the body before the guard sees it.
 	// The caller still gets a 400, just from the decoder's message.
 	for _, payload := range []string{`{"a":`, `not json`, ``, `{`, `[1,`, "{\"name\":\"a\x00b\"}"} {
-		if err := rejectUnstorablePayload([]byte(payload)); err != nil {
+		if err := RejectUnstorable([]byte(payload)); err != nil {
 			t.Errorf("payload %q: guard returned %v; malformed JSON is the decoder's rejection", payload, err)
 		}
 	}

--- a/internal/domain/model/ingest/testdata/fuzz/FuzzRejectUnstorable/55126d52dfedc9ee
+++ b/internal/domain/model/ingest/testdata/fuzz/FuzzRejectUnstorable/55126d52dfedc9ee
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("[\"a\":\"\\ud800\"}")

--- a/internal/domain/model/ingest/validate.go
+++ b/internal/domain/model/ingest/validate.go
@@ -1,0 +1,186 @@
+// Package ingest holds the checks every entity payload passes before it is
+// stored, wherever the payload came from.
+//
+// It lives below both internal/domain/entity and internal/domain/workflow so
+// that a processor's returned data goes through exactly the same storability
+// and schema checks as a client write. entity imports workflow, so the engine
+// can never call back into the entity handler; and the scheduled-transition
+// ingress has no handler at all. A shared leaf package is therefore the only
+// wiring that reaches every ingress.
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/importer"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+)
+
+// ErrInternalSchema tags schema-processing errors inside validateOrExtend
+// that represent internal failures (codec decode/encode, Diff computation,
+// plugin-layer ExtendSchema write) rather than client-contract violations.
+// The handler classifier uses errors.Is to route these to 5xx with a
+// logged ticket. Using a sentinel rather than string-matching the wrap
+// messages makes classification robust to future wording changes — the
+// prior string-match classifier would have silently shifted a renamed
+// "failed to extend schema" to 4xx.
+var ErrInternalSchema = errors.New("internal schema processing failure")
+
+// IncompatibleTypeError is the typed validation failure surfaced when at
+// least one ValidationError carries ErrKindIncompatibleType (the
+// dictionary-aligned "wrong DataType" signal — Cloud's
+// FoundIncompatibleTypeWithEntityModelException).
+//
+// Rendered by classifyValidateOrExtendErr into a 400 INCOMPATIBLE_TYPE
+// AppError with Props {fieldPath, expectedType, actualType} so SDKs can
+// branch on the precondition without scraping the Message string.
+type IncompatibleTypeError struct {
+	Path          string
+	ExpectedTypes []schema.DataType
+	ActualType    schema.DataType
+	Message       string
+	EntityName    string // populated by enrichWithModelRef post-validation
+	EntityVersion string // populated by enrichWithModelRef post-validation
+}
+
+func (e *IncompatibleTypeError) Error() string { return e.Message }
+
+// enrichWithModelRef threads model identification (entity name, version)
+// onto an *IncompatibleTypeError so the classifier can render those Props
+// alongside the validator-supplied (path, expected/actualType). For all
+// other error types the input is returned unchanged.
+func enrichWithModelRef(err error, ref spi.ModelRef) error {
+	var incompatErr *IncompatibleTypeError
+	if errors.As(err, &incompatErr) {
+		incompatErr.EntityName = ref.EntityName
+		incompatErr.EntityVersion = ref.ModelVersion
+	}
+	return err
+}
+
+func ValidateOrExtend(ctx context.Context, modelStore spi.ModelStore, desc *spi.ModelDescriptor, parsedData any) error {
+	modelNode, err := schema.Unmarshal(desc.Schema)
+	if err != nil {
+		return fmt.Errorf("%w: failed to unmarshal model schema: %w", ErrInternalSchema, err)
+	}
+
+	if desc.ChangeLevel == "" {
+		errs := schema.Validate(modelNode, parsedData)
+		if len(errs) > 0 {
+			return enrichWithModelRef(ValidationErrorsToError(errs), desc.Ref)
+		}
+		return nil
+	}
+
+	incomingModel, err := importer.Walk(parsedData)
+	if err != nil {
+		return fmt.Errorf("failed to walk data: %w", err)
+	}
+	extended, err := schema.Extend(modelNode, incomingModel, desc.ChangeLevel)
+	if err != nil {
+		// Polymorphic-slot rejections cannot be resolved by raising ChangeLevel
+		// and so must not wear the "change level violation" prefix — the phrase
+		// misleads clients into tuning a setting that wouldn't help.
+		if errors.Is(err, schema.ErrPolymorphicSlot) {
+			return err
+		}
+		return fmt.Errorf("change level violation: %w", err)
+	}
+
+	// Guard: if any unique key field would become non-scalar in the extended
+	// schema, reject the write now. This catches the null-only-leaf → object/array
+	// widening case (a TYPE-level change permitted by Structural ChangeLevel)
+	// that would otherwise surface as an opaque Diff "kind change" 5xx. The
+	// unique keys were valid when declared; the schema extension must not
+	// silently invalidate them.
+	if len(desc.UniqueKeys) > 0 {
+		if vErr := schema.ValidateUniqueKeys(extended, desc.UniqueKeys); vErr != nil {
+			var de *schema.UniqueKeyDefError
+			if errors.As(vErr, &de) {
+				return common.Operational(http.StatusUnprocessableEntity, common.ErrCodeInvalidUniqueKeyDefinition,
+					"schema change would invalidate a composite unique key: "+de.Reason)
+			}
+			return fmt.Errorf("%w: re-validate unique keys: %w", ErrInternalSchema, vErr)
+		}
+	}
+
+	// Compute the additive delta. Diff returns (nil, nil) when the
+	// extension is a semantic no-op, which is the common case on
+	// every entity write.
+	delta, err := schema.Diff(modelNode, extended)
+	if err != nil {
+		return fmt.Errorf("%w: failed to compute schema delta: %w", ErrInternalSchema, err)
+	}
+	if delta == nil {
+		return nil
+	}
+	// Append to the extension log via the plugin. Participates in the
+	// ambient entity transaction so visibility is commit-bound.
+	if err := modelStore.ExtendSchema(ctx, desc.Ref, delta); err != nil {
+		return fmt.Errorf("%w: failed to extend schema: %w", ErrInternalSchema, err)
+	}
+	return nil
+}
+
+// ValidateStrict validates parsedData against the model schema WITHOUT
+// extending it. PATCH uses this: a sparse delta must never widen the tenant's
+// model (a stray/typo'd key is rejected, not absorbed). Mirrors the
+// ChangeLevel=="" branch of validateOrExtend.
+func ValidateStrict(desc *spi.ModelDescriptor, parsedData any) error {
+	modelNode, err := schema.Unmarshal(desc.Schema)
+	if err != nil {
+		return fmt.Errorf("%w: failed to unmarshal model schema: %w", ErrInternalSchema, err)
+	}
+	errs := schema.Validate(modelNode, parsedData)
+	if len(errs) > 0 {
+		return enrichWithModelRef(ValidationErrorsToError(errs), desc.Ref)
+	}
+	return nil
+}
+
+// ValidateDescriptor unmarshals desc.Schema and runs schema.Validate.
+// Returns nil on success, or a []ValidationError on failure (including
+// a descriptive entry if desc itself is malformed or nil).
+func ValidateDescriptor(desc *spi.ModelDescriptor, data any) []schema.ValidationError {
+	if desc == nil {
+		return []schema.ValidationError{{Message: "nil descriptor"}}
+	}
+	node, err := schema.Unmarshal(desc.Schema)
+	if err != nil {
+		return []schema.ValidationError{{Message: fmt.Sprintf("unmarshal schema: %v", err)}}
+	}
+	return schema.Validate(node, data)
+}
+
+// ValidationErrorsToError converts a []ValidationError to a single error,
+// preserving the concatenation style used by validateOrExtend.
+//
+// When at least one entry classifies as ErrKindIncompatibleType (the
+// dictionary-aligned "wrong DataType" signal), the function returns a
+// typed *IncompatibleTypeError carrying the first such entry's structured
+// fields so classifyValidateOrExtendErr can render INCOMPATIBLE_TYPE Props
+// without scraping the Message string. Other validation errors fall back
+// to the generic "validation failed: ..." wrap, classified as
+// BAD_REQUEST downstream.
+func ValidationErrorsToError(errs []schema.ValidationError) error {
+	msgs := make([]string, len(errs))
+	for i, e := range errs {
+		msgs[i] = e.Error()
+	}
+	joined := fmt.Sprintf("validation failed: %s", strings.Join(msgs, "; "))
+	if first := schema.FirstIncompatibleType(errs); first != nil {
+		return &IncompatibleTypeError{
+			Path:          first.Path,
+			ExpectedTypes: first.ExpectedTypes,
+			ActualType:    first.ActualType,
+			Message:       joined,
+		}
+	}
+	return fmt.Errorf("%s", joined)
+}

--- a/internal/domain/workflow/engine_ifmatch_test.go
+++ b/internal/domain/workflow/engine_ifmatch_test.go
@@ -8,6 +8,7 @@ import (
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
 
@@ -106,6 +107,16 @@ func TestManualTransitionWithIfMatch_CBDCascadeMatching(t *testing.T) {
 
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "ifmatch-cbd-match", ModelVersion: "1.0"}
+
+	// The processor's returned data passes the same model checks a client
+	// write does, so the model must declare the entity's own field (`x`) and
+	// every field cbd-proc writes (`enriched`). Zero values declare the type
+	// without asserting a value; the model stays strict (no ChangeLevel), so a
+	// processor writing an undeclared field still fails.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x":        schema.Integer,
+		"enriched": schema.Boolean,
+	})
 
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "IfMatchCbdWF", InitialState: "S_pre", Active: true,

--- a/internal/domain/workflow/engine_processors.go
+++ b/internal/domain/workflow/engine_processors.go
@@ -54,6 +54,9 @@ func (e *Engine) executeProcessors(ctx context.Context, processors []spi.Process
 		spi.SMEventProcessingPaused,
 		fmt.Sprintf("Paused for processors: %v", names), nil)
 
+	// Resolved lazily and at most once across the pipeline — see modelDescMemo.
+	desc := &modelDescMemo{}
+
 	currentCtx := ctx
 	currentTxID := txID
 
@@ -96,7 +99,7 @@ func (e *Engine) executeProcessors(ctx context.Context, processors []spi.Process
 		case ExecutionModeCommitBeforeDispatch:
 			var nCtx context.Context
 			var nTxID string
-			nCtx, nTxID, procErr = e.executeCommitBeforeDispatch(currentCtx, entity, proc, workflow, transition, currentTxID, auditStore, txID)
+			nCtx, nTxID, procErr = e.executeCommitBeforeDispatch(currentCtx, entity, desc, proc, workflow, transition, currentTxID, auditStore, txID)
 			success = procErr == nil
 			if procErr == nil {
 				currentCtx = nCtx
@@ -104,7 +107,7 @@ func (e *Engine) executeProcessors(ctx context.Context, processors []spi.Process
 			}
 
 		default: // SYNC, ASYNC_SAME_TX — both inline in caller's transaction.
-			procErr = e.executeSyncProcessor(currentCtx, entity, proc, workflow, transition, currentTxID)
+			procErr = e.executeSyncProcessor(currentCtx, entity, desc, proc, workflow, transition, currentTxID)
 			success = procErr == nil
 		}
 
@@ -158,7 +161,7 @@ func (e *Engine) rollbackOpenSegmentOnFailure(ctx context.Context, currentTxID, 
 // executeSyncProcessor runs a SYNC or ASYNC_SAME_TX processor inline in the
 // caller's transaction. On success the entity's Data is updated with the
 // processor's returned modifications.
-func (e *Engine) executeSyncProcessor(ctx context.Context, entity *spi.Entity, proc spi.ProcessorDefinition, workflow, transition, txID string) error {
+func (e *Engine) executeSyncProcessor(ctx context.Context, entity *spi.Entity, desc *modelDescMemo, proc spi.ProcessorDefinition, workflow, transition, txID string) error {
 	if e.extProc == nil {
 		return nil
 	}
@@ -178,7 +181,7 @@ func (e *Engine) executeSyncProcessor(ctx context.Context, entity *spi.Entity, p
 		return err
 	}
 	if modifiedEntity != nil && modifiedEntity.Data != nil {
-		entity.Data = modifiedEntity.Data
+		return e.applyProcessorData(ctx, entity, desc, modifiedEntity.Data)
 	}
 	return nil
 }
@@ -245,8 +248,13 @@ func (e *Engine) executeAsyncNewTx(ctx context.Context, entity *spi.Entity, proc
 // Per spec §3, §10.3: in the startNewTxOnDispatch=true branch, processors
 // must not save the cascade-anchor entity themselves AND also return
 // mutations for it (last-writer-wins inside TX_post's buffer).
-func (e *Engine) executeCommitBeforeDispatch(ctx context.Context, entity *spi.Entity, proc spi.ProcessorDefinition, workflow, transition, txID string, auditStore spi.StateMachineAuditStore, entryTxID string) (newCtx context.Context, newTxID string, err error) {
+func (e *Engine) executeCommitBeforeDispatch(ctx context.Context, entity *spi.Entity, desc *modelDescMemo, proc spi.ProcessorDefinition, workflow, transition, txID string, auditStore spi.StateMachineAuditStore, entryTxID string) (newCtx context.Context, newTxID string, err error) {
 	tPre := txID
+	// Staged here rather than assigned: in the startNewTxOnDispatch=false
+	// branch, ctx still carries the committed TX_pre at the point the result
+	// arrives, so a schema extension would run outside any transaction. Both
+	// branches converge below on TX_post, which is the correct place to check.
+	var pending []byte
 
 	// Read the flag. Nil pointer == default == false.
 	startNewTx := proc.Config.StartNewTxOnDispatch != nil && *proc.Config.StartNewTxOnDispatch
@@ -285,7 +293,7 @@ func (e *Engine) executeCommitBeforeDispatch(ctx context.Context, entity *spi.En
 				return nil, "", dispatchErr
 			}
 			if modified != nil && modified.Data != nil {
-				entity.Data = modified.Data
+				pending = modified.Data
 			}
 		}
 	} else {
@@ -318,13 +326,20 @@ func (e *Engine) executeCommitBeforeDispatch(ctx context.Context, entity *spi.En
 			return nil, "", dispatchErr
 		}
 		if modified != nil && modified.Data != nil {
-			entity.Data = modified.Data
+			pending = modified.Data
 		}
 
 		// Begin TX_post.
 		newTxID, newCtx, err = e.txMgr.Begin(context.WithoutCancel(ctx))
 		if err != nil {
 			return nil, "", fmt.Errorf("commit-before-dispatch: begin TX_post: %w", errors.Join(ErrCommitBeforeDispatchInfra, err))
+		}
+	}
+
+	if pending != nil {
+		if applyErr := e.applyProcessorData(newCtx, entity, desc, pending); applyErr != nil {
+			_ = e.txMgr.Rollback(newCtx, newTxID)
+			return nil, "", applyErr
 		}
 	}
 

--- a/internal/domain/workflow/engine_processors_type_test.go
+++ b/internal/domain/workflow/engine_processors_type_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 )
 
 // TestInternalizedRejection_ExecutionModeMatrix asserts that Type:
@@ -102,6 +103,12 @@ func TestType_Externalized_FallsThroughToExecutionModeDispatch(t *testing.T) {
 			ctx := ctxWithTenant(testTenant)
 			modelRef := spi.ModelRef{EntityName: "fall-through-" + tc.typeVal, ModelVersion: "1.0"}
 
+			// The processor echoes the entity back unchanged, so its output
+			// still passes the model checks a client write does. The entity
+			// carries no data fields, so an empty (but registered, strict)
+			// model is the honest declaration.
+			registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{})
+
 			var dispatched bool
 			engine.extProc = &mockExternalProcessing{
 				dispatchFunc: func(ctx context.Context, entity *spi.Entity, proc spi.ProcessorDefinition, wf, tr, txID string) (*spi.Entity, error) {
@@ -156,6 +163,11 @@ func TestType_UnknownValues_FallThrough(t *testing.T) {
 			engine, factory := setupEngine(t)
 			ctx := ctxWithTenant(testTenant)
 			modelRef := spi.ModelRef{EntityName: "unknown-" + typeVal, ModelVersion: "1.0"}
+
+			// Same reasoning as the fall-through test above: the echoing
+			// processor's output is checked against the model, so the model
+			// must exist. Registered under the same subtest-derived name.
+			registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{})
 
 			var dispatched bool
 			engine.extProc = &mockExternalProcessing{
@@ -246,6 +258,14 @@ func TestInternalizedRejection_CascadePosition_SYNC(t *testing.T) {
 	engine, factory := setupEngine(t)
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cascade-position", ModelVersion: "1.0"}
+
+	// Processor A's output goes through the same model checks a client write
+	// does: declare the entity's own field (`original`) and the field A writes
+	// (`A_ran`). Strict model — an undeclared field would still fail.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"original": schema.Boolean,
+		"A_ran":    schema.Boolean,
+	})
 
 	dispatchOrder := []string{}
 	engine.extProc = &mockExternalProcessing{

--- a/internal/domain/workflow/engine_result_test.go
+++ b/internal/domain/workflow/engine_result_test.go
@@ -7,6 +7,7 @@ import (
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
 
@@ -92,6 +93,14 @@ func TestEngineResult_Segmented_TrueOnCBDCascade(t *testing.T) {
 
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cbd-segmented", ModelVersion: "1.0"}
+
+	// cbd-proc's returned data passes the same model checks a client write
+	// does: declare the entity's own `x` and the `enriched` field the
+	// processor writes. Strict model — no ChangeLevel.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x":        schema.Integer,
+		"enriched": schema.Boolean,
+	})
 
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "CbdSegmentedWF", InitialState: "S_pre", Active: true,

--- a/internal/domain/workflow/engine_test.go
+++ b/internal/domain/workflow/engine_test.go
@@ -1098,6 +1098,13 @@ func TestProcessorDispatchModifiesEntityData(t *testing.T) {
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "ext-mod", ModelVersion: "1.0"}
 
+	// enrich-proc's output passes the same model checks a client write does:
+	// declare the entity's own `x` and the `enriched` field it writes.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x":        schema.Integer,
+		"enriched": schema.Boolean,
+	})
+
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "ModWF", InitialState: "INITIAL", Active: true,
 		States: map[string]spi.StateDefinition{
@@ -1641,6 +1648,15 @@ func TestAsyncNewTxFailureDoesNotKillPipeline(t *testing.T) {
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "async-fail-test", ModelVersion: "1.0"}
 
+	// sync-proc's output passes the same model checks a client write does:
+	// declare the entity's own `original` and the `modified` field it writes.
+	// (async-fail-proc's return is discarded by ASYNC_NEW_TX, so it adds
+	// nothing to the model's contract.)
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"original": schema.Boolean,
+		"modified": schema.String,
+	})
+
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "AsyncFailWF", InitialState: "INITIAL", Active: true,
 		States: map[string]spi.StateDefinition{
@@ -1766,6 +1782,16 @@ func TestSyncProcessorsSequentialCumulativeMutations(t *testing.T) {
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cumulative-test", ModelVersion: "1.0"}
 
+	// Each processor's output passes the same model checks a client write
+	// does. Every processor adds a key named after itself, so the model
+	// declares the entity's own `base` plus one field per processor.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"base":   schema.Boolean,
+		"first":  schema.Boolean,
+		"second": schema.Boolean,
+		"third":  schema.Boolean,
+	})
+
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "CumulativeWF", InitialState: "INITIAL", Active: true,
 		States: map[string]spi.StateDefinition{
@@ -1826,6 +1852,13 @@ func TestAsyncNewTx_SeesSyncChanges(t *testing.T) {
 	engine := NewEngine(factory, uuids, nil)
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "async-sees-sync", ModelVersion: "1.0"}
+
+	// sync-modifier's output passes the same model checks a client write does:
+	// declare the entity's own `original` and the `sync` field it writes.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"original": schema.Boolean,
+		"sync":     schema.String,
+	})
 
 	var asyncReceivedData []byte
 	engine.extProc = &mockExternalProcessing{
@@ -2087,6 +2120,13 @@ func TestEngine_CommitBeforeDispatch_FalseBranch_HappyPath(t *testing.T) {
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cbd-false", ModelVersion: "1.0"}
 
+	// cbd-proc's output passes the same model checks a client write does:
+	// declare the entity's own `x` and the `enriched` field it writes.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x":        schema.Integer,
+		"enriched": schema.Boolean,
+	})
+
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "CbdFalseWF", InitialState: "S_pre", Active: true,
 		States: map[string]spi.StateDefinition{
@@ -2263,6 +2303,13 @@ func TestEngine_SingleSegment_NoEngineCommit(t *testing.T) {
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "single-seg", ModelVersion: "1.0"}
 
+	// p1 echoes the entity back, and that output still passes the same model
+	// checks a client write does — so the model must declare the entity's
+	// own `x`.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x": schema.Integer,
+	})
+
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "SingleSegWF", InitialState: "S1", Active: true,
 		States: map[string]spi.StateDefinition{
@@ -2348,6 +2395,17 @@ func TestEngine_CommitBeforeDispatch_CASConflict_BubblesAsErrConflict(t *testing
 
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cbd-cas-conflict", ModelVersion: "1.0"}
+
+	// The cascade's intended result passes the same model checks a client
+	// write does, so the model declares every field this test stores: the
+	// entity's own `x`, the `cascade` field the processor returns, and the
+	// `interloper` field the competing writer commits. With all of them
+	// declared, the CAS conflict is the ONLY thing that can fail the cascade.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x":          schema.Integer,
+		"cascade":    schema.Boolean,
+		"interloper": schema.Boolean,
+	})
 
 	mock := &mockExternalProcessing{
 		dispatchFunc: func(_ context.Context, entity *spi.Entity, _ spi.ProcessorDefinition, _, _, _ string) (*spi.Entity, error) {
@@ -2530,6 +2588,15 @@ func TestEngine_CommitBeforeDispatch_TrueBranch_HappyPath(t *testing.T) {
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cbd-true", ModelVersion: "1.0"}
 
+	// The anchor mutation cbd-proc returns passes the same model checks a
+	// client write does. The processor also saves a SECONDARY entity under
+	// this same model, so `y` is declared too.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x":        schema.Integer,
+		"enriched": schema.Boolean,
+		"y":        schema.Integer,
+	})
+
 	tt := true
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "CbdTrueWF", InitialState: "S_pre", Active: true,
@@ -2672,6 +2739,17 @@ func TestEngine_CommitBeforeDispatch_TrueBranch_DoubleWriteIsLastWriterWins(t *t
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cbd-true-lww", ModelVersion: "1.0"}
 
+	// The processor writes the anchor twice — once directly through the store
+	// (`processor_wrote`) and once as its returned mutation
+	// (`engine_applied`), the latter going through the same model checks a
+	// client write does. Declare both, plus the entity's own `x`, so the LWW
+	// ordering is what this test observes.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x":               schema.Integer,
+		"processor_wrote": schema.Boolean,
+		"engine_applied":  schema.Boolean,
+	})
+
 	tt := true
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "CbdTrueLWWWF", InitialState: "S_pre", Active: true,
@@ -2784,6 +2862,12 @@ func TestEngine_CommitBeforeDispatch_AuditEventPlacement(t *testing.T) {
 
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cbd-audit", ModelVersion: "1.0"}
+
+	// p1's returned data (`{"x":42}`) passes the same model checks a client
+	// write does; `x` is also the entity's own field.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x": schema.Integer,
+	})
 
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "CbdAuditWF", InitialState: "S1", Active: true,
@@ -2929,6 +3013,13 @@ func TestEngine_Execute_ReturnsFinalSegmentTxOnCBDCascade(t *testing.T) {
 
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cbd-final-tx", ModelVersion: "1.0"}
+
+	// cbd-proc's output passes the same model checks a client write does:
+	// declare the entity's own `x` and the `enriched` field it writes.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"x":        schema.Integer,
+		"enriched": schema.Boolean,
+	})
 
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "CbdFinalTxWF", InitialState: "S_pre", Active: true,

--- a/internal/domain/workflow/fire_scheduled_test.go
+++ b/internal/domain/workflow/fire_scheduled_test.go
@@ -1338,6 +1338,11 @@ func TestFireScheduled_CBDSegmentedFire_HappyPath(t *testing.T) {
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cbd-fire-order", ModelVersion: "1.0"}
 
+	// cbd-proc echoes the entity back, and that output still passes the same
+	// model checks a client write does. The entity carries no data fields, so
+	// an empty (but registered, strict) model is the honest declaration.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{})
+
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "CBDFireWF", InitialState: "OPEN", Active: true,
 		States: map[string]spi.StateDefinition{
@@ -1487,6 +1492,11 @@ func TestFireScheduled_CBDIntermediateFlush_AttributesToArmingPrincipal_NotPrior
 	engine, factory, _, advance := setupEngineForCBDFire(t, armMs, mock, 0)
 	ctx := ctxWithTenant(testTenant)
 	modelRef := spi.ModelRef{EntityName: "cbd-intermediate-order", ModelVersion: "1.0"}
+
+	// cbd-proc echoes the entity back, and that output still passes the same
+	// model checks a client write does. The entity carries no data fields, so
+	// an empty (but registered, strict) model is the honest declaration.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{})
 
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "CBDIntermediateWF", InitialState: "OPEN", Active: true,
@@ -1651,6 +1661,15 @@ func TestFireScheduled_SiblingEntityWrite_AttributesToArmingUser_ViaAmbientOrigi
 	engine, factory, _, advance := setupEngineForCBDFire(t, armMs, mock, 0)
 	factoryRef = factory
 	ctx := ctxWithTenant(testTenant)
+
+	// sibling-writer-proc echoes the anchor back, and that output passes the
+	// same model checks a client write does — the anchor carries no data
+	// fields. The sibling entity it saves shares this model, so `createdBy`
+	// is declared too, keeping the model an accurate description of every
+	// field the test stores under it.
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{
+		"createdBy": schema.String,
+	})
 
 	wf := spi.WorkflowDefinition{
 		Version: "1.1", Name: "SiblingWriteWF", InitialState: "OPEN", Active: true,

--- a/internal/domain/workflow/processor_output.go
+++ b/internal/domain/workflow/processor_output.go
@@ -1,0 +1,119 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/ingest"
+)
+
+// ErrProcessorOutputRejected marks data returned by a processor that the model
+// rejects — unstorable content, or a shape the model's ChangeLevel does not
+// permit.
+//
+// The cause's text is folded in with %s, deliberately NOT %w. ingest returns
+// *common.AppError values carrying 400 BAD_REQUEST, and the handler's
+// classifier unwraps any embedded AppError first — so wrapping would surface
+// the checker's verdict verbatim and blame the caller for bytes a processor
+// produced. Breaking the chain routes this to the WORKFLOW_FAILED branch,
+// which is the truthful answer: the transition failed.
+var ErrProcessorOutputRejected = errors.New("processor output rejected")
+
+// ErrProcessorOutputInfra marks a server-side failure while checking a
+// processor's output — the model store being unreachable, a codec failure, or
+// a schema-extension write failing. Handlers map it to a sanitized 5xx.
+var ErrProcessorOutputInfra = errors.New("processor output check failed")
+
+// applyProcessorData runs a processor's returned bytes through the same checks
+// a client write passes, and only then adopts them onto the entity.
+//
+// The project's rule is that the engine gets no special rights: a processor may
+// extend an entity beyond its model exactly when a client could, i.e. when the
+// model's ChangeLevel allows it, and never otherwise. Before this existed a
+// processor could write anything at all — content no backend could store
+// (surfacing as a 500), or fields the model does not declare (leaving an entity
+// the API could read but not accept back on a PUT, and absent from the model
+// export).
+//
+// desc resolves the model descriptor lazily and at most once per transition;
+// see modelDescMemo.
+//
+// Coverage note: this rule deliberately has no cross-backend parity scenario.
+// Every check here runs above the SPI, before any store is called, so no
+// backend can answer differently — unlike the storability guard, where memory
+// and postgres genuinely disagreed about what could be persisted. The contract
+// is pinned by internal/e2e/workflow_proc_output_test.go instead.
+func (e *Engine) applyProcessorData(ctx context.Context, entity *spi.Entity, desc *modelDescMemo, data []byte) error {
+	if err := ingest.RejectUnstorable(data); err != nil {
+		return fmt.Errorf("%w: %s", ErrProcessorOutputRejected, err)
+	}
+
+	var parsed any
+	if err := ingest.DecodeJSONPreservingNumbers(data, &parsed); err != nil {
+		return fmt.Errorf("%w: invalid JSON: %s", ErrProcessorOutputRejected, err)
+	}
+
+	modelStore, err := e.factory.ModelStore(ctx)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrProcessorOutputInfra, err)
+	}
+
+	resolved, err := desc.get(ctx, modelStore, entity)
+	if err != nil {
+		return err
+	}
+
+	if err := ingest.ValidateOrExtend(ctx, modelStore, resolved, parsed); err != nil {
+		if errors.Is(err, ingest.ErrInternalSchema) {
+			return fmt.Errorf("%w: %s", ErrProcessorOutputInfra, err)
+		}
+		return fmt.Errorf("%w: %s", ErrProcessorOutputRejected, err)
+	}
+
+	entity.Data = data
+	return nil
+}
+
+// modelDescMemo resolves the entity's model descriptor lazily, at most once per
+// transition.
+//
+// Lazily, because a pipeline whose processors never return data needs no
+// descriptor at all — requiring one would impose a new precondition the rule
+// does not ask for.
+//
+// At most once, because that is correctness rather than an optimisation. The
+// model cache is not transaction-aware and ExtendSchema invalidates it before
+// the surrounding transaction commits, so re-reading between processors could
+// repopulate the cache from the pre-extension schema and then reject the next
+// processor's legitimate field. One descriptor carried across the pipeline
+// cannot see that flap, and a stale-narrow descriptor is harmless because
+// extension deltas are additive.
+type modelDescMemo struct {
+	desc   *spi.ModelDescriptor
+	err    error
+	loaded bool
+}
+
+// get returns the descriptor, loading it on first call.
+//
+// Fails closed when the model cannot be read, matching how criterion typing
+// already treats a missing schema: a required input for judging correctness is
+// absent, so reject rather than guess.
+func (m *modelDescMemo) get(ctx context.Context, modelStore spi.ModelStore, entity *spi.Entity) (*spi.ModelDescriptor, error) {
+	if m.loaded {
+		return m.desc, m.err
+	}
+	m.loaded = true
+	desc, err := modelStore.Get(ctx, entity.Meta.ModelRef)
+	switch {
+	case err != nil:
+		m.err = fmt.Errorf("%w: model %s: %s", ErrProcessorOutputInfra, entity.Meta.ModelRef, err)
+	case desc == nil:
+		m.err = fmt.Errorf("%w: model %s not found", ErrProcessorOutputInfra, entity.Meta.ModelRef)
+	default:
+		m.desc = desc
+	}
+	return m.desc, m.err
+}

--- a/internal/domain/workflow/processor_output_test.go
+++ b/internal/domain/workflow/processor_output_test.go
@@ -1,0 +1,277 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// procOutputEngine builds an engine whose single processor returns procData,
+// running in the given execution mode, over a model declaring modelFields.
+func procOutputEngine(
+	t *testing.T,
+	mode string,
+	modelFields map[string]schema.DataType,
+	procData string,
+	procErr error,
+) (*Engine, spi.StoreFactory, spi.TransactionManager, context.Context, spi.ModelRef) {
+	t.Helper()
+
+	factory := memory.NewStoreFactory()
+	t.Cleanup(func() { factory.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := factory.NewTransactionManager(uuids)
+
+	mock := &mockExternalProcessing{
+		dispatchFunc: func(ctx context.Context, entity *spi.Entity, proc spi.ProcessorDefinition, _, _, txID string) (*spi.Entity, error) {
+			if procErr != nil {
+				return nil, procErr
+			}
+			return &spi.Entity{Data: []byte(procData)}, nil
+		},
+	}
+	engine := NewEngine(factory, uuids, txMgr, WithExternalProcessing(mock))
+
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "procout-" + mode, ModelVersion: "1.0"}
+	if modelFields != nil {
+		registerModelFields(t, ctx, factory, modelRef, modelFields)
+	}
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.1", Name: "ProcOutWF", InitialState: "S_pre", Active: true,
+		States: map[string]spi.StateDefinition{
+			"S_pre": {Transitions: []spi.TransitionDefinition{
+				{Name: "CALLOUT", Next: "S_post", Manual: false,
+					Processors: []spi.ProcessorDefinition{
+						{Type: ProcessorTypeExternalized, Name: "procout-proc", ExecutionMode: mode},
+					}},
+			}},
+			"S_post": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+	return engine, factory, txMgr, ctx, modelRef
+}
+
+func runProcOutput(t *testing.T, engine *Engine, txMgr spi.TransactionManager, ctx context.Context, modelRef spi.ModelRef) (*spi.Entity, error) {
+	t.Helper()
+	txID, txCtx, err := txMgr.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	entity := &spi.Entity{
+		Meta: spi.EntityMeta{
+			ID: "procout-1", TenantID: testTenant, ModelRef: modelRef, TransactionID: txID,
+		},
+		Data: []byte(`{"x":1}`),
+	}
+	_, err = engine.Execute(txCtx, entity, "")
+	return entity, err
+}
+
+// TestProcessorOutput_OffModelFieldRejectedInEveryExecutionMode covers the
+// rejection path in each mode a processor's data can reach the entity through —
+// including both COMMIT_BEFORE_DISPATCH branches, where the check runs on
+// TX_post rather than where the data arrives.
+func TestProcessorOutput_OffModelFieldRejectedInEveryExecutionMode(t *testing.T) {
+	modes := []string{
+		ExecutionModeSync,
+		ExecutionModeAsyncSameTx,
+		ExecutionModeCommitBeforeDispatch,
+	}
+	for _, mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			engine, _, txMgr, ctx, ref := procOutputEngine(t, mode,
+				map[string]schema.DataType{"x": schema.Integer},
+				`{"x":1,"undeclared":"v"}`, nil)
+
+			entity, err := runProcOutput(t, engine, txMgr, ctx, ref)
+			if err == nil {
+				t.Fatalf("processor wrote a field the model does not declare; want an error")
+			}
+			if !errors.Is(err, ErrProcessorOutputRejected) {
+				t.Errorf("err = %v; want ErrProcessorOutputRejected", err)
+			}
+			if string(entity.Data) != `{"x":1}` {
+				t.Errorf("entity.Data = %s; the rejected data must not be adopted", entity.Data)
+			}
+		})
+	}
+}
+
+// TestProcessorOutput_RejectionDoesNotLeakAnAppError is the regression guard for
+// the %s-not-%w choice in applyProcessorData.
+//
+// ingest returns *common.AppError values carrying 400 BAD_REQUEST. The handler's
+// classifier unwraps any embedded AppError first, so wrapping the cause with %w
+// would surface the checker's verdict verbatim — blaming the caller for bytes a
+// processor produced. The chain must stay broken.
+func TestProcessorOutput_RejectionDoesNotLeakAnAppError(t *testing.T) {
+	engine, _, txMgr, ctx, ref := procOutputEngine(t, ExecutionModeSync,
+		map[string]schema.DataType{"x": schema.Integer},
+		`{"x":1,"undeclared":"v"}`, nil)
+
+	_, err := runProcOutput(t, engine, txMgr, ctx, ref)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var appErr *common.AppError
+	if errors.As(err, &appErr) {
+		t.Errorf("an *common.AppError is reachable through the chain (status %d, code %s) — "+
+			"the handler would surface it and blame the caller for the processor's bytes",
+			appErr.Status, appErr.Code)
+	}
+}
+
+// TestProcessorOutput_UnstorableContentRejected covers the storability half.
+func TestProcessorOutput_UnstorableContentRejected(t *testing.T) {
+	engine, _, txMgr, ctx, ref := procOutputEngine(t, ExecutionModeSync,
+		map[string]schema.DataType{"x": schema.Integer, "s": schema.String},
+		"{\"x\":1,\"s\":\"a\\ud800b\"}", nil)
+
+	_, err := runProcOutput(t, engine, txMgr, ctx, ref)
+	if err == nil {
+		t.Fatal("processor returned an unpaired surrogate; want an error, not a storage failure")
+	}
+	if !errors.Is(err, ErrProcessorOutputRejected) {
+		t.Errorf("err = %v; want ErrProcessorOutputRejected", err)
+	}
+}
+
+// TestProcessorOutput_StorableOnModelDataAccepted keeps the guard from being
+// vacuously strict: data that matches the model must still be adopted.
+func TestProcessorOutput_StorableOnModelDataAccepted(t *testing.T) {
+	engine, _, txMgr, ctx, ref := procOutputEngine(t, ExecutionModeSync,
+		map[string]schema.DataType{"x": schema.Integer, "enriched": schema.Boolean},
+		`{"x":1,"enriched":true}`, nil)
+
+	entity, err := runProcOutput(t, engine, txMgr, ctx, ref)
+	if err != nil {
+		t.Fatalf("on-model processor output was rejected: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(entity.Data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["enriched"] != true {
+		t.Errorf("processor output was not adopted: %s", entity.Data)
+	}
+}
+
+// TestProcessorOutput_FailsClosedWhenTheModelCannotBeRead pins the infra route.
+//
+// A missing or unreadable model means the input needed to judge the output is
+// absent, so the transition is rejected rather than guessed at — and it routes
+// to ErrProcessorOutputInfra, which the handler maps to a sanitized 5xx rather
+// than blaming the caller.
+func TestProcessorOutput_FailsClosedWhenTheModelCannotBeRead(t *testing.T) {
+	t.Run("model store unavailable", func(t *testing.T) {
+		engine, factory, txMgr, ctx, ref := procOutputEngine(t, ExecutionModeSync,
+			map[string]schema.DataType{"x": schema.Integer}, `{"x":1}`, nil)
+		engine.factory = &errModelStoreFactory{StoreFactory: factory, err: fmt.Errorf("store down")}
+
+		if _, err := runProcOutput(t, engine, txMgr, ctx, ref); !errors.Is(err, ErrProcessorOutputInfra) {
+			t.Errorf("err = %v; want ErrProcessorOutputInfra", err)
+		}
+	})
+
+	t.Run("model not registered", func(t *testing.T) {
+		// nil modelFields — no descriptor is saved for this model.
+		engine, _, txMgr, ctx, ref := procOutputEngine(t, ExecutionModeSync, nil, `{"x":1}`, nil)
+		if _, err := runProcOutput(t, engine, txMgr, ctx, ref); !errors.Is(err, ErrProcessorOutputInfra) {
+			t.Errorf("err = %v; want ErrProcessorOutputInfra", err)
+		}
+	})
+}
+
+// TestProcessorOutput_DescriptorResolvedOnceAcrossThePipeline pins the reason
+// modelDescMemo exists.
+//
+// The model cache is not transaction-aware and ExtendSchema invalidates it
+// before the surrounding transaction commits. Re-reading the descriptor between
+// processors could therefore repopulate it from the pre-extension schema and
+// reject the next processor's legitimate field. One read across the pipeline
+// cannot see that flap.
+func TestProcessorOutput_DescriptorResolvedOnceAcrossThePipeline(t *testing.T) {
+	factory := memory.NewStoreFactory()
+	t.Cleanup(func() { factory.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := factory.NewTransactionManager(uuids)
+
+	calls := 0
+	mock := &mockExternalProcessing{
+		dispatchFunc: func(ctx context.Context, entity *spi.Entity, proc spi.ProcessorDefinition, _, _, txID string) (*spi.Entity, error) {
+			calls++
+			return &spi.Entity{Data: []byte(fmt.Sprintf(`{"x":%d}`, calls))}, nil
+		},
+	}
+	engine := NewEngine(factory, uuids, txMgr, WithExternalProcessing(mock))
+
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "procout-memo", ModelVersion: "1.0"}
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{"x": schema.Integer})
+
+	counting := &countingModelStoreFactory{StoreFactory: factory}
+	engine.factory = counting
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.1", Name: "MemoWF", InitialState: "S_pre", Active: true,
+		States: map[string]spi.StateDefinition{
+			"S_pre": {Transitions: []spi.TransitionDefinition{
+				{Name: "CALLOUT", Next: "S_post", Manual: false,
+					Processors: []spi.ProcessorDefinition{
+						{Type: ProcessorTypeExternalized, Name: "p1", ExecutionMode: ExecutionModeSync},
+						{Type: ProcessorTypeExternalized, Name: "p2", ExecutionMode: ExecutionModeSync},
+						{Type: ProcessorTypeExternalized, Name: "p3", ExecutionMode: ExecutionModeSync},
+					}},
+			}},
+			"S_post": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	counting.gets = 0
+	if _, err := runProcOutput(t, engine, txMgr, ctx, modelRef); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 processor dispatches, got %d", calls)
+	}
+	if counting.gets != 1 {
+		t.Errorf("model descriptor was read %d times for one transition; want 1 — "+
+			"re-reading between processors can observe a cache invalidated by an "+
+			"uncommitted extension", counting.gets)
+	}
+}
+
+// countingModelStoreFactory counts ModelStore.Get calls.
+type countingModelStoreFactory struct {
+	spi.StoreFactory
+	gets int
+}
+
+func (f *countingModelStoreFactory) ModelStore(ctx context.Context) (spi.ModelStore, error) {
+	inner, err := f.StoreFactory.ModelStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &countingModelStore{ModelStore: inner, f: f}, nil
+}
+
+type countingModelStore struct {
+	spi.ModelStore
+	f *countingModelStoreFactory
+}
+
+func (s *countingModelStore) Get(ctx context.Context, ref spi.ModelRef) (*spi.ModelDescriptor, error) {
+	s.f.gets++
+	return s.ModelStore.Get(ctx, ref)
+}

--- a/internal/e2e/admin_loglevel_test.go
+++ b/internal/e2e/admin_loglevel_test.go
@@ -1,0 +1,89 @@
+package e2e_test
+
+// End-to-end coverage for the runtime log-level admin endpoint. The handler's
+// branches are unit-tested in internal/api/admin_test.go; what these tests add
+// is the wired route behind real JWT auth, and that a POST is observable by a
+// subsequent GET (the level is process-global state, not per-request).
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func getLogLevelE2E(t *testing.T) string {
+	t.Helper()
+	resp := doAuth(t, http.MethodGet, "/api/admin/log-level", "")
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET log-level: status=%d body=%s", resp.StatusCode, body)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(body), &cfg); err != nil {
+		t.Fatalf("GET log-level: decode %q: %v", body, err)
+	}
+	level, _ := cfg["level"].(string)
+	if level == "" {
+		t.Fatalf("GET log-level: no level in response: %s", body)
+	}
+	return level
+}
+
+// TestAdminLogLevel_SetRoundTrip asserts POST changes the level, reports the
+// previous one, and that the change is visible to a subsequent GET.
+func TestAdminLogLevel_SetRoundTrip(t *testing.T) {
+	original := getLogLevelE2E(t)
+	// Restore the level so this test cannot leak verbosity into the rest of
+	// the suite (the level is process-global).
+	defer func() {
+		resp := doAuth(t, http.MethodPost, "/api/admin/log-level", `{"level":"`+original+`"}`)
+		readBody(t, resp)
+	}()
+
+	resp := doAuth(t, http.MethodPost, "/api/admin/log-level", `{"level":"debug"}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST log-level: status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var got struct {
+		Level    string `json:"level"`
+		Previous string `json:"previous"`
+	}
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("POST log-level: decode %q: %v", body, err)
+	}
+	if got.Level != "debug" {
+		t.Errorf("POST log-level: level=%q, want debug", got.Level)
+	}
+	if got.Previous != original {
+		t.Errorf("POST log-level: previous=%q, want %q", got.Previous, original)
+	}
+
+	if now := getLogLevelE2E(t); now != "debug" {
+		t.Errorf("GET after POST: level=%q, want debug — the change did not take effect process-wide", now)
+	}
+}
+
+// TestAdminLogLevel_BadRequests covers the documented 400 paths.
+func TestAdminLogLevel_BadRequests(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"malformed-json", `{not json`},
+		{"empty-body", ``},
+		{"missing-level", `{}`},
+		{"empty-level", `{"level":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := doAuth(t, http.MethodPost, "/api/admin/log-level", tc.body)
+			body := readBody(t, resp)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400; body: %s", resp.StatusCode, body)
+			}
+			assertErrorCode(t, body, "BAD_REQUEST")
+		})
+	}
+}

--- a/internal/e2e/admin_loglevel_test.go
+++ b/internal/e2e/admin_loglevel_test.go
@@ -33,6 +33,13 @@ func getLogLevelE2E(t *testing.T) string {
 // previous one, and that the change is visible to a subsequent GET.
 func TestAdminLogLevel_SetRoundTrip(t *testing.T) {
 	original := getLogLevelE2E(t)
+	// Target a level that differs from the current one, so "previous" and the
+	// post-POST GET both prove something even if the suite is already running
+	// at debug.
+	target := "debug"
+	if original == target {
+		target = "warn"
+	}
 	// Restore the level so this test cannot leak verbosity into the rest of
 	// the suite (the level is process-global).
 	defer func() {
@@ -40,7 +47,7 @@ func TestAdminLogLevel_SetRoundTrip(t *testing.T) {
 		readBody(t, resp)
 	}()
 
-	resp := doAuth(t, http.MethodPost, "/api/admin/log-level", `{"level":"debug"}`)
+	resp := doAuth(t, http.MethodPost, "/api/admin/log-level", `{"level":"`+target+`"}`)
 	body := readBody(t, resp)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("POST log-level: status=%d body=%s", resp.StatusCode, body)
@@ -53,15 +60,15 @@ func TestAdminLogLevel_SetRoundTrip(t *testing.T) {
 	if err := json.Unmarshal([]byte(body), &got); err != nil {
 		t.Fatalf("POST log-level: decode %q: %v", body, err)
 	}
-	if got.Level != "debug" {
-		t.Errorf("POST log-level: level=%q, want debug", got.Level)
+	if got.Level != target {
+		t.Errorf("POST log-level: level=%q, want %q", got.Level, target)
 	}
 	if got.Previous != original {
 		t.Errorf("POST log-level: previous=%q, want %q", got.Previous, original)
 	}
 
-	if now := getLogLevelE2E(t); now != "debug" {
-		t.Errorf("GET after POST: level=%q, want debug — the change did not take effect process-wide", now)
+	if now := getLogLevelE2E(t); now != target {
+		t.Errorf("GET after POST: level=%q, want %q — the change did not take effect process-wide", now, target)
 	}
 }
 

--- a/internal/e2e/auth_failures_test.go
+++ b/internal/e2e/auth_failures_test.go
@@ -1,0 +1,154 @@
+package e2e_test
+
+// Authentication-failure coverage through the full HTTP stack. The rejection
+// logic itself is unit-tested in internal/auth; what these tests pin is that
+// every authenticated route is actually wrapped in the auth middleware and
+// that the rejection reaches the client as the uniform RFC 9457 problem
+// detail — routing and wiring the unit tests cannot see.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// unauthRequest issues a request to path with the given Authorization header
+// verbatim ("" omits the header entirely).
+func unauthRequest(t *testing.T, method, path, authHeader string) *http.Response {
+	t.Helper()
+	req, err := e2eNewRequest(t, method, serverURL+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	return resp
+}
+
+// A syntactically valid JWT signed by a key the server does not trust.
+const untrustedJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+	"eyJzdWIiOiJhdHRhY2tlciIsImlzcyI6ImN5b2RhLXRlc3QiLCJleHAiOjQxMDI0NDQ4MDB9." +
+	"ZmFrZXNpZ25hdHVyZWZha2VzaWduYXR1cmVmYWtlc2ln"
+
+// TestAuth_MissingOrInvalidCredentials_401 asserts that every authenticated
+// route rejects absent and malformed credentials with 401 UNAUTHORIZED.
+func TestAuth_MissingOrInvalidCredentials_401(t *testing.T) {
+	routes := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"entity-list", http.MethodGet, "/api/entity/e2e-auth-probe/1"},
+		{"entity-create", http.MethodPost, "/api/entity/JSON/e2e-auth-probe/1"},
+		{"admin-log-level", http.MethodGet, "/api/admin/log-level"},
+		{"clients-list", http.MethodGet, "/api/clients"},
+		{"model-export", http.MethodGet, "/api/model/export/SIMPLE_VIEW/e2e-auth-probe/1"},
+	}
+	credentials := []struct {
+		name   string
+		header string
+	}{
+		{"no-header", ""},
+		{"empty-bearer", "Bearer "},
+		{"garbage-bearer", "Bearer not-a-jwt"},
+		{"wrong-scheme", "Basic dGVzdGNsaWVudDp0ZXN0c2VjcmV0"},
+		{"untrusted-signature", "Bearer " + untrustedJWT},
+	}
+
+	for _, route := range routes {
+		for _, cred := range credentials {
+			t.Run(route.name+"/"+cred.name, func(t *testing.T) {
+				resp := unauthRequest(t, route.method, route.path, cred.header)
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusUnauthorized {
+					raw, _ := io.ReadAll(resp.Body)
+					t.Fatalf("status=%d, want 401; body: %s", resp.StatusCode, raw)
+				}
+				assertUnauthorizedProblem(t, resp)
+			})
+		}
+	}
+}
+
+// assertUnauthorizedProblem checks the RFC 9457 shape of a 401 body.
+func assertUnauthorizedProblem(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/problem+json") {
+		t.Errorf("content-type=%q, want application/problem+json", ct)
+	}
+	var pd struct {
+		Status     int            `json:"status"`
+		Detail     string         `json:"detail"`
+		Properties map[string]any `json:"properties"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&pd); err != nil {
+		t.Fatalf("decode problem detail: %v", err)
+	}
+	if pd.Status != http.StatusUnauthorized {
+		t.Errorf("problem.status=%d, want 401", pd.Status)
+	}
+	if got := pd.Properties["errorCode"]; got != "UNAUTHORIZED" {
+		t.Errorf("errorCode=%v, want UNAUTHORIZED", got)
+	}
+}
+
+// TestAuth_RejectionCarriesNoEnumerationSignal asserts that a 401 body is
+// byte-identical no matter why authentication failed. A caller must not be
+// able to distinguish "no such client", "wrong secret", "expired token" or
+// "untrusted signer" from the response — that difference is an account
+// enumeration oracle.
+func TestAuth_RejectionCarriesNoEnumerationSignal(t *testing.T) {
+	const path = "/api/entity/e2e-auth-probe/1"
+	headers := []string{
+		"",
+		"Bearer ",
+		"Bearer not-a-jwt",
+		"Basic dGVzdGNsaWVudDp0ZXN0c2VjcmV0",
+		"Bearer " + untrustedJWT,
+	}
+
+	var first string
+	for i, header := range headers {
+		resp := unauthRequest(t, http.MethodGet, path, header)
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("header %q: status=%d, want 401", header, resp.StatusCode)
+		}
+		// The ticket UUID (if any) is per-request; compare the stable detail.
+		var pd struct {
+			Title  string `json:"title"`
+			Detail string `json:"detail"`
+		}
+		if err := json.Unmarshal([]byte(body), &pd); err != nil {
+			t.Fatalf("header %q: decode: %v", header, err)
+		}
+		got := fmt.Sprintf("%s|%s", pd.Title, pd.Detail)
+		if i == 0 {
+			first = got
+			continue
+		}
+		if got != first {
+			t.Errorf("401 body differs by failure reason — enumeration signal.\n header %q: %q\n baseline: %q",
+				header, got, first)
+		}
+	}
+}
+
+// TestAuth_ValidCredentialsStillPass guards against the 401 tests above
+// passing for the wrong reason (e.g. a route that 401s unconditionally).
+func TestAuth_ValidCredentialsStillPass(t *testing.T) {
+	resp := doAuth(t, http.MethodGet, "/api/admin/log-level", "")
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated GET /api/admin/log-level: status=%d, want 200; body: %s", resp.StatusCode, body)
+	}
+}

--- a/internal/e2e/auth_failures_test.go
+++ b/internal/e2e/auth_failures_test.go
@@ -101,11 +101,16 @@ func assertUnauthorizedProblem(t *testing.T, resp *http.Response) {
 	}
 }
 
-// TestAuth_RejectionCarriesNoEnumerationSignal asserts that a 401 body is
-// byte-identical no matter why authentication failed. A caller must not be
-// able to distinguish "no such client", "wrong secret", "expired token" or
-// "untrusted signer" from the response — that difference is an account
-// enumeration oracle.
+// TestAuth_RejectionCarriesNoEnumerationSignal asserts that the 401 a
+// protected route returns is identical no matter how the credential was
+// malformed — absent, empty, unparseable, wrong scheme, or signed by an
+// untrusted key. Any variation would let a caller probe which part of the
+// credential the server got far enough to reject.
+//
+// The credential-validity oracle proper (valid client + wrong secret vs.
+// unknown client) lives on the token endpoint, not here; it is covered by
+// internal/auth/delegating_uniform_message_test.go and
+// delegating_enumeration_test.go.
 func TestAuth_RejectionCarriesNoEnumerationSignal(t *testing.T) {
 	const path = "/api/entity/e2e-auth-probe/1"
 	headers := []string{

--- a/internal/e2e/callback_concurrency_test.go
+++ b/internal/e2e/callback_concurrency_test.go
@@ -198,29 +198,26 @@ func TestDispatch_NeverHoldsGateAcrossDispatch(t *testing.T) {
 
 	// Watchdog: the create blocks until the cascade completes. Run it off-goroutine
 	// so a gate-across-dispatch deadlock surfaces as a timeout, not a frozen test.
-	type result struct {
-		id     string
-		status int
-		body   string
-	}
-	done := make(chan result, 1)
+	done := make(chan createEntityResult, 1)
 	go func() {
-		id, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
-		done <- result{id, status, body}
+		done <- h.CreateEntityRaw(primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	}()
 
-	var r result
+	var r createEntityResult
 	select {
 	case r = <-done:
 	case <-time.After(15 * time.Second):
 		t.Fatal("DEADLOCK: primary transition did not complete within 15s — the owner is holding the txgate across engine.Execute (H3 invariant violated); a joined callback cannot acquire the gate")
 	}
 
+	if r.err != nil {
+		t.Fatalf("primary create: %v", r.err)
+	}
 	if r.status != http.StatusOK {
 		t.Fatalf("primary create: status=%d body=%s", r.status, r.body)
 	}
 
-	data := h.GetEntityData(t, r.id)
+	data := h.GetEntityData(t, r.entityID)
 	if ok, _ := data["joinedReadOK"].(bool); !ok {
 		t.Fatalf("joined callback read-your-writes failed: joinedReadOK=%v", data["joinedReadOK"])
 	}

--- a/internal/e2e/callback_concurrency_test.go
+++ b/internal/e2e/callback_concurrency_test.go
@@ -94,7 +94,8 @@ func TestCallback_ConcurrentCallbacks_Serialise(t *testing.T) {
 			}
 		}]
 	}`
-	h.SetupModelWithWorkflow(t, primary, primaryWF)
+	// cb-concurrent-fanout writes `secondaryCount`; the model must declare it.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(`"secondaryCount": 0`), primaryWF)
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {
@@ -194,7 +195,9 @@ func TestDispatch_NeverHoldsGateAcrossDispatch(t *testing.T) {
 			}
 		}]
 	}`
-	h.SetupModelWithWorkflow(t, primary, primaryWF)
+	// cb-join-during-dispatch writes `joinedSecondaryId`/`joinedReadOK`; declare both.
+	h.setupModelSampleWithWorkflow(t, primary,
+		workflowSampleWith(`"joinedSecondaryId": "", "joinedReadOK": false`), primaryWF)
 
 	// Watchdog: the create blocks until the cascade completes. Run it off-goroutine
 	// so a gate-across-dispatch deadlock surfaces as a timeout, not a frozen test.

--- a/internal/e2e/callback_depth2_test.go
+++ b/internal/e2e/callback_depth2_test.go
@@ -113,18 +113,12 @@ func depth2Chain(t *testing.T, tag, execMode string) {
 	}`, primProc)
 	h.SetupModelWithWorkflow(t, primary, primaryWF)
 
-	type result struct {
-		id     string
-		status int
-		body   string
-	}
-	done := make(chan result, 1)
+	done := make(chan createEntityResult, 1)
 	go func() {
-		id, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
-		done <- result{id, status, body}
+		done <- h.CreateEntityRaw(primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	}()
 
-	var r result
+	var r createEntityResult
 	select {
 	case r = <-done:
 	case <-time.After(20 * time.Second):
@@ -133,10 +127,13 @@ func depth2Chain(t *testing.T, tag, execMode string) {
 			"not upheld for the joined path); the third-level joined write cannot acquire the gate", execMode)
 	}
 
+	if r.err != nil {
+		t.Fatalf("primary create: %v", r.err)
+	}
 	if r.status != http.StatusOK {
 		t.Fatalf("primary create: status=%d body=%s", r.status, r.body)
 	}
-	if got := h.GetEntityData(t, r.id)["secondaryId"]; got == nil || got == "" {
+	if got := h.GetEntityData(t, r.entityID)["secondaryId"]; got == nil || got == "" {
 		t.Fatal("primary missing secondaryId — depth-2 cascade did not complete")
 	}
 
@@ -245,18 +242,12 @@ func TestCallback_Depth2NestedJoin_FunctionCriterion(t *testing.T) {
 	}`
 	h.SetupModelWithWorkflow(t, primary, primaryWF)
 
-	type result struct {
-		id     string
-		status int
-		body   string
-	}
-	done := make(chan result, 1)
+	done := make(chan createEntityResult, 1)
 	go func() {
-		id, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
-		done <- result{id, status, body}
+		done <- h.CreateEntityRaw(primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	}()
 
-	var r result
+	var r createEntityResult
 	select {
 	case r = <-done:
 	case <-time.After(20 * time.Second):
@@ -264,10 +255,13 @@ func TestCallback_Depth2NestedJoin_FunctionCriterion(t *testing.T) {
 			"within 20s — a joined callback is holding the txgate across the criterion dispatch")
 	}
 
+	if r.err != nil {
+		t.Fatalf("primary create: %v", r.err)
+	}
 	if r.status != http.StatusOK {
 		t.Fatalf("primary create: status=%d body=%s", r.status, r.body)
 	}
-	if got := h.GetEntityData(t, r.id)["secondaryId"]; got == nil || got == "" {
+	if got := h.GetEntityData(t, r.entityID)["secondaryId"]; got == nil || got == "" {
 		t.Fatal("primary missing secondaryId — depth-2 cascade did not complete")
 	}
 	select {

--- a/internal/e2e/callback_depth2_test.go
+++ b/internal/e2e/callback_depth2_test.go
@@ -82,7 +82,10 @@ func depth2Chain(t *testing.T, tag, execMode string) {
 			}
 		}]
 	}`, secProc, execMode)
-	h.SetupModelWithWorkflow(t, secondary, secondaryWF)
+	// The inner processor writes `tertiaryId` onto the SECONDARY; that model must
+	// declare it, or the inner transition fails and the rejection surfaces nested
+	// inside the outer processor's error.
+	h.setupModelSampleWithWorkflow(t, secondary, workflowSampleWith(`"tertiaryId": ""`), secondaryWF)
 
 	// primary: `init` runs a SYNC processor that creates a secondary in T.
 	primProc := "cb-d2-" + tag + "-primary"
@@ -111,7 +114,8 @@ func depth2Chain(t *testing.T, tag, execMode string) {
 			}
 		}]
 	}`, primProc)
-	h.SetupModelWithWorkflow(t, primary, primaryWF)
+	// The outer processor writes `secondaryId`; the primary model must declare it.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(`"secondaryId": ""`), primaryWF)
 
 	done := make(chan createEntityResult, 1)
 	go func() {
@@ -240,7 +244,8 @@ func TestCallback_Depth2NestedJoin_FunctionCriterion(t *testing.T) {
 			}
 		}]
 	}`
-	h.SetupModelWithWorkflow(t, primary, primaryWF)
+	// cb-d2-crit-primary writes `secondaryId`; the primary model must declare it.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(`"secondaryId": ""`), primaryWF)
 
 	done := make(chan createEntityResult, 1)
 	go func() {

--- a/internal/e2e/callback_harness_test.go
+++ b/internal/e2e/callback_harness_test.go
@@ -411,22 +411,48 @@ func (h *callbackHarness) SetupModelWithWorkflow(t *testing.T, entityName, workf
 // can assert on both success and failure of the cascade.
 func (h *callbackHarness) CreateEntity(t *testing.T, entityName string, modelVersion int, payload string) (entityID string, status int, body string) {
 	t.Helper()
-	resp := h.DoAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/%d", entityName, modelVersion), payload, "")
-	body = h.readBody(t, resp)
-	status = resp.StatusCode
-	if status != http.StatusOK {
-		return "", status, body
+	h.token(t) // seed the cached bearer token that CreateEntityRaw reads
+	res := h.CreateEntityRaw(entityName, modelVersion, payload)
+	if res.err != nil {
+		t.Fatalf("%v", res.err)
+	}
+	return res.entityID, res.status, res.body
+}
+
+// createEntityResult is the outcome of a client-facing entity POST, captured
+// so it can be asserted on the test goroutine.
+type createEntityResult struct {
+	entityID string
+	status   int
+	body     string
+	err      error
+}
+
+// CreateEntityRaw is the goroutine-safe form of CreateEntity: it returns the
+// outcome instead of aborting the test, so callers driving the cascade from a
+// goroutine can assert after joining. It reuses h.callback, which reads the
+// cached bearer token seeded on the test goroutine during setup.
+func (h *callbackHarness) CreateEntityRaw(entityName string, modelVersion int, payload string) createEntityResult {
+	res, err := h.callback(http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/%d", entityName, modelVersion), payload, "")
+	if err != nil {
+		return createEntityResult{status: -1, err: fmt.Errorf("createEntity %s: %w", entityName, err)}
+	}
+	out := createEntityResult{status: res.StatusCode, body: res.Body}
+	if out.status != http.StatusOK {
+		return out
 	}
 	var arr []map[string]any
-	if err := json.Unmarshal([]byte(body), &arr); err != nil || len(arr) == 0 {
-		t.Fatalf("createEntity %s: unparseable response: %s", entityName, body)
+	if err := json.Unmarshal([]byte(res.Body), &arr); err != nil || len(arr) == 0 {
+		out.err = fmt.Errorf("createEntity %s: unparseable response: %s", entityName, res.Body)
+		return out
 	}
 	ids, _ := arr[0]["entityIds"].([]any)
 	if len(ids) == 0 {
-		t.Fatalf("createEntity %s: no entityIds: %s", entityName, body)
+		out.err = fmt.Errorf("createEntity %s: no entityIds: %s", entityName, res.Body)
+		return out
 	}
-	entityID, _ = ids[0].(string)
-	return entityID, status, body
+	out.entityID, _ = ids[0].(string)
+	return out
 }
 
 // GetEntityState returns an entity's state, or "" (with the status) when the GET

--- a/internal/e2e/callback_txjoin_grpc_search_test.go
+++ b/internal/e2e/callback_txjoin_grpc_search_test.go
@@ -241,7 +241,11 @@ func TestCallback_GRPCSearch_SeesUncommittedWrite(t *testing.T) {
 			}
 		}]
 	}`
-	h.SetupModelWithWorkflow(t, primary, primaryWF)
+	// cb-grpc-search reports its findings through the primary's data; the model
+	// must declare every field it writes.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(
+		`"getFoundJoined": false, "getFoundStandalone": false, "searchCountJoined": 0, `+
+			`"searchCountStandalone": 0, "joinedMarker": "", "secondaryId": ""`), primaryWF)
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {

--- a/internal/e2e/callback_txjoin_modes_test.go
+++ b/internal/e2e/callback_txjoin_modes_test.go
@@ -227,7 +227,8 @@ func TestCallback_CBDPost_JoinsTxPost(t *testing.T) {
 			}
 		}]
 	}`
-	h.SetupModelWithWorkflow(t, primary, primaryWF)
+	// cb-cbd-post-proc writes `secondaryId`; the model must declare it.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(`"secondaryId": ""`), primaryWF)
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {
@@ -318,7 +319,8 @@ func TestCallback_CBDDefault_RunsStandalone(t *testing.T) {
 			}
 		}]
 	}`
-	h.SetupModelWithWorkflow(t, primary, primaryWF)
+	// cb-cbd-default-proc writes `secondaryId`; the model must declare it.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(`"secondaryId": ""`), primaryWF)
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {

--- a/internal/e2e/callback_txjoin_test.go
+++ b/internal/e2e/callback_txjoin_test.go
@@ -82,7 +82,8 @@ func TestCallback_SyncWrite_AtomicWithTransition(t *testing.T) {
 			}
 		}]
 	}`)
-	h.SetupModelWithWorkflow(t, primary, primaryWF)
+	// cb-create-ok writes `secondaryId`; the model must declare it.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(`"secondaryId": ""`), primaryWF)
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {
@@ -233,7 +234,10 @@ func TestCallback_SyncRead_SeesUncommittedCascadeWrite(t *testing.T) {
 			}
 		}]
 	}`
-	h.SetupModelWithWorkflow(t, primary, primaryWF)
+	// cb-read reports its joined read back through the primary's data; the
+	// model must declare those fields.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(
+		`"readbackStatus": 0, "readbackFound": false, "readbackMarker": "", "secondaryId": ""`), primaryWF)
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {

--- a/internal/e2e/entity_nul_payload_test.go
+++ b/internal/e2e/entity_nul_payload_test.go
@@ -1,0 +1,119 @@
+package e2e_test
+
+// A payload carrying U+0000 is valid JSON and passes schema validation, but
+// PostgreSQL text/jsonb cannot store it. It used to reach the store and fail
+// there, returning 500 SERVER_ERROR with a support ticket for what is a client
+// input error. Every write path must now reject it at the boundary with 400.
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// nulPayload is a JSON body whose "name" string carries a NUL (U+0000) escape.
+const nulPayload = "{\"name\":\"a\\u0000b\",\"amount\":1,\"status\":\"new\"}"
+
+func setupNulModel(t *testing.T, model string) {
+	t.Helper()
+	setupModelWithWorkflow(t, model, `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "nul-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {}
+			}
+		}]
+	}`)
+}
+
+// TestEntity_NulInPayload_400 covers every write path that accepts an entity
+// payload: single create, batch-array create, collection create, update, and
+// collection update.
+func TestEntity_NulInPayload_400(t *testing.T) {
+	const model = "e2e-nul-payload"
+	setupNulModel(t, model)
+
+	// A clean entity to aim the update paths at.
+	entityID := createEntityE2E(t, model, 1, `{"name":"ok","amount":1,"status":"new"}`)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{
+			name: "create", method: http.MethodPost,
+			path: fmt.Sprintf("/api/entity/JSON/%s/1", model),
+			body: nulPayload,
+		},
+		{
+			name: "create-batch-array", method: http.MethodPost,
+			path: fmt.Sprintf("/api/entity/JSON/%s/1", model),
+			body: "[" + nulPayload + "]",
+		},
+		{
+			name: "create-collection", method: http.MethodPost,
+			path: "/api/entity/JSON",
+			body: fmt.Sprintf(`[{"model":{"name":%q,"version":1},"payload":%s}]`, model, nulPayload),
+		},
+		{
+			name: "update", method: http.MethodPut,
+			path: fmt.Sprintf("/api/entity/JSON/%s", entityID),
+			body: nulPayload,
+		},
+		{
+			name: "update-collection", method: http.MethodPut,
+			path: "/api/entity/JSON",
+			body: fmt.Sprintf(`[{"id":%q,"payload":%s}]`, entityID, nulPayload),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := doAuth(t, tc.method, tc.path, tc.body)
+			body := readBody(t, resp)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400 (a NUL in the payload is a client error, not a storage failure); body: %s",
+					resp.StatusCode, body)
+			}
+			assertErrorCode(t, body, "BAD_REQUEST")
+		})
+	}
+
+	// The rejected writes must have left nothing behind, and the pre-existing
+	// entity must be untouched.
+	count := queryDB(t, "test-tenant",
+		"SELECT count(*) FROM entities WHERE model_name = $1 AND NOT deleted", model)
+	if count != 1 {
+		t.Errorf("expected exactly the 1 clean entity after the rejected writes, got %d", count)
+	}
+	if data := getEntityData(t, entityID, ""); data["name"] != "ok" {
+		t.Errorf("existing entity was modified by a rejected write: name=%v, want \"ok\"", data["name"])
+	}
+}
+
+// TestEntity_NulAdjacentPayloadsStillAccepted guards the rejection from being
+// over-broad: other control characters and text that merely looks like an
+// escape are legitimate payload content.
+func TestEntity_NulAdjacentPayloadsStillAccepted(t *testing.T) {
+	const model = "e2e-nul-adjacent"
+	setupNulModel(t, model)
+
+	bodies := map[string]string{
+		"tab-and-newline":   "{\"name\":\"a\\tb\\nc\",\"amount\":1,\"status\":\"new\"}",
+		"literal-backslash": "{\"name\":\"a\\\\u0000b\",\"amount\":1,\"status\":\"new\"}",
+		"unicode-escape":    "{\"name\":\"a\\u00e9b\",\"amount\":1,\"status\":\"new\"}",
+	}
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model), body)
+			respBody := readBody(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d, want 200 — this payload is storable; body: %s", resp.StatusCode, respBody)
+			}
+		})
+	}
+}

--- a/internal/e2e/entity_nul_payload_test.go
+++ b/internal/e2e/entity_nul_payload_test.go
@@ -31,6 +31,13 @@ func setupNulModel(t *testing.T, model string) {
 // TestEntity_NulInPayload_400 covers every write path that accepts an entity
 // payload: single create, batch-array create, collection create, update, and
 // collection update.
+//
+// The two collection bodies use %q, not %s, and that is load-bearing: the
+// collection endpoints declare Payload as a string (a JSON-ENCODED document,
+// see internal/domain/entity/handler.go). Embedding a raw object instead makes
+// the outer array parse fail with "invalid JSON array" — still a 400, so the
+// assertion passes, but from the array parser rather than from the guard under
+// test. These two subtests shipped that way and were vacuous.
 func TestEntity_NulInPayload_400(t *testing.T) {
 	const model = "e2e-nul-payload"
 	setupNulModel(t, model)
@@ -57,7 +64,7 @@ func TestEntity_NulInPayload_400(t *testing.T) {
 		{
 			name: "create-collection", method: http.MethodPost,
 			path: "/api/entity/JSON",
-			body: fmt.Sprintf(`[{"model":{"name":%q,"version":1},"payload":%s}]`, model, nulPayload),
+			body: fmt.Sprintf(`[{"model":{"name":%q,"version":1},"payload":%q}]`, model, nulPayload),
 		},
 		{
 			name: "update", method: http.MethodPut,
@@ -67,7 +74,7 @@ func TestEntity_NulInPayload_400(t *testing.T) {
 		{
 			name: "update-collection", method: http.MethodPut,
 			path: "/api/entity/JSON",
-			body: fmt.Sprintf(`[{"id":%q,"payload":%s}]`, entityID, nulPayload),
+			body: fmt.Sprintf(`[{"id":%q,"payload":%q}]`, entityID, nulPayload),
 		},
 	}
 

--- a/internal/e2e/entity_patch_test.go
+++ b/internal/e2e/entity_patch_test.go
@@ -27,21 +27,34 @@ import (
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 )
 
-// patchEntity issues an authenticated PATCH request to path with the given
-// Content-Type, If-Match (non-empty), and body. It returns the raw response.
-func patchEntity(t *testing.T, path, contentType, ifMatch, body string) *http.Response {
-	t.Helper()
-	token := getToken(t, "testclient", "testsecret")
-	req, err := e2eNewRequest(t, http.MethodPatch, serverURL+path, strings.NewReader(body))
+// patchEntityRaw issues an authenticated PATCH request to path with the given
+// Content-Type, If-Match (non-empty), and body. It never touches *testing.T,
+// so it is safe to call from a goroutine.
+func patchEntityRaw(ctx context.Context, path, contentType, ifMatch, body string) (*http.Response, error) {
+	token, err := getTokenRaw(ctx, "testclient", "testsecret")
 	if err != nil {
-		t.Fatalf("patchEntity newRequest: %v", err)
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, serverURL+path, strings.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("patchEntity newRequest: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("If-Match", ifMatch)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatalf("patchEntity do: %v", err)
+		return nil, fmt.Errorf("patchEntity do: %w", err)
+	}
+	return resp, nil
+}
+
+// patchEntity is the test-goroutine form of patchEntityRaw.
+func patchEntity(t *testing.T, path, contentType, ifMatch, body string) *http.Response {
+	t.Helper()
+	resp, err := patchEntityRaw(e2eCtx(t), path, contentType, ifMatch, body)
+	if err != nil {
+		t.Fatalf("%v", err)
 	}
 	return resp
 }
@@ -343,44 +356,42 @@ func TestE2E_EntityPatch_ConcurrentConflict(t *testing.T) {
 		`{"name":"Race","amount":1,"status":"draft"}`)
 
 	type patchResult struct {
-		status int
+		res    httpResult
 		amount int // 100 or 200 — which value this goroutine tried to set
 	}
 	results := [2]patchResult{}
+	amounts := [2]int{100, 200}
+	ctx := e2eCtx(t)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	go func() {
-		defer wg.Done()
-		resp := patchEntity(t,
-			fmt.Sprintf("/api/entity/JSON/%s", entityID),
-			"application/merge-patch+json",
-			createTxID,
-			`{"amount":100}`,
-		)
-		readBody(t, resp)
-		results[0] = patchResult{status: resp.StatusCode, amount: 100}
-	}()
-	go func() {
-		defer wg.Done()
-		resp := patchEntity(t,
-			fmt.Sprintf("/api/entity/JSON/%s", entityID),
-			"application/merge-patch+json",
-			createTxID,
-			`{"amount":200}`,
-		)
-		readBody(t, resp)
-		results[1] = patchResult{status: resp.StatusCode, amount: 200}
-	}()
+	for i, amount := range amounts {
+		go func(slot, amount int) {
+			defer wg.Done()
+			results[slot] = patchResult{
+				res: resultOf(patchEntityRaw(ctx,
+					fmt.Sprintf("/api/entity/JSON/%s", entityID),
+					"application/merge-patch+json",
+					createTxID,
+					fmt.Sprintf(`{"amount":%d}`, amount),
+				)),
+				amount: amount,
+			}
+		}(i, amount)
+	}
 	wg.Wait()
 
 	// Exactly one goroutine must have won (200); the other must have been
 	// rejected with 409 (Conflict) or 412 (Precondition Failed).
+	// Assert on the test goroutine — Fatal is only legal here.
 	var winnerAmount int
 	var successCount int
 	for _, r := range results {
-		switch r.status {
+		if r.res.err != nil {
+			t.Fatalf("concurrent PATCH (amount=%d): %v", r.amount, r.res.err)
+		}
+		switch r.res.status {
 		case http.StatusOK:
 			successCount++
 			winnerAmount = r.amount
@@ -388,7 +399,7 @@ func TestE2E_EntityPatch_ConcurrentConflict(t *testing.T) {
 			// expected loser codes
 		default:
 			t.Errorf("concurrent PATCH goroutine (amount=%d): unexpected status %d; want 200, 409, or 412",
-				r.amount, r.status)
+				r.amount, r.res.status)
 		}
 	}
 	if successCount != 1 {

--- a/internal/e2e/entity_patch_test.go
+++ b/internal/e2e/entity_patch_test.go
@@ -287,7 +287,8 @@ func TestE2E_EntityPatch_MergeOrdering_WithProcessor(t *testing.T) {
 			}
 		}]
 	}`, procName)
-	setupModelWithWorkflow(t, model, wf)
+	// The processor writes `seenAmount`; the model must declare it.
+	setupModelSampleWithWorkflow(t, model, workflowSampleWith(`"seenAmount": 0`), wf)
 
 	entityID, createTxID := createEntityE2EWithTxID(t, model, 1,
 		`{"name":"Charlie","amount":50,"status":"draft"}`)

--- a/internal/e2e/entity_request_body_test.go
+++ b/internal/e2e/entity_request_body_test.go
@@ -32,3 +32,36 @@ func TestCreateCollection_RejectsNonArray(t *testing.T) {
 		t.Fatalf("non-array collection: expected 400, got %d: %s", resp.StatusCode, readBody(t, resp))
 	}
 }
+
+// TestCreate_MalformedJSON_400 asserts a syntactically invalid body is
+// rejected at the boundary with an RFC 9457 400 — not persisted, not a 500.
+func TestCreate_MalformedJSON_400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	const model = "e2e-create-malformed"
+	importModel(t, model, 1)
+
+	bodies := map[string]string{
+		"truncated-object": `{"x":1`,
+		"not-json":         `this is not json`,
+		"trailing-garbage": `{"x":1}}}`,
+		"bare-empty":       ``,
+	}
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model), body)
+			respBody := readBody(t, resp)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("malformed create: expected 400, got %d: %s", resp.StatusCode, respBody)
+			}
+			assertErrorCode(t, respBody, "BAD_REQUEST")
+		})
+	}
+
+	// Nothing may have been persisted by any of the rejected requests.
+	if count := queryDB(t, "test-tenant",
+		"SELECT count(*) FROM entities WHERE model_name = $1 AND NOT deleted", model); count != 0 {
+		t.Errorf("expected 0 entities after malformed creates, got %d", count)
+	}
+}

--- a/internal/e2e/entity_unstorable_number_dup_test.go
+++ b/internal/e2e/entity_unstorable_number_dup_test.go
@@ -1,0 +1,197 @@
+package e2e_test
+
+// Coverage for the last two members of the "valid JSON that cannot be stored
+// consistently" family: numbers outside PostgreSQL's numeric range, and
+// duplicate object names.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// setupUnboundModel imports a model whose "big" field infers UNBOUND_INTEGER
+// and "dec" infers UNBOUND_DECIMAL, then locks it and attaches a trivial
+// workflow. The sample matters: on a plain INTEGER field an over-range literal
+// is rejected earlier with 400 INCOMPATIBLE_TYPE and never reaches the store,
+// so a test built on the standard sample would pass for the wrong reason.
+func setupUnboundModel(t *testing.T, model string) {
+	t.Helper()
+	resp := doAuth(t, http.MethodPost,
+		fmt.Sprintf("/api/model/import/JSON/SAMPLE_DATA/%s/1", model),
+		`{"name":"x","big":1e400,"dec":1e-400,"status":"d"}`)
+	if body := readBody(t, resp); resp.StatusCode != http.StatusOK {
+		t.Fatalf("import unbound model: %d %s", resp.StatusCode, body)
+	}
+	resp = doAuth(t, http.MethodPut, fmt.Sprintf("/api/model/%s/1/lock", model), "")
+	if body := readBody(t, resp); resp.StatusCode != http.StatusOK {
+		t.Fatalf("lock unbound model: %d %s", resp.StatusCode, body)
+	}
+	resp = doAuth(t, http.MethodPost, fmt.Sprintf("/api/model/%s/1/workflow/import", model), `{
+		"importMode":"REPLACE",
+		"workflows":[{"version":"1.1","name":"unbound-wf","initialState":"NONE","active":true,
+			"states":{"NONE":{"transitions":[{"name":"init","next":"CREATED","manual":false}]},"CREATED":{}}}]}`)
+	if body := readBody(t, resp); resp.StatusCode != http.StatusOK {
+		t.Fatalf("import workflow: %d %s", resp.StatusCode, body)
+	}
+}
+
+// TestEntity_NumberOutOfRange_400 asserts a literal PostgreSQL numeric cannot
+// hold is rejected at the boundary rather than failing inside the store.
+func TestEntity_NumberOutOfRange_400(t *testing.T) {
+	const model = "e2e-num-range"
+	setupUnboundModel(t, model)
+	path := fmt.Sprintf("/api/entity/JSON/%s/1", model)
+
+	rejected := map[string]string{
+		"weight-just-over":   `{"name":"x","big":1e131072,"dec":1,"status":"d"}`,
+		"weight-far-over":    `{"name":"x","big":1e1000000,"dec":1,"status":"d"}`,
+		"weight-via-digits":  `{"name":"x","big":12e131071,"dec":1,"status":"d"}`,
+		"scale-just-over":    `{"name":"x","big":1,"dec":1e-16384,"status":"d"}`,
+		"scale-via-fraction": `{"name":"x","big":1,"dec":1.5e-16383,"status":"d"}`,
+	}
+	for name, body := range rejected {
+		t.Run("rejected/"+name, func(t *testing.T) {
+			resp := doAuth(t, http.MethodPost, path, body)
+			respBody := readBody(t, resp)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400 (a number no backend can store is a client error); body: %s",
+					resp.StatusCode, respBody)
+			}
+			assertErrorCode(t, respBody, "BAD_REQUEST")
+		})
+	}
+
+	// The guard must stop exactly at the limit, not before it.
+	accepted := map[string]string{
+		"weight-at-limit":     `{"name":"x","big":1e131071,"dec":1,"status":"d"}`,
+		"scale-at-limit":      `{"name":"x","big":1,"dec":1e-16383,"status":"d"}`,
+		"leading-zeros":       `{"name":"x","big":0.0001e131075,"dec":1,"status":"d"}`,
+		"zero-huge-exponent":  `{"name":"x","big":0e999999999,"dec":1,"status":"d"}`,
+		"high-precision":      `{"name":"x","big":123456789012345678901234567890,"dec":1,"status":"d"}`,
+		"ordinary-scientific": `{"name":"x","big":1e400,"dec":1.5e-400,"status":"d"}`,
+	}
+	for name, body := range accepted {
+		t.Run("accepted/"+name, func(t *testing.T) {
+			resp := doAuth(t, http.MethodPost, path, body)
+			respBody := readBody(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d, want 200 — this number is storable; body: %s", resp.StatusCode, respBody)
+			}
+		})
+	}
+}
+
+// TestEntity_DuplicateKeys_400 asserts duplicate object names are rejected on
+// every write path.
+//
+// Left accepted, a duplicated name is read as the LAST occurrence by schema
+// validation and the GET response, and as the FIRST by the criterion evaluator
+// and search — so an entity can be reported as holding one value while its
+// workflow transition was decided on another. Measured before this fix: a
+// criterion `amount == 5` did not fire for an entity the API reports as
+// amount=5, leaving it in the wrong state with nothing logged.
+func TestEntity_DuplicateKeys_400(t *testing.T) {
+	const model = "e2e-dup-keys"
+	setupUnstorableModel(t, model)
+
+	entityID := createEntityE2E(t, model, 1, `{"name":"ok","amount":1,"status":"new"}`)
+	dup := `{"name":"x","amount":"not-a-number","amount":5,"status":"new"}`
+
+	writes := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"create", http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model), dup},
+		{"create-batch-array", http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model), "[" + dup + "]"},
+		{"create-collection", http.MethodPost, "/api/entity/JSON",
+			fmt.Sprintf(`[{"model":{"name":%q,"version":1},"payload":%q}]`, model, dup)},
+		{"update", http.MethodPut, fmt.Sprintf("/api/entity/JSON/%s", entityID), dup},
+		{"update-collection", http.MethodPut, "/api/entity/JSON",
+			fmt.Sprintf(`[{"id":%q,"payload":%q}]`, entityID, dup)},
+	}
+	for _, w := range writes {
+		t.Run(w.name, func(t *testing.T) {
+			resp := doAuth(t, w.method, w.path, w.body)
+			body := readBody(t, resp)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400 — a duplicated name is read differently by different subsystems; body: %s",
+					resp.StatusCode, body)
+			}
+			assertErrorCode(t, body, "BAD_REQUEST")
+		})
+	}
+
+}
+
+// TestEntity_RepeatedNamesInDifferentObjectsAccepted guards the duplicate-key
+// rejection from over-reaching. A name repeated in sibling objects, across
+// array elements, or at different depths is perfectly ordinary JSON — only a
+// name repeated within ONE object is ambiguous.
+//
+// This needs its own model whose sample declares the nested shapes; on a model
+// that does not declare them the write is rejected by schema validation before
+// the guard is reached, which would make the test pass for the wrong reason.
+func TestEntity_RepeatedNamesInDifferentObjectsAccepted(t *testing.T) {
+	const model = "e2e-dup-keys-ok"
+	resp := doAuth(t, http.MethodPost,
+		fmt.Sprintf("/api/model/import/JSON/SAMPLE_DATA/%s/1", model),
+		`{"name":"x","a":{"k":1},"b":{"k":2},"xs":[{"k":1}],"k":{"k":1}}`)
+	if body := readBody(t, resp); resp.StatusCode != http.StatusOK {
+		t.Fatalf("import: %d %s", resp.StatusCode, body)
+	}
+	resp = doAuth(t, http.MethodPut, fmt.Sprintf("/api/model/%s/1/lock", model), "")
+	readBody(t, resp)
+	resp = doAuth(t, http.MethodPost, fmt.Sprintf("/api/model/%s/1/workflow/import", model), `{
+		"importMode":"REPLACE",
+		"workflows":[{"version":"1.1","name":"dupok-wf","initialState":"NONE","active":true,
+			"states":{"NONE":{"transitions":[{"name":"init","next":"CREATED","manual":false}]},"CREATED":{}}}]}`)
+	readBody(t, resp)
+
+	ok := map[string]string{
+		"sibling-objects":  `{"name":"x","a":{"k":1},"b":{"k":2},"xs":[{"k":1}],"k":{"k":1}}`,
+		"array-elements":   `{"name":"x","a":{"k":1},"b":{"k":1},"xs":[{"k":1},{"k":2}],"k":{"k":1}}`,
+		"different-depths": `{"name":"x","a":{"k":9},"b":{"k":9},"xs":[{"k":9}],"k":{"k":9}}`,
+	}
+	for name, body := range ok {
+		t.Run(name, func(t *testing.T) {
+			resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model), body)
+			respBody := readBody(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d, want 200 — no name is repeated within one object; body: %s",
+					resp.StatusCode, respBody)
+			}
+		})
+	}
+}
+
+// TestEntity_DuplicateKeys_NoEntityLeftBehind confirms the rejected writes
+// persisted nothing, so the corruption path is closed rather than merely
+// reported.
+func TestEntity_DuplicateKeys_NoEntityLeftBehind(t *testing.T) {
+	const model = "e2e-dup-keys-clean"
+	setupUnstorableModel(t, model)
+
+	resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model),
+		`{"name":"x","amount":"not-a-number","amount":5,"status":"new"}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("duplicate-key create: status=%d, want 400; body: %s", resp.StatusCode, body)
+	}
+
+	resp = doAuth(t, http.MethodGet, fmt.Sprintf("/api/entity/%s/1", model), "")
+	listBody := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: status=%d; body: %s", resp.StatusCode, listBody)
+	}
+	var entities []map[string]any
+	if err := json.Unmarshal([]byte(listBody), &entities); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(entities) != 0 {
+		t.Errorf("expected no entities after the rejected write, got %d", len(entities))
+	}
+}

--- a/internal/e2e/entity_unstorable_test.go
+++ b/internal/e2e/entity_unstorable_test.go
@@ -1,0 +1,185 @@
+package e2e_test
+
+// Coverage for the remaining members of the "valid JSON that no backend can
+// store" family, and for the empty-document round-trip.
+//
+// An unpaired UTF-16 surrogate escape and a byte sequence that is not valid
+// UTF-8 are both accepted by Go's JSON parser and both rejected by PostgreSQL
+// text/jsonb, so they used to reach the store and come back as 500 with a
+// support ticket. They are client input errors: 400.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func setupUnstorableModel(t *testing.T, model string) {
+	t.Helper()
+	setupModelWithWorkflow(t, model, `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "unstorable-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {}
+			}
+		}]
+	}`)
+}
+
+// TestEntity_UnstorableStrings_400 asserts every write path rejects an unpaired
+// surrogate and invalid UTF-8 with 400 rather than failing in the store.
+//
+// As in the NUL test, the collection bodies use %q because those endpoints take
+// the payload as a JSON-encoded string; %s would be rejected by the outer array
+// parser and never reach the guard.
+func TestEntity_UnstorableStrings_400(t *testing.T) {
+	const model = "e2e-unstorable-str"
+	setupUnstorableModel(t, model)
+
+	entityID := createEntityE2E(t, model, 1, `{"name":"ok","amount":1,"status":"new"}`)
+
+	payloads := map[string]string{
+		"lone-high-surrogate": "{\"name\":\"a\\ud800b\",\"amount\":1,\"status\":\"new\"}",
+		"lone-low-surrogate":  "{\"name\":\"a\\udc00b\",\"amount\":1,\"status\":\"new\"}",
+		"invalid-utf8":        "{\"name\":\"a\xffb\",\"amount\":1,\"status\":\"new\"}",
+	}
+
+	for name, payload := range payloads {
+		writes := []struct {
+			path   string
+			method string
+			path2  string
+			body   string
+		}{
+			{path: "create", method: http.MethodPost, path2: fmt.Sprintf("/api/entity/JSON/%s/1", model), body: payload},
+			{path: "create-batch-array", method: http.MethodPost, path2: fmt.Sprintf("/api/entity/JSON/%s/1", model), body: "[" + payload + "]"},
+			{path: "create-collection", method: http.MethodPost, path2: "/api/entity/JSON",
+				body: fmt.Sprintf(`[{"model":{"name":%q,"version":1},"payload":%q}]`, model, payload)},
+			{path: "update", method: http.MethodPut, path2: fmt.Sprintf("/api/entity/JSON/%s", entityID), body: payload},
+			{path: "update-collection", method: http.MethodPut, path2: "/api/entity/JSON",
+				body: fmt.Sprintf(`[{"id":%q,"payload":%q}]`, entityID, payload)},
+		}
+		for _, w := range writes {
+			t.Run(name+"/"+w.path, func(t *testing.T) {
+				resp := doAuth(t, w.method, w.path2, w.body)
+				body := readBody(t, resp)
+				if resp.StatusCode != http.StatusBadRequest {
+					t.Fatalf("status=%d, want 400 (unstorable text is a client error, not a storage failure); body: %s",
+						resp.StatusCode, body)
+				}
+				assertErrorCode(t, body, "BAD_REQUEST")
+			})
+		}
+	}
+
+	// Nothing may have been persisted, and the clean entity must be untouched.
+	if count := queryDB(t, "test-tenant",
+		"SELECT count(*) FROM entities WHERE model_name = $1 AND NOT deleted", model); count != 1 {
+		t.Errorf("expected exactly the 1 clean entity after the rejected writes, got %d", count)
+	}
+	if data := getEntityData(t, entityID, ""); data["name"] != "ok" {
+		t.Errorf("existing entity modified by a rejected write: name=%v", data["name"])
+	}
+}
+
+// TestEntity_StorableTextStillAccepted guards the rejection from over-reaching.
+// A correctly paired surrogate is ordinary text, and so is a client legitimately
+// sending U+FFFD.
+func TestEntity_StorableTextStillAccepted(t *testing.T) {
+	const model = "e2e-unstorable-ok"
+	setupUnstorableModel(t, model)
+
+	bodies := map[string]string{
+		"valid-surrogate-pair":   "{\"name\":\"a\\ud83d\\ude00b\",\"amount\":1,\"status\":\"new\"}",
+		"literal-emoji":          "{\"name\":\"a😀b\",\"amount\":1,\"status\":\"new\"}",
+		"client-sent-U+FFFD":     "{\"name\":\"a\\ufffdb\",\"amount\":1,\"status\":\"new\"}",
+		"backslash-then-ud800":   "{\"name\":\"a\\\\ud800b\",\"amount\":1,\"status\":\"new\"}",
+		"accented-latin":         "{\"name\":\"caf\\u00e9\",\"amount\":1,\"status\":\"new\"}",
+		"tab-newline-and-quotes": "{\"name\":\"a\\tb\\n\\\"c\\\"\",\"amount\":1,\"status\":\"new\"}",
+	}
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model), body)
+			respBody := readBody(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d, want 200 — this text is storable; body: %s", resp.StatusCode, respBody)
+			}
+		})
+	}
+}
+
+// TestEntity_EmptyDocument_RoundTrips covers the defect where an empty payload
+// wrote successfully and then made itself — and every list of its model —
+// permanently unreadable.
+//
+// postgres merges _meta into the domain data, so `{}` was stored as
+// `{"_meta":...}`; on read, _meta was removed and nothing remained, so the
+// entity's Data came back empty. Decoding an empty slice is io.EOF, which
+// surfaced as 500 SERVER_ERROR. memory and sqlite always round-tripped `{}`.
+func TestEntity_EmptyDocument_RoundTrips(t *testing.T) {
+	const model = "e2e-empty-doc"
+	setupUnstorableModel(t, model)
+
+	resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model), `{}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create {}: status=%d, want 200; body: %s", resp.StatusCode, body)
+	}
+	var created []map[string]any
+	if err := json.Unmarshal([]byte(body), &created); err != nil || len(created) == 0 {
+		t.Fatalf("create {}: unparseable response: %s", body)
+	}
+	ids, _ := created[0]["entityIds"].([]any)
+	if len(ids) == 0 {
+		t.Fatalf("create {}: no entityIds: %s", body)
+	}
+	emptyID, _ := ids[0].(string)
+
+	// The entity itself must be readable.
+	resp = doAuth(t, http.MethodGet, "/api/entity/"+emptyID, "")
+	body = readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET the empty entity: status=%d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	// And so must the whole model's list — this is what a single empty document
+	// used to take down.
+	resp = doAuth(t, http.MethodGet, fmt.Sprintf("/api/entity/%s/1", model), "")
+	body = readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("LIST the model containing an empty document: status=%d, want 200; body: %s",
+			resp.StatusCode, body)
+	}
+}
+
+// TestEntity_EmptyDocumentUpdate_DoesNotBrickEntity covers the more damaging
+// face of the same defect: updating a healthy, readable entity to `{}` made
+// that entity permanently unreadable.
+func TestEntity_EmptyDocumentUpdate_DoesNotBrickEntity(t *testing.T) {
+	const model = "e2e-empty-doc-update"
+	setupUnstorableModel(t, model)
+
+	entityID := createEntityE2E(t, model, 1, `{"name":"ok","amount":1,"status":"new"}`)
+
+	resp := doAuth(t, http.MethodPut, fmt.Sprintf("/api/entity/JSON/%s", entityID), `{}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT {}: status=%d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	resp = doAuth(t, http.MethodGet, "/api/entity/"+entityID, "")
+	body = readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET after updating to {}: status=%d, want 200 — the entity must not become unreadable; body: %s",
+			resp.StatusCode, body)
+	}
+
+	resp = doAuth(t, http.MethodGet, fmt.Sprintf("/api/entity/%s/1", model), "")
+	body = readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("LIST after updating an entity to {}: status=%d, want 200; body: %s", resp.StatusCode, body)
+	}
+}

--- a/internal/e2e/goroutinesafety/checker_test.go
+++ b/internal/e2e/goroutinesafety/checker_test.go
@@ -1,0 +1,165 @@
+package goroutinesafety
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestChecker_Fixtures pins the analyser's own behaviour: the guard over the
+// E2E suite is only meaningful if it actually fires. Each case is a complete
+// source file; wantViolations lists a distinguishing substring per expected
+// finding, in sorted order.
+func TestChecker_Fixtures(t *testing.T) {
+	cases := []struct {
+		name           string
+		src            string
+		wantViolations []string
+	}{
+		{
+			name: "direct t.Fatalf inside go func",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	go func() { t.Fatalf("boom") }()
+}`,
+			wantViolations: []string{"calls t.Fatalf from a goroutine"},
+		},
+		{
+			name: "t handed to a helper inside go func",
+			src: `package p
+import "testing"
+func helper(t *testing.T) {}
+func TestX(t *testing.T) {
+	go func() { helper(t) }()
+}`,
+			wantViolations: []string{"passes t to helper(…) from a goroutine"},
+		},
+		{
+			name: "t handed to a method inside go func",
+			src: `package p
+import "testing"
+type h struct{}
+func TestX(t *testing.T) {
+	var x h
+	go func() { x.Create(t, 1) }()
+}`,
+			wantViolations: []string{"passes t to x.Create(…) from a goroutine"},
+		},
+		{
+			name: "go f(t) passes t to a concurrent body",
+			src: `package p
+import "testing"
+func worker(t *testing.T) {}
+func TestX(t *testing.T) {
+	go worker(t)
+}`,
+			wantViolations: []string{"passes t to a goroutine"},
+		},
+		{
+			name: "violation nested in a closure inside the goroutine",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	go func() {
+		func() { t.FailNow() }()
+	}()
+}`,
+			wantViolations: []string{"calls t.FailNow from a goroutine"},
+		},
+		{
+			name: "subtest t shadows the outer t",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	t.Run("sub", func(t *testing.T) {
+		go func() { t.Skip("nope") }()
+	})
+}`,
+			wantViolations: []string{"calls t.Skip from a goroutine"},
+		},
+		{
+			name: "testing.TB parameter is covered too",
+			src: `package p
+import "testing"
+func withTB(tb testing.TB) {
+	go func() { tb.Fatal("boom") }()
+}`,
+			wantViolations: []string{"calls tb.Fatal from a goroutine"},
+		},
+		{
+			name: "goroutine-safe methods are allowed",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	go func() {
+		t.Errorf("bad")
+		t.Logf("note")
+		t.Error("bad")
+		t.Log("note")
+		_ = t.Name()
+		_ = t.Failed()
+	}()
+}`,
+		},
+		{
+			name: "helpers that do not take t are allowed",
+			src: `package p
+import "testing"
+func rawHelper(path string) (int, error) { return 0, nil }
+func TestX(t *testing.T) {
+	done := make(chan int, 1)
+	go func() {
+		status, _ := rawHelper("/x")
+		done <- status
+	}()
+	if <-done != 200 {
+		t.Fatal("bad status")
+	}
+}`,
+		},
+		{
+			name: "Fatal on the test goroutine is allowed",
+			src: `package p
+import "testing"
+func helper(t *testing.T) { t.Fatal("boom") }
+func TestX(t *testing.T) {
+	helper(t)
+	t.Fatalf("done")
+}`,
+		},
+		{
+			name: "arguments of a go statement evaluate on the test goroutine",
+			src: `package p
+import "testing"
+func value(t *testing.T) int { return 1 }
+func worker(v int) {}
+func TestX(t *testing.T) {
+	go worker(value(t))
+}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "fixture.go", tc.src, 0)
+			if err != nil {
+				t.Fatalf("parse fixture: %v", err)
+			}
+
+			got := analyze(fset, []*ast.File{file})
+			if len(got) != len(tc.wantViolations) {
+				t.Fatalf("got %d violation(s), want %d\ngot:  %v\nwant: %v",
+					len(got), len(tc.wantViolations), got, tc.wantViolations)
+			}
+			for i, want := range tc.wantViolations {
+				if !strings.Contains(got[i], want) {
+					t.Errorf("violation %d = %q; want it to contain %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}

--- a/internal/e2e/goroutinesafety/checker_test.go
+++ b/internal/e2e/goroutinesafety/checker_test.go
@@ -56,7 +56,37 @@ func worker(t *testing.T) {}
 func TestX(t *testing.T) {
 	go worker(t)
 }`,
-			wantViolations: []string{"passes t to a goroutine"},
+			wantViolations: []string{"passes t to worker(…) from a goroutine"},
+		},
+		{
+			name: "go t.Fatal directly",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	go t.Fatal("boom")
+}`,
+			wantViolations: []string{"calls t.Fatal from a goroutine"},
+		},
+		{
+			name: "aliased t used in a goroutine",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	tt := t
+	go func() { tt.Fatalf("boom") }()
+}`,
+			wantViolations: []string{"calls tt.Fatalf from a goroutine"},
+		},
+		{
+			name: "aliased t handed to a helper in a goroutine",
+			src: `package p
+import "testing"
+func helper(t *testing.T) {}
+func TestX(t *testing.T) {
+	tt := t
+	go func() { helper(tt) }()
+}`,
+			wantViolations: []string{"passes tt to helper(…) from a goroutine"},
 		},
 		{
 			name: "violation nested in a closure inside the goroutine",

--- a/internal/e2e/goroutinesafety/doc.go
+++ b/internal/e2e/goroutinesafety/doc.go
@@ -1,6 +1,12 @@
 // Package goroutinesafety holds a static guard over the E2E suite's own test
 // sources: a *testing.T must not be used from a goroutine other than the one
-// running the test.
+// running the test, because Fatal/FailNow/Skip stop only the calling goroutine.
+//
+// The guard is syntactic and covers `go` statements in package
+// github.com/cyoda-platform/cyoda-go/internal/e2e only. See the doc comment on
+// TestNoTestingTUseInGoroutines for the exact scope and its known blind spots
+// — a green run means "no `go` statement hands over a t", not "no goroutine
+// anywhere can reach a t".
 //
 // It lives in its own package (rather than in internal/e2e) so it runs under
 // `go test -short`, which the E2E TestMain exits early from — the guard is

--- a/internal/e2e/goroutinesafety/doc.go
+++ b/internal/e2e/goroutinesafety/doc.go
@@ -1,0 +1,8 @@
+// Package goroutinesafety holds a static guard over the E2E suite's own test
+// sources: a *testing.T must not be used from a goroutine other than the one
+// running the test.
+//
+// It lives in its own package (rather than in internal/e2e) so it runs under
+// `go test -short`, which the E2E TestMain exits early from — the guard is
+// pure source analysis and needs neither Docker nor a database.
+package goroutinesafety

--- a/internal/e2e/goroutinesafety/goroutinesafety_test.go
+++ b/internal/e2e/goroutinesafety/goroutinesafety_test.go
@@ -1,0 +1,202 @@
+package goroutinesafety
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// e2eSourceDir is the package whose sources this guard analyses.
+const e2eSourceDir = ".."
+
+// safeTMethods are the *testing.T methods that the testing package documents
+// as callable from any goroutine. Everything else — Fatal, FailNow, Skip and
+// friends — terminates only the calling goroutine via runtime.Goexit, so the
+// test keeps running past a failure it believes it aborted on.
+var safeTMethods = map[string]bool{
+	"Error":  true,
+	"Errorf": true,
+	"Fail":   true,
+	"Failed": true,
+	"Helper": true,
+	"Log":    true,
+	"Logf":   true,
+	"Name":   true,
+}
+
+// TestNoTestingTUseInGoroutines asserts that no goroutine spawned by the E2E
+// suite touches a *testing.T except through safeTMethods.
+//
+// The rule is deliberately stricter than "no direct t.Fatal in a go func":
+// passing t to a helper hides the Fatal one call away, which is exactly how
+// doAuth/getToken/readBody smuggled t.Fatalf into concurrent tests. The
+// goroutine-safe shape is to return values, collect them, and assert on the
+// test goroutine after wg.Wait().
+func TestNoTestingTUseInGoroutines(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, e2eSourceDir, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", e2eSourceDir, err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatalf("no packages parsed from %s", e2eSourceDir)
+	}
+
+	var files []*ast.File
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			files = append(files, file)
+		}
+	}
+
+	if violations := analyze(fset, files); len(violations) > 0 {
+		t.Errorf("*testing.T used from a goroutine in %d place(s) — "+
+			"Fatal/FailNow/Skip only stop the calling goroutine, so the test "+
+			"races on past the failure. Return the outcome from the goroutine "+
+			"and assert it on the test goroutine instead:\n\t%s",
+			len(violations), strings.Join(violations, "\n\t"))
+	}
+}
+
+// analyze reports every *testing.T use that happens on a non-test goroutine,
+// sorted for stable output.
+func analyze(fset *token.FileSet, files []*ast.File) []string {
+	c := &checker{fset: fset}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			c.walk(fd.Body, tNamesOf(fd.Type, nil), false)
+		}
+	}
+	sort.Strings(c.violations)
+	return c.violations
+}
+
+type checker struct {
+	fset       *token.FileSet
+	violations []string
+}
+
+func (c *checker) reportf(pos token.Pos, format string, args ...any) {
+	p := c.fset.Position(pos)
+	loc := fmt.Sprintf("%s:%d", filepath.Join("internal", "e2e", filepath.Base(p.Filename)), p.Line)
+	c.violations = append(c.violations, loc+": "+fmt.Sprintf(format, args...))
+}
+
+// walk traverses n, tracking the *testing.T identifiers in scope and whether
+// the code being visited runs on a goroutine other than the test's.
+func (c *checker) walk(n ast.Node, tNames map[string]bool, inGoroutine bool) {
+	ast.Inspect(n, func(node ast.Node) bool {
+		switch v := node.(type) {
+		case *ast.FuncLit:
+			// A literal inherits the enclosing scope's t and goroutine-ness,
+			// plus any *testing.T of its own (e.g. a t.Run subtest body).
+			c.walk(v.Body, tNamesOf(v.Type, tNames), inGoroutine)
+			return false
+
+		case *ast.GoStmt:
+			// Arguments are evaluated on the current goroutine; only the
+			// called function value runs on the new one.
+			for _, arg := range v.Call.Args {
+				c.walk(arg, tNames, inGoroutine)
+			}
+			// `go f(t)` hands t to a function body that runs concurrently.
+			if !inGoroutine {
+				for _, arg := range v.Call.Args {
+					if id, ok := arg.(*ast.Ident); ok && tNames[id.Name] {
+						c.reportf(arg.Pos(), "go %s(…) passes %s to a goroutine", exprString(v.Call.Fun), id.Name)
+					}
+				}
+			}
+			c.walk(v.Call.Fun, tNames, true)
+			return false
+
+		case *ast.CallExpr:
+			if inGoroutine {
+				c.checkCall(v, tNames)
+			}
+			return true
+		}
+		return true
+	})
+}
+
+// checkCall flags any use of an in-scope *testing.T inside a goroutine: an
+// unsafe method on it, or handing it to another function that may Fatal.
+func (c *checker) checkCall(call *ast.CallExpr, tNames map[string]bool) {
+	if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+		if id, ok := sel.X.(*ast.Ident); ok && tNames[id.Name] && !safeTMethods[sel.Sel.Name] {
+			c.reportf(call.Pos(), "calls %s.%s from a goroutine", id.Name, sel.Sel.Name)
+			return
+		}
+	}
+	for _, arg := range call.Args {
+		if id, ok := arg.(*ast.Ident); ok && tNames[id.Name] {
+			c.reportf(call.Pos(), "passes %s to %s(…) from a goroutine", id.Name, exprString(call.Fun))
+		}
+	}
+}
+
+// tNamesOf returns inherited plus the *testing.T/testing.TB parameter names
+// declared by fn.
+func tNamesOf(fn *ast.FuncType, inherited map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(inherited)+1)
+	for k := range inherited {
+		out[k] = true
+	}
+	if fn.Params == nil {
+		return out
+	}
+	for _, field := range fn.Params.List {
+		if !isTestingT(field.Type) {
+			continue
+		}
+		for _, name := range field.Names {
+			if name.Name != "_" {
+				out[name.Name] = true
+			}
+		}
+	}
+	return out
+}
+
+// isTestingT reports whether expr denotes *testing.T, *testing.B or testing.TB.
+func isTestingT(expr ast.Expr) bool {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "testing" {
+		return false
+	}
+	switch sel.Sel.Name {
+	case "T", "B", "TB":
+		return true
+	}
+	return false
+}
+
+// exprString renders a callee expression for the violation message.
+func exprString(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return exprString(v.X) + "." + v.Sel.Name
+	case *ast.FuncLit:
+		return "func literal"
+	}
+	return "call"
+}

--- a/internal/e2e/goroutinesafety/goroutinesafety_test.go
+++ b/internal/e2e/goroutinesafety/goroutinesafety_test.go
@@ -19,17 +19,19 @@ const e2eSourceDir = ".."
 // friends — terminates only the calling goroutine via runtime.Goexit, so the
 // test keeps running past a failure it believes it aborted on.
 var safeTMethods = map[string]bool{
-	"Error":  true,
-	"Errorf": true,
-	"Fail":   true,
-	"Failed": true,
-	"Helper": true,
-	"Log":    true,
-	"Logf":   true,
-	"Name":   true,
+	"Deadline": true,
+	"Error":    true,
+	"Errorf":   true,
+	"Fail":     true,
+	"Failed":   true,
+	"Helper":   true,
+	"Log":      true,
+	"Logf":     true,
+	"Name":     true,
+	"Skipped":  true,
 }
 
-// TestNoTestingTUseInGoroutines asserts that no goroutine spawned by the E2E
+// TestNoTestingTUseInGoroutines asserts that no `go` statement in the E2E
 // suite touches a *testing.T except through safeTMethods.
 //
 // The rule is deliberately stricter than "no direct t.Fatal in a go func":
@@ -37,6 +39,21 @@ var safeTMethods = map[string]bool{
 // doAuth/getToken/readBody smuggled t.Fatalf into concurrent tests. The
 // goroutine-safe shape is to return values, collect them, and assert on the
 // test goroutine after wg.Wait().
+//
+// Scope, stated precisely so the guard is not mistaken for more than it is.
+// It reasons syntactically about `go` statements in this one package, and
+// tracks *testing.T through function parameters and direct aliases (tt := t).
+// It does NOT catch a t that reaches another goroutine by:
+//   - being stored in a struct field or sent over a channel,
+//   - being captured by a func literal that some registrar invokes later on
+//     its own goroutine — notably callbackHarness.RegisterProc/RegisterCriterion/
+//     RegisterFunction bodies, which run on the compute-member goroutine,
+//   - a method value (f := t.Fatalf) called elsewhere.
+//
+// Those need type/callgraph analysis. The syntactic check covers the class
+// that actually regressed here; the blind spots are listed so a reviewer knows
+// to look for them by hand rather than trusting a green run to mean more than
+// it does.
 func TestNoTestingTUseInGoroutines(t *testing.T) {
 	fset := token.NewFileSet()
 	pkgs, err := parser.ParseDir(fset, e2eSourceDir, nil, 0)
@@ -102,20 +119,31 @@ func (c *checker) walk(n ast.Node, tNames map[string]bool, inGoroutine bool) {
 			c.walk(v.Body, tNamesOf(v.Type, tNames), inGoroutine)
 			return false
 
+		case *ast.AssignStmt:
+			// Track aliases (`tt := t`) so a goroutine using the alias is still
+			// caught. Over-approximates across sibling scopes, which is the
+			// safe direction for a lint.
+			for i, rhs := range v.Rhs {
+				id, ok := rhs.(*ast.Ident)
+				if !ok || !tNames[id.Name] || i >= len(v.Lhs) {
+					continue
+				}
+				if lhs, ok := v.Lhs[i].(*ast.Ident); ok && lhs.Name != "_" {
+					tNames[lhs.Name] = true
+				}
+			}
+			return true
+
 		case *ast.GoStmt:
-			// Arguments are evaluated on the current goroutine; only the
-			// called function value runs on the new one.
+			// Arguments are evaluated on the current goroutine, so walk them
+			// with the enclosing goroutine-ness...
 			for _, arg := range v.Call.Args {
 				c.walk(arg, tNames, inGoroutine)
 			}
-			// `go f(t)` hands t to a function body that runs concurrently.
-			if !inGoroutine {
-				for _, arg := range v.Call.Args {
-					if id, ok := arg.(*ast.Ident); ok && tNames[id.Name] {
-						c.reportf(arg.Pos(), "go %s(…) passes %s to a goroutine", exprString(v.Call.Fun), id.Name)
-					}
-				}
-			}
+			// ...but the call itself runs on the new goroutine. This covers
+			// both `go t.Fatal(...)` (unsafe method on the receiver) and
+			// `go f(t)` (handing t to a concurrently-running body).
+			c.checkCall(v.Call, tNames)
 			c.walk(v.Call.Fun, tNames, true)
 			return false
 

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -47,18 +47,26 @@ func resultOf(resp *http.Response, err error) httpResult {
 	return httpResult{status: resp.StatusCode, body: string(raw)}
 }
 
-// e2eCtx returns a context carrying t for the OpenAPI validator middleware.
-// Build it on the test goroutine and pass it to the Raw helpers; the validator
-// only ever calls t.Errorf, which is safe from any goroutine.
+// e2eCtx returns the request context for a test's HTTP calls.
+//
+// It attaches t via openapivalidator.WithTestT for continuity with the
+// existing helpers, but note that this does NOT reach the validator: the
+// suite talks to a real httptest TCP listener (see TestMain), and the
+// middleware reads TestTFromContext(r.Context()) — the *server's* context,
+// which is built fresh per connection. A client-side context value cannot
+// cross the wire, so the validator's TestName is always "unknown" and its
+// enforce-mode t.Errorf never fires. That is pre-existing; wiring it up
+// needs the test identity carried in a header and resolved server-side.
+//
+// What the context is actually good for here is the standard thing —
+// cancellation and deadlines — and giving the Raw helpers an idiomatic
+// first parameter. Nothing about goroutine safety depends on it.
 func e2eCtx(t *testing.T) context.Context {
 	t.Helper()
 	return openapivalidator.WithTestT(context.Background(), t)
 }
 
-// e2eNewRequest creates an http.Request with the test name attached to the
-// request context via openapivalidator.WithTestT. The validator middleware
-// uses the captured *testing.T to call t.Errorf in -run-filtered enforce
-// mode (see openapivalidator/doc.go).
+// e2eNewRequest creates an http.Request bound to the test's context.
 func e2eNewRequest(t *testing.T, method, urlStr string, body io.Reader) (*http.Request, error) {
 	t.Helper()
 	return http.NewRequestWithContext(e2eCtx(t), method, urlStr, body)

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -14,73 +14,131 @@ import (
 	"github.com/cyoda-platform/cyoda-go/internal/e2e/openapivalidator"
 )
 
+// The helpers below come in two shapes. The `t`-taking form (doAuth, readBody,
+// …) aborts the test with t.Fatalf on transport failure and is the default for
+// sequential test code. The `Raw` form takes a context.Context and returns an
+// error instead; it is the only shape that may be used from a goroutine other
+// than the one running the test, because Fatal/FailNow only stop the calling
+// goroutine. The `t` form is a thin wrapper over the `Raw` form, so the request
+// behaviour (auth, retry-on-retryable-409) is defined exactly once.
+// internal/e2e/goroutinesafety enforces the split.
+
+// httpResult is an HTTP outcome captured off the test goroutine, for assertion
+// on the test goroutine after the concurrent phase has joined.
+type httpResult struct {
+	status int
+	body   string
+	err    error
+}
+
+// resultOf drains resp into an httpResult. It is written to consume the
+// (*http.Response, error) pair returned by the Raw helpers directly:
+//
+//	res := resultOf(doAuthRaw(ctx, http.MethodPost, path, payload))
+func resultOf(resp *http.Response, err error) httpResult {
+	if err != nil {
+		return httpResult{status: -1, err: err}
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return httpResult{status: resp.StatusCode, err: fmt.Errorf("read body: %w", err)}
+	}
+	return httpResult{status: resp.StatusCode, body: string(raw)}
+}
+
+// e2eCtx returns a context carrying t for the OpenAPI validator middleware.
+// Build it on the test goroutine and pass it to the Raw helpers; the validator
+// only ever calls t.Errorf, which is safe from any goroutine.
+func e2eCtx(t *testing.T) context.Context {
+	t.Helper()
+	return openapivalidator.WithTestT(context.Background(), t)
+}
+
 // e2eNewRequest creates an http.Request with the test name attached to the
 // request context via openapivalidator.WithTestT. The validator middleware
 // uses the captured *testing.T to call t.Errorf in -run-filtered enforce
 // mode (see openapivalidator/doc.go).
 func e2eNewRequest(t *testing.T, method, urlStr string, body io.Reader) (*http.Request, error) {
 	t.Helper()
-	req, err := http.NewRequest(method, urlStr, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(openapivalidator.WithTestT(req.Context(), t))
-	return req, nil
+	return http.NewRequestWithContext(e2eCtx(t), method, urlStr, body)
 }
 
-// getToken obtains a JWT token via client_credentials grant.
-// The token endpoint uses HTTP Basic Auth for client authentication.
-func getToken(t *testing.T, clientID, clientSecret string) string {
-	t.Helper()
+// getTokenRaw obtains a JWT token via client_credentials grant. The token
+// endpoint uses HTTP Basic Auth for client authentication.
+func getTokenRaw(ctx context.Context, clientID, clientSecret string) (string, error) {
 	data := url.Values{
 		"grant_type": {"client_credentials"},
 	}
-	req, err := e2eNewRequest(t, "POST", serverURL+"/api/oauth/token", strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", serverURL+"/api/oauth/token", strings.NewReader(data.Encode()))
 	if err != nil {
-		t.Fatalf("failed to create token request: %v", err)
+		return "", fmt.Errorf("create token request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(clientID, clientSecret)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatalf("token request failed: %v", err)
+		return "", fmt.Errorf("token request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("token request returned %d: %s", resp.StatusCode, body)
+		return "", fmt.Errorf("token request returned %d: %s", resp.StatusCode, body)
 	}
 	var result map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("failed to decode token response: %v", err)
+		return "", fmt.Errorf("decode token response: %w", err)
 	}
 	token, ok := result["access_token"].(string)
 	if !ok || token == "" {
-		t.Fatalf("no access_token in response: %v", result)
+		return "", fmt.Errorf("no access_token in response: %v", result)
+	}
+	return token, nil
+}
+
+// getToken is the test-goroutine form of getTokenRaw.
+func getToken(t *testing.T, clientID, clientSecret string) string {
+	t.Helper()
+	token, err := getTokenRaw(e2eCtx(t), clientID, clientSecret)
+	if err != nil {
+		t.Fatalf("get token: %v", err)
 	}
 	return token
 }
 
-// authRequest creates an authenticated HTTP request.
-func authRequest(t *testing.T, method, path string, body io.Reader) *http.Request {
-	t.Helper()
-	token := getToken(t, "testclient", "testsecret")
-	req, err := e2eNewRequest(t, method, serverURL+path, body)
+// authRequestRaw creates an authenticated HTTP request.
+func authRequestRaw(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
+	token, err := getTokenRaw(ctx, "testclient", "testsecret")
 	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, serverURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// authRequest is the test-goroutine form of authRequestRaw.
+func authRequest(t *testing.T, method, path string, body io.Reader) *http.Request {
+	t.Helper()
+	req, err := authRequestRaw(e2eCtx(t), method, path, body)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
 	return req
 }
 
-// doAuth performs an authenticated HTTP request and returns the response.
+// doAuthRaw performs an authenticated HTTP request and returns the response.
 // On 409 Conflict with properties.retryable=true (SERIALIZABLE 40001/40P01
 // aborts, classified by the server), retries up to 5 times with a short
 // backoff. Non-retryable 409s (business-logic conflicts) are returned to
 // the caller on the first response.
-func doAuth(t *testing.T, method, path string, body string) *http.Response {
-	t.Helper()
+//
+// It never touches *testing.T, so it is safe to call from a goroutine.
+func doAuthRaw(ctx context.Context, method, path string, body string) (*http.Response, error) {
 	const maxAttempts = 5
 	var resp *http.Response
 	for attempt := 0; attempt < maxAttempts; attempt++ {
@@ -88,13 +146,16 @@ func doAuth(t *testing.T, method, path string, body string) *http.Response {
 		if body != "" {
 			bodyReader = strings.NewReader(body)
 		}
-		req := authRequest(t, method, path, bodyReader)
+		req, err := authRequestRaw(ctx, method, path, bodyReader)
+		if err != nil {
+			return nil, err
+		}
 		r, err := http.DefaultClient.Do(req)
 		if err != nil {
-			t.Fatalf("%s %s failed: %v", method, path, err)
+			return nil, fmt.Errorf("%s %s failed: %w", method, path, err)
 		}
 		if r.StatusCode != http.StatusConflict {
-			return r
+			return r, nil
 		}
 		// Peek the body without consuming it — caller still owns r.Body.
 		raw, _ := io.ReadAll(r.Body)
@@ -103,11 +164,21 @@ func doAuth(t *testing.T, method, path string, body string) *http.Response {
 			// Not safe to retry; return the response with a re-stuffed body
 			// so the caller can read it normally.
 			r.Body = io.NopCloser(strings.NewReader(string(raw)))
-			return r
+			return r, nil
 		}
 		resp = r
 		resp.Body = io.NopCloser(strings.NewReader(string(raw)))
 		time.Sleep(time.Duration(10*(attempt+1)) * time.Millisecond)
+	}
+	return resp, nil
+}
+
+// doAuth is the test-goroutine form of doAuthRaw.
+func doAuth(t *testing.T, method, path string, body string) *http.Response {
+	t.Helper()
+	resp, err := doAuthRaw(e2eCtx(t), method, path, body)
+	if err != nil {
+		t.Fatalf("%v", err)
 	}
 	return resp
 }

--- a/internal/e2e/message_concurrency_test.go
+++ b/internal/e2e/message_concurrency_test.go
@@ -1,0 +1,107 @@
+package e2e_test
+
+// Isolated single-backend concurrency coverage for the messaging domain.
+// Messages have no per-subject serialisation point, so the invariant is that
+// concurrent writers all commit and every message is independently readable —
+// no lost write, no id collision, no torn payload.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+// TestMessage_ConcurrentCreates_AllCommitAndAreReadable fires N concurrent
+// NewMessage calls on the same subject and asserts every one lands with a
+// distinct id and its own payload intact.
+func TestMessage_ConcurrentCreates_AllCommitAndAreReadable(t *testing.T) {
+	const subject = "e2e-msg-concurrent"
+	const n = 12
+
+	ctx := e2eCtx(t)
+	results := make([]httpResult, n)
+	ready := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			body := fmt.Sprintf(`{"payload": {"seq": %d}, "metaData": {"source": "e2e"}}`, idx)
+			<-ready
+			results[idx] = resultOf(doAuthRaw(ctx, http.MethodPost, "/api/message/new/"+subject, body))
+		}(i)
+	}
+	close(ready)
+	wg.Wait()
+
+	// Assert on the test goroutine — Fatal is only legal here.
+	ids := make(map[string]int, n)
+	for idx, res := range results {
+		if res.err != nil {
+			t.Fatalf("concurrent message %d: %v", idx, res.err)
+		}
+		if res.status != http.StatusOK {
+			t.Fatalf("concurrent message %d: status=%d, want 200; body: %s", idx, res.status, res.body)
+		}
+		id := messageIDFromCreateBody(t, res.body)
+		if prev, dup := ids[id]; dup {
+			t.Fatalf("message id %s returned for both writer %d and writer %d — id collision", id, prev, idx)
+		}
+		ids[id] = idx
+	}
+	if len(ids) != n {
+		t.Fatalf("got %d distinct message ids, want %d", len(ids), n)
+	}
+
+	// Every message must be readable and carry its own writer's payload.
+	for id, writer := range ids {
+		resp := doAuth(t, http.MethodGet, "/api/message/"+id, "")
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET message %s (writer %d): status=%d; body: %s", id, writer, resp.StatusCode, body)
+			continue
+		}
+		var msg struct {
+			Content struct {
+				Seq *float64 `json:"seq"`
+			} `json:"content"`
+		}
+		if err := json.Unmarshal([]byte(body), &msg); err != nil {
+			t.Errorf("GET message %s: decode %q: %v", id, body, err)
+			continue
+		}
+		if msg.Content.Seq == nil {
+			t.Errorf("GET message %s (writer %d): content.seq missing; body: %s", id, writer, body)
+			continue
+		}
+		if int(*msg.Content.Seq) != writer {
+			t.Errorf("GET message %s: content.seq=%d, want %d — payloads were crossed between concurrent writers",
+				id, int(*msg.Content.Seq), writer)
+		}
+	}
+}
+
+// messageIDFromCreateBody extracts the single created message id from a
+// NewMessage response body.
+func messageIDFromCreateBody(t *testing.T, body string) string {
+	t.Helper()
+	var results []map[string]any
+	if err := json.Unmarshal([]byte(body), &results); err != nil {
+		t.Fatalf("parse create response %q: %v", body, err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("create response has no results: %s", body)
+	}
+	entityIDs, ok := results[0]["entityIds"].([]any)
+	if !ok || len(entityIDs) == 0 {
+		t.Fatalf("create response has no entityIds: %s", body)
+	}
+	id, _ := entityIDs[0].(string)
+	if id == "" {
+		t.Fatalf("create response has blank entityId: %s", body)
+	}
+	return id
+}

--- a/internal/e2e/model_lock_concurrency_test.go
+++ b/internal/e2e/model_lock_concurrency_test.go
@@ -1,0 +1,86 @@
+package e2e_test
+
+// Isolated single-backend concurrency coverage for model locking. Per
+// .claude/rules/test-coverage.md concurrency scenarios live here, not in the
+// shared parity suite: they assert consistency (one winner, losers rejected),
+// never a precise interleave.
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+// TestModelLock_Concurrent_ConvergesToLocked asserts that N simultaneous lock
+// attempts on the same unlocked model leave the model consistently LOCKED,
+// with every attempt terminating in a documented status and the schema intact.
+//
+// Deliberately NOT asserted: that exactly one attempt wins. LockModel checks
+// state and then locks without holding the two together, so concurrent callers
+// can all observe UNLOCKED and all receive 200 rather than one 200 and N-1
+// 409 MODEL_ALREADY_LOCKED. Locking is an operator action taken in a
+// controlled rollout, the converged state is identical either way, and the
+// duplicate lifecycle savepoints the race writes are drained by Unlock — so
+// enforcing single-winner semantics is not worth the atomic-transition work
+// across every backend. The sequential contract is covered by
+// TestModelLock_AlreadyLocked_409.
+//
+// What this test does guard: no attempt may 500, the model must not be left
+// half-transitioned, and the schema must survive the race.
+func TestModelLock_Concurrent_ConvergesToLocked(t *testing.T) {
+	const model = "e2e-lock-concurrent"
+	const n = 8
+
+	importModelE2E(t, model, 1)
+
+	ctx := e2eCtx(t)
+	path := fmt.Sprintf("/api/model/%s/1/lock", model)
+	results := make([]httpResult, n)
+	ready := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-ready // release all lockers together
+			results[idx] = resultOf(doAuthRaw(ctx, http.MethodPut, path, ""))
+		}(i)
+	}
+	close(ready)
+	wg.Wait()
+
+	// Assert on the test goroutine — Fatal is only legal here.
+	var winners int
+	for idx, res := range results {
+		if res.err != nil {
+			t.Fatalf("lock attempt %d: %v", idx, res.err)
+		}
+		switch res.status {
+		case http.StatusOK:
+			winners++
+		case http.StatusConflict:
+			assertErrorCode(t, res.body, "MODEL_ALREADY_LOCKED")
+		default:
+			t.Errorf("lock attempt %d: status=%d, want 200 or 409; body: %s", idx, res.status, res.body)
+		}
+	}
+	if winners == 0 {
+		t.Errorf("no lock attempt succeeded — the model was never locked")
+	}
+
+	// The model must be genuinely locked afterwards, not left half-transitioned.
+	resp := doAuth(t, http.MethodPut, path, "")
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("post-race relock: status=%d, want 409; body: %s", resp.StatusCode, body)
+	}
+	assertErrorCode(t, body, "MODEL_ALREADY_LOCKED")
+
+	// The schema must have survived the race — a locked model is readable and
+	// exports the fields it declared before the storm.
+	if raw := fmt.Sprintf("%v", exportModelE2E(t, model, 1)); raw == "" {
+		t.Error("model export empty after concurrent locks — schema fold did not survive the race")
+	}
+}

--- a/internal/e2e/model_lock_concurrency_test.go
+++ b/internal/e2e/model_lock_concurrency_test.go
@@ -6,8 +6,10 @@ package e2e_test
 // never a precise interleave.
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -61,7 +63,10 @@ func TestModelLock_Concurrent_ConvergesToLocked(t *testing.T) {
 		case http.StatusOK:
 			winners++
 		case http.StatusConflict:
-			assertErrorCode(t, res.body, "MODEL_ALREADY_LOCKED")
+			// MODEL_ALREADY_LOCKED is the business conflict. CONFLICT is the
+			// retryable serialization abort, which doAuthRaw may still surface
+			// if all five of its retries lose the race — not a defect.
+			assertErrorCodeOneOf(t, res.body, "MODEL_ALREADY_LOCKED", "CONFLICT")
 		default:
 			t.Errorf("lock attempt %d: status=%d, want 200 or 409; body: %s", idx, res.status, res.body)
 		}
@@ -78,9 +83,32 @@ func TestModelLock_Concurrent_ConvergesToLocked(t *testing.T) {
 	}
 	assertErrorCode(t, body, "MODEL_ALREADY_LOCKED")
 
-	// The schema must have survived the race — a locked model is readable and
-	// exports the fields it declared before the storm.
-	if raw := fmt.Sprintf("%v", exportModelE2E(t, model, 1)); raw == "" {
-		t.Error("model export empty after concurrent locks — schema fold did not survive the race")
+	// The schema must have survived the race: the locked model still exports
+	// the properties it declared before the storm.
+	exported := exportModelE2E(t, model, 1)
+	if len(exported) == 0 {
+		t.Fatalf("model export empty after concurrent locks — schema did not survive the race")
 	}
+	if raw := fmt.Sprintf("%v", exported); !strings.Contains(raw, "name") {
+		t.Errorf("exported schema lost its declared properties after the race: %s", raw)
+	}
+}
+
+// assertErrorCodeOneOf asserts the problem body carries one of the given error
+// codes.
+func assertErrorCodeOneOf(t *testing.T, body string, codes ...string) {
+	t.Helper()
+	var pd struct {
+		Properties map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(body), &pd); err != nil {
+		t.Fatalf("decode problem detail %q: %v", body, err)
+	}
+	got, _ := pd.Properties["errorCode"].(string)
+	for _, want := range codes {
+		if got == want {
+			return
+		}
+	}
+	t.Errorf("errorCode=%q, want one of %v; body: %s", got, codes, body)
 }

--- a/internal/e2e/model_schema_extensions_test.go
+++ b/internal/e2e/model_schema_extensions_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 )
 
@@ -36,12 +35,9 @@ func TestModelSchemaExtensions_ConcurrentUpdatesNoConflict(t *testing.T) {
 	// distinct new property (field_i) so every write genuinely triggers
 	// an ExtendSchema path. Under the old Save-based path, N-1 of these
 	// would fail with 40001/CONFLICT.
-	var (
-		wg        sync.WaitGroup
-		conflicts atomic.Int32
-		other     atomic.Int32
-		okCount   atomic.Int32
-	)
+	ctx := e2eCtx(t)
+	results := make([]httpResult, N)
+	var wg sync.WaitGroup
 	for i := 0; i < N; i++ {
 		i := i
 		wg.Add(1)
@@ -52,32 +48,39 @@ func TestModelSchemaExtensions_ConcurrentUpdatesNoConflict(t *testing.T) {
 				i, i*10, i, i,
 			)
 			path := fmt.Sprintf("/api/entity/JSON/%s/%d", modelName, version)
-			resp := doAuth(t, http.MethodPost, path, payload)
-			body := readBody(t, resp)
-			switch resp.StatusCode {
-			case http.StatusOK:
-				okCount.Add(1)
-			case http.StatusConflict:
-				conflicts.Add(1)
-				t.Logf("goroutine %d got 409 CONFLICT: %s", i, body)
-			default:
-				other.Add(1)
-				t.Logf("goroutine %d got %d: %s", i, resp.StatusCode, body)
-			}
+			results[i] = resultOf(doAuthRaw(ctx, http.MethodPost, path, payload))
 		}()
 	}
 	wg.Wait()
 
-	if conflicts.Load() != 0 {
+	// Classify on the test goroutine — Fatal is only legal here.
+	var conflicts, other, okCount int
+	for i, res := range results {
+		if res.err != nil {
+			t.Fatalf("goroutine %d transport error: %v", i, res.err)
+		}
+		switch res.status {
+		case http.StatusOK:
+			okCount++
+		case http.StatusConflict:
+			conflicts++
+			t.Logf("goroutine %d got 409 CONFLICT: %s", i, res.body)
+		default:
+			other++
+			t.Logf("goroutine %d got %d: %s", i, res.status, res.body)
+		}
+	}
+
+	if conflicts != 0 {
 		t.Errorf("regression: %d of %d concurrent entity updates returned CONFLICT (409). ExtendSchema must eliminate hot-row contention.",
-			conflicts.Load(), N)
+			conflicts, N)
 	}
-	if other.Load() != 0 {
+	if other != 0 {
 		t.Errorf("%d of %d concurrent entity updates returned neither 200 nor 409 (unexpected status).",
-			other.Load(), N)
+			other, N)
 	}
-	if okCount.Load() != int32(N) {
-		t.Errorf("expected all %d concurrent creates to succeed, got %d", N, okCount.Load())
+	if okCount != N {
+		t.Errorf("expected all %d concurrent creates to succeed, got %d", N, okCount)
 	}
 
 	// 3. After the storm, the folded schema must reflect every new field.

--- a/internal/e2e/search_bounded_test.go
+++ b/internal/e2e/search_bounded_test.go
@@ -186,7 +186,10 @@ func TestSearchDirect_InTx_OverLimit_Returns400(t *testing.T) {
 		return out, nil
 	})
 
-	h.SetupModelWithWorkflow(t, primary, intxSearchPrimaryWF("primary-intx-bounded-wf", "cb-intx-bounded-search"))
+	// cb-intx-bounded-search reports both search outcomes through the primary's data.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(
+		`"joinedStatus": 0, "joinedCode": "", "standaloneStatus": 0, "standaloneCount": 0`),
+		intxSearchPrimaryWF("primary-intx-bounded-wf", "cb-intx-bounded-search"))
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {

--- a/internal/e2e/search_intx_test.go
+++ b/internal/e2e/search_intx_test.go
@@ -219,7 +219,10 @@ func TestIntxSearch_HTTP_TrackingRead_SeesUncommittedWrite(t *testing.T) {
 		return out, nil
 	})
 
-	h.SetupModelWithWorkflow(t, primary, intxSearchPrimaryWF("primary-intx-http-wf", "cb-intx-http-search"))
+	// cb-intx-http-search reports its findings through the primary's data.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(
+		`"joinedStatus": 0, "joinedCount": 0, "standaloneStatus": 0, "standaloneCount": 0, "secondaryId": ""`),
+		intxSearchPrimaryWF("primary-intx-http-wf", "cb-intx-http-search"))
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {
@@ -313,7 +316,10 @@ func TestIntxSearch_GRPC_TrackingRead_SeesUncommittedWrite(t *testing.T) {
 		return out, nil
 	})
 
-	h.SetupModelWithWorkflow(t, primary, intxSearchPrimaryWF("primary-intx-grpc-wf", "cb-intx-grpc-search"))
+	// cb-intx-grpc-search reports its findings through the primary's data.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(
+		`"searchCountJoined": 0, "searchCountStandalone": 0, "secondaryId": ""`),
+		intxSearchPrimaryWF("primary-intx-grpc-wf", "cb-intx-grpc-search"))
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {
@@ -405,7 +411,12 @@ func TestIntxSearch_InTx_ErrorCodes(t *testing.T) {
 		return out, nil
 	})
 
-	h.SetupModelWithWorkflow(t, primary, intxSearchPrimaryWF("primary-intx-errcodes-wf", "cb-intx-search-errcodes"))
+	// cb-intx-search-errcodes reports the four observed outcomes through the
+	// primary's data; the model must declare every field it writes.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(
+		`"httpNotFoundStatus": 0, "httpNotFoundCode": "", "httpBadPathStatus": 0, "httpBadPathCode": "", `+
+			`"grpcNotFoundMsg": "", "grpcBadPathMsg": ""`),
+		intxSearchPrimaryWF("primary-intx-errcodes-wf", "cb-intx-search-errcodes"))
 
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
 	if status != http.StatusOK {

--- a/internal/e2e/transaction_test.go
+++ b/internal/e2e/transaction_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
@@ -29,8 +28,9 @@ func TestTransaction_ConcurrentCreates(t *testing.T) {
 	}`)
 
 	const n = 10
+	ctx := e2eCtx(t)
+	results := make([]httpResult, n)
 	var wg sync.WaitGroup
-	var successCount atomic.Int32
 
 	for i := 0; i < n; i++ {
 		wg.Add(1)
@@ -38,17 +38,23 @@ func TestTransaction_ConcurrentCreates(t *testing.T) {
 			defer wg.Done()
 			payload := fmt.Sprintf(`{"name":"concurrent-%d","amount":%d,"status":"new"}`, idx, idx*10)
 			path := fmt.Sprintf("/api/entity/JSON/%s/%d", model, 1)
-			resp := doAuth(t, http.MethodPost, path, payload)
-			readBody(t, resp)
-			if resp.StatusCode == http.StatusOK {
-				successCount.Add(1)
-			}
+			results[idx] = resultOf(doAuthRaw(ctx, http.MethodPost, path, payload))
 		}(i)
 	}
 	wg.Wait()
 
-	if successCount.Load() != int32(n) {
-		t.Errorf("expected all %d creates to succeed, got %d", n, successCount.Load())
+	// Assert on the test goroutine — Fatal is only legal here.
+	successCount := 0
+	for idx, res := range results {
+		if res.err != nil {
+			t.Fatalf("concurrent create %d: %v", idx, res.err)
+		}
+		if res.status == http.StatusOK {
+			successCount++
+		}
+	}
+	if successCount != n {
+		t.Errorf("expected all %d creates to succeed, got %d", n, successCount)
 	}
 
 	// Verify total entity count.
@@ -78,8 +84,9 @@ func TestTransaction_ConcurrentUpdates(t *testing.T) {
 	entityID := createEntityE2E(t, model, 1, `{"name":"shared","amount":0,"status":"new"}`)
 
 	const n = 5
+	ctx := e2eCtx(t)
+	results := make([]httpResult, n)
 	var wg sync.WaitGroup
-	var successCount, conflictCount atomic.Int32
 
 	for i := 0; i < n; i++ {
 		wg.Add(1)
@@ -87,20 +94,24 @@ func TestTransaction_ConcurrentUpdates(t *testing.T) {
 			defer wg.Done()
 			payload := fmt.Sprintf(`{"name":"shared","amount":%d,"status":"updated"}`, idx)
 			path := fmt.Sprintf("/api/entity/JSON/%s", entityID)
-			resp := doAuth(t, http.MethodPut, path, payload)
-			readBody(t, resp)
-			switch resp.StatusCode {
-			case http.StatusOK:
-				successCount.Add(1)
-			case http.StatusConflict:
-				conflictCount.Add(1)
-			}
+			results[idx] = resultOf(doAuthRaw(ctx, http.MethodPut, path, payload))
 		}(i)
 	}
 	wg.Wait()
 
+	// Assert on the test goroutine — Fatal is only legal here.
+	successCount := 0
+	for idx, res := range results {
+		if res.err != nil {
+			t.Fatalf("concurrent update %d: %v", idx, res.err)
+		}
+		if res.status == http.StatusOK {
+			successCount++
+		}
+	}
+
 	// At least one should succeed.
-	if successCount.Load() < 1 {
+	if successCount < 1 {
 		t.Error("expected at least one concurrent update to succeed")
 	}
 
@@ -165,8 +176,9 @@ func TestTransaction_StressTest(t *testing.T) {
 	}`)
 
 	const n = 25
+	ctx := e2eCtx(t)
+	results := make([]httpResult, n)
 	var wg sync.WaitGroup
-	var successCount atomic.Int32
 
 	for i := 0; i < n; i++ {
 		wg.Add(1)
@@ -174,17 +186,23 @@ func TestTransaction_StressTest(t *testing.T) {
 			defer wg.Done()
 			payload := fmt.Sprintf(`{"name":"stress-%d","amount":%d,"status":"new"}`, idx, idx)
 			path := fmt.Sprintf("/api/entity/JSON/%s/%d", model, 1)
-			resp := doAuth(t, http.MethodPost, path, payload)
-			readBody(t, resp)
-			if resp.StatusCode == http.StatusOK {
-				successCount.Add(1)
-			}
+			results[idx] = resultOf(doAuthRaw(ctx, http.MethodPost, path, payload))
 		}(i)
 	}
 	wg.Wait()
 
-	if successCount.Load() != int32(n) {
-		t.Errorf("expected all %d creates to succeed, got %d", n, successCount.Load())
+	// Assert on the test goroutine — Fatal is only legal here.
+	successCount := 0
+	for idx, res := range results {
+		if res.err != nil {
+			t.Fatalf("stress create %d: %v", idx, res.err)
+		}
+		if res.status == http.StatusOK {
+			successCount++
+		}
+	}
+	if successCount != n {
+		t.Errorf("expected all %d creates to succeed, got %d", n, successCount)
 	}
 
 	// Verify total count — must match exactly, no duplicates or missing.

--- a/internal/e2e/workflow_proc_output_test.go
+++ b/internal/e2e/workflow_proc_output_test.go
@@ -123,13 +123,15 @@ func TestWorkflowProcOutput_UnstorableRejected(t *testing.T) {
 	assertErrorCode(t, body, "WORKFLOW_FAILED")
 }
 
-// TestWorkflowProcOutput_ExtensionRollsBackWithTheTransition pins where the
-// check happens for commit-before-dispatch.
+// TestWorkflowProcOutput_ExtensionRollsBackWithTheTransition asserts that a
+// schema extension made by one processor does not survive a later processor
+// failing the same transition.
 //
-// A first processor extends the model; a second then fails. The whole
-// transition rolls back, so the extension must not survive. This fails if the
-// check is ever moved to the point between committing TX_pre and opening
-// TX_post, where a schema write would run outside any transaction.
+// Both processors here are SYNC, so this exercises the ordinary in-transaction
+// path. The commit-before-dispatch placement — where the check must run on
+// TX_post rather than where the data arrives — is pinned at the unit level by
+// TestProcessorOutput_OffModelFieldRejectedInEveryExecutionMode, which drives
+// all three execution modes.
 func TestWorkflowProcOutput_ExtensionRollsBackWithTheTransition(t *testing.T) {
 	const model = "e2e-procout-rollback"
 	registerRewriter(t, "procout-p1", `{"name":"x","amount":1,"status":"new","p1Field":"v"}`)

--- a/internal/e2e/workflow_proc_output_test.go
+++ b/internal/e2e/workflow_proc_output_test.go
@@ -1,0 +1,209 @@
+package e2e_test
+
+// A processor's returned data is subject to the same checks as a client write:
+// the storability guard, and schema validation or extension governed by the
+// model's changeLevel. The engine gets no special rights — a processor may
+// extend an entity beyond its model exactly when a client could, and never
+// otherwise.
+//
+// Before this, a processor could write anything: content no backend could store
+// (surfacing as 500), or fields the model does not declare — leaving an entity
+// the API would return but refuse to accept back on a PUT, and that the model
+// export did not mention.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// procOutputWorkflow is a workflow whose single automatic transition runs one
+// named processor.
+func procOutputWorkflow(procName string) string {
+	return fmt.Sprintf(`{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "proc-output-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false,
+					"processors": [{"type": "calculator", "name": %q, "executionMode": "SYNC",
+						"config": {"attachEntity": true, "calculationNodesTags": ""}}]}]},
+				"CREATED": {}
+			}
+		}]
+	}`, procName)
+}
+
+// registerRewriter registers a processor that replaces the entity's data wholesale.
+func registerRewriter(t *testing.T, name, data string) {
+	t.Helper()
+	procSvc.RegisterProcessor(name, func(ctx context.Context, e *spi.Entity, p spi.ProcessorDefinition) (*spi.Entity, error) {
+		return &spi.Entity{Meta: e.Meta, Data: []byte(data)}, nil
+	})
+}
+
+// TestWorkflowProcOutput_OffModelFieldRejectedOnStrictModel asserts a processor
+// cannot introduce a field the model does not declare when the model has no
+// changeLevel — the same answer a client gets.
+func TestWorkflowProcOutput_OffModelFieldRejectedOnStrictModel(t *testing.T) {
+	const model = "e2e-procout-strict"
+	registerRewriter(t, "procout-adds-field", `{"name":"x","amount":1,"status":"new","undeclared":"v"}`)
+	defer procSvc.Reset()
+
+	setupModelWithWorkflow(t, model, procOutputWorkflow("procout-adds-field"))
+
+	resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model),
+		`{"name":"x","amount":1,"status":"new"}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400 — a processor may not write a field a client could not; body: %s",
+			resp.StatusCode, body)
+	}
+	assertErrorCode(t, body, "WORKFLOW_FAILED")
+
+	// The transition failed, so nothing may have been committed.
+	if count := queryDB(t, "test-tenant",
+		"SELECT count(*) FROM entities WHERE model_name = $1 AND NOT deleted", model); count != 0 {
+		t.Errorf("expected no entity after the rejected transition, got %d", count)
+	}
+	// And the model must not have been widened.
+	if raw := fmt.Sprintf("%v", exportModelE2E(t, model, 1)); strings.Contains(raw, "undeclared") {
+		t.Errorf("model gained the rejected field: %s", raw)
+	}
+}
+
+// TestWorkflowProcOutput_OffModelFieldExtendsOnStructuralModel is the other half
+// of the same rule: where a client's write would extend the model, so does a
+// processor's.
+func TestWorkflowProcOutput_OffModelFieldExtendsOnStructuralModel(t *testing.T) {
+	const model = "e2e-procout-structural"
+	registerRewriter(t, "procout-extends", `{"name":"x","amount":1,"status":"new","procAdded":"v"}`)
+	defer procSvc.Reset()
+
+	importModelE2E(t, model, 1)
+	lockModelE2E(t, model, 1)
+	setChangeLevelE2E(t, model, 1, "STRUCTURAL")
+	status, body := importWorkflowE2E(t, model, 1, procOutputWorkflow("procout-extends"))
+	if status != http.StatusOK {
+		t.Fatalf("workflow import: %d %s", status, body)
+	}
+
+	resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model),
+		`{"name":"x","amount":1,"status":"new"}`)
+	respBody := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d, want 200 — STRUCTURAL permits the extension; body: %s", resp.StatusCode, respBody)
+	}
+	if raw := fmt.Sprintf("%v", exportModelE2E(t, model, 1)); !strings.Contains(raw, "procAdded") {
+		t.Errorf("model was not extended with the processor's field: %s", raw)
+	}
+}
+
+// TestWorkflowProcOutput_UnstorableRejected asserts unstorable content from a
+// processor is a failed transition (400), not a storage failure (500).
+func TestWorkflowProcOutput_UnstorableRejected(t *testing.T) {
+	const model = "e2e-procout-unstorable"
+	registerRewriter(t, "procout-surrogate",
+		"{\"name\":\"a\\ud800b\",\"amount\":1,\"status\":\"new\"}")
+	defer procSvc.Reset()
+
+	setupModelWithWorkflow(t, model, procOutputWorkflow("procout-surrogate"))
+
+	resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model),
+		`{"name":"x","amount":1,"status":"new"}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400 (was 500 before the guard existed); body: %s", resp.StatusCode, body)
+	}
+	assertErrorCode(t, body, "WORKFLOW_FAILED")
+}
+
+// TestWorkflowProcOutput_ExtensionRollsBackWithTheTransition pins where the
+// check happens for commit-before-dispatch.
+//
+// A first processor extends the model; a second then fails. The whole
+// transition rolls back, so the extension must not survive. This fails if the
+// check is ever moved to the point between committing TX_pre and opening
+// TX_post, where a schema write would run outside any transaction.
+func TestWorkflowProcOutput_ExtensionRollsBackWithTheTransition(t *testing.T) {
+	const model = "e2e-procout-rollback"
+	registerRewriter(t, "procout-p1", `{"name":"x","amount":1,"status":"new","p1Field":"v"}`)
+	procSvc.RegisterProcessor("procout-p2", func(ctx context.Context, e *spi.Entity, p spi.ProcessorDefinition) (*spi.Entity, error) {
+		return nil, fmt.Errorf("deliberate failure after the extension")
+	})
+	defer procSvc.Reset()
+
+	importModelE2E(t, model, 1)
+	lockModelE2E(t, model, 1)
+	setChangeLevelE2E(t, model, 1, "STRUCTURAL")
+	status, body := importWorkflowE2E(t, model, 1, fmt.Sprintf(`{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "procout-rollback-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false,
+					"processors": [
+						{"type": "calculator", "name": "procout-p1", "executionMode": "SYNC",
+							"config": {"attachEntity": true, "calculationNodesTags": ""}},
+						{"type": "calculator", "name": "procout-p2", "executionMode": "SYNC",
+							"config": {"attachEntity": true, "calculationNodesTags": ""}}
+					]}]},
+				"CREATED": {}
+			}
+		}]
+	}`))
+	if status != http.StatusOK {
+		t.Fatalf("workflow import: %d %s", status, body)
+	}
+
+	resp := doAuth(t, http.MethodPost, fmt.Sprintf("/api/entity/JSON/%s/1", model),
+		`{"name":"x","amount":1,"status":"new"}`)
+	respBody := readBody(t, resp)
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("expected the transition to fail on the second processor; body: %s", respBody)
+	}
+	if raw := fmt.Sprintf("%v", exportModelE2E(t, model, 1)); strings.Contains(raw, "p1Field") {
+		t.Errorf("the first processor's schema extension survived a rolled-back transition: %s", raw)
+	}
+}
+
+// TestWorkflowProcOutput_EntityRemainsRoundTrippable is the defect this rule
+// closes, stated as a property: whatever the engine stores, a client must be
+// able to send back.
+//
+// Previously a processor could add a field the model did not declare; the
+// entity then read back with that field, but PUTting the very same document
+// returned 400 because the model had never heard of it.
+func TestWorkflowProcOutput_EntityRemainsRoundTrippable(t *testing.T) {
+	const model = "e2e-procout-roundtrip"
+	registerRewriter(t, "procout-enrich", `{"name":"x","amount":1,"status":"new","enriched":true}`)
+	defer procSvc.Reset()
+
+	setupModelSampleWithWorkflow(t, model,
+		`{"name":"x","amount":1,"status":"new","enriched":false}`,
+		procOutputWorkflow("procout-enrich"))
+
+	entityID := createEntityE2E(t, model, 1, `{"name":"x","amount":1,"status":"new"}`)
+
+	data := getEntityData(t, entityID, "")
+	if data["enriched"] != true {
+		t.Fatalf("processor did not run: %v", data)
+	}
+
+	// Send the stored document straight back.
+	raw, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	resp := doAuth(t, http.MethodPut, fmt.Sprintf("/api/entity/JSON/%s", entityID), string(raw))
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT of the entity's own stored document: status=%d, want 200 — what the engine stores the API must accept; body: %s",
+			resp.StatusCode, body)
+	}
+}

--- a/internal/e2e/workflow_proc_test.go
+++ b/internal/e2e/workflow_proc_test.go
@@ -67,7 +67,15 @@ func getSMAuditEventsWithLimit(t *testing.T, entityID string, limit int) []map[s
 // setupModelWithWorkflow imports a model, locks it, and imports a workflow.
 func setupModelWithWorkflow(t *testing.T, entityName string, workflowJSON string) {
 	t.Helper()
-	importModelE2E(t, entityName, 1)
+	setupModelSampleWithWorkflow(t, entityName, workflowSampleModel, workflowJSON)
+}
+
+// setupModelSampleWithWorkflow is setupModelWithWorkflow from a CUSTOM sample,
+// used when the workflow's processors write fields workflowSampleModel does not
+// declare (see workflowSampleWith).
+func setupModelSampleWithWorkflow(t *testing.T, entityName, sample, workflowJSON string) {
+	t.Helper()
+	importModelSampleE2E(t, entityName, 1, sample)
 	lockModelE2E(t, entityName, 1)
 	status, body := importWorkflowE2E(t, entityName, 1, workflowJSON)
 	if status != http.StatusOK {
@@ -216,7 +224,12 @@ func TestWorkflowProc_ProcessorModifiesData(t *testing.T) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, model, wf)
+	// compute-total writes `total` = amount*1.1 in float64, which carries 17
+	// significant digits and therefore classifies BIG_DECIMAL. The sample
+	// declares that type with a neutral 16-digit decimal — a bare 0 (or 0.0,
+	// which strips to 0) would type the field INTEGER and the processor's
+	// write would be rejected as a narrowing.
+	setupModelSampleWithWorkflow(t, model, workflowSampleWith(`"total": 0.1234567890123456`), wf)
 
 	entityID := createEntityE2E(t, model, 1, `{"name":"Test","amount":100,"status":"new"}`)
 
@@ -269,7 +282,8 @@ func TestWorkflowProc_MultipleProcessorsSameTransition(t *testing.T) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, model, wf)
+	// step-1/step-2 write `step1`/`step2`; the model must declare them.
+	setupModelSampleWithWorkflow(t, model, workflowSampleWith(`"step1": false, "step2": false`), wf)
 
 	entityID := createEntityE2E(t, model, 1, `{"name":"Test","amount":10,"status":"new"}`)
 
@@ -411,7 +425,9 @@ func TestWorkflowProc_UpdateWithCBD_DurablyCommitsPostCascadeState(t *testing.T)
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, model, wf)
+	// cbd-enrich writes `enriched`/`enrichedAmount`; the model must declare them.
+	setupModelSampleWithWorkflow(t, model,
+		workflowSampleWith(`"enriched": false, "enrichedAmount": 0`), wf)
 
 	// Create — lands in PENDING via the automated init.
 	entityID := createEntityE2E(t, model, 1, `{"name":"Test","amount":100,"status":"new"}`)
@@ -493,7 +509,9 @@ func TestWorkflowProc_UpdateWithCBD_StaleIfMatchAbortsBeforeDispatch(t *testing.
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, model, wf)
+	// cbd-enrich-counted writes `enriched`; the model must declare it so the
+	// only reason this transition can fail is the stale If-Match under test.
+	setupModelSampleWithWorkflow(t, model, workflowSampleWith(`"enriched": false`), wf)
 
 	// Create — lands in PENDING via the automated init.
 	entityID := createEntityE2E(t, model, 1, `{"name":"Test","amount":100,"status":"new"}`)
@@ -631,7 +649,9 @@ func TestWorkflowProc_CreateWithCBD_DurablyCommitsPostCascadeState(t *testing.T)
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, model, wf)
+	// cbd-enrich-create writes `enriched`/`enrichedAmount`; declare both.
+	setupModelSampleWithWorkflow(t, model,
+		workflowSampleWith(`"enriched": false, "enrichedAmount": 0`), wf)
 
 	// POST — drives the create cascade through both segments.
 	entityID, txID := createEntityE2EWithTxID(t, model, 1, `{"name":"Test","amount":50,"status":"new"}`)
@@ -715,7 +735,8 @@ func TestWorkflowProc_UpdateWithCBD_TrueBranch_SecondaryEntityWritten(t *testing
 			}
 		}]
 	}`
-	h.SetupModelWithWorkflow(t, primary, wf)
+	// cbd-true-proc writes `secondaryId`; the model must declare it.
+	h.setupModelSampleWithWorkflow(t, primary, workflowSampleWith(`"secondaryId": ""`), wf)
 
 	// Create entity — automated init lands it in PENDING.
 	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"anchor","amount":100,"status":"new"}`)
@@ -829,7 +850,8 @@ func TestWorkflowProc_SearchSeesPreCalloutStateDuringDispatch(t *testing.T) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, model, wf)
+	// cbd-blocker writes `enriched`; the model must declare it.
+	setupModelSampleWithWorkflow(t, model, workflowSampleWith(`"enriched": false`), wf)
 
 	entityID := createEntityE2E(t, model, 1, `{"name":"Test","amount":100,"status":"new"}`)
 	if state := getEntityState(t, entityID); state != "PENDING" {
@@ -925,7 +947,8 @@ func TestWorkflowProc_UpdateWithoutCBD_RegressionBound(t *testing.T) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, model, wf)
+	// sync-enrich writes `enriched`; the model must declare it.
+	setupModelSampleWithWorkflow(t, model, workflowSampleWith(`"enriched": false`), wf)
 
 	entityID := createEntityE2E(t, model, 1, `{"name":"Test","amount":100,"status":"new"}`)
 
@@ -1058,7 +1081,9 @@ func TestWorkflowProc_LoopbackWithCBD(t *testing.T) {
 			}
 		}]
 	}`
-	setupModelWithWorkflow(t, model, wf)
+	// cbd-loopback-enrich writes `enriched`/`upgradedBy`; declare both.
+	setupModelSampleWithWorkflow(t, model,
+		workflowSampleWith(`"enriched": false, "upgradedBy": ""`), wf)
 
 	// Create with amount=50 — criterion fails, entity rests in PENDING_BIG.
 	entityID := createEntityE2E(t, model, 1, `{"name":"Test","amount":50,"status":"new"}`)

--- a/internal/e2e/workflow_proc_test.go
+++ b/internal/e2e/workflow_proc_test.go
@@ -838,12 +838,13 @@ func TestWorkflowProc_SearchSeesPreCalloutStateDuringDispatch(t *testing.T) {
 
 	// Driver goroutine: fires the PUT that triggers the CBD cascade. It
 	// will block in the dispatch fake until releaseDispatch is closed.
+	driverCtx := e2eCtx(t)
 	driverDone := make(chan struct{})
+	var driverRes httpResult
 	go func() {
 		defer close(driverDone)
 		path := fmt.Sprintf("/api/entity/JSON/%s/approve", entityID)
-		resp := doAuth(t, http.MethodPut, path, `{"name":"Test","amount":100,"status":"approved"}`)
-		readBody(t, resp)
+		driverRes = resultOf(doAuthRaw(driverCtx, http.MethodPut, path, `{"name":"Test","amount":100,"status":"approved"}`))
 	}()
 
 	// Wait until the dispatch fake has been entered — TX_pre is committed
@@ -867,6 +868,12 @@ func TestWorkflowProc_SearchSeesPreCalloutStateDuringDispatch(t *testing.T) {
 	// will return.
 	close(releaseDispatch)
 	<-driverDone
+	if driverRes.err != nil {
+		t.Fatalf("driver PUT: %v", driverRes.err)
+	}
+	if driverRes.status != http.StatusOK {
+		t.Fatalf("driver PUT: status=%d body=%s", driverRes.status, driverRes.body)
+	}
 
 	// Post-cascade durability: the cascade has fully committed.
 	if state := getEntityState(t, entityID); state != "APPROVED" {

--- a/internal/e2e/workflow_test.go
+++ b/internal/e2e/workflow_test.go
@@ -10,6 +10,20 @@ import (
 
 const workflowSampleModel = `{"name": "Test Order", "amount": 100, "status": "draft"}`
 
+// workflowSampleWith returns workflowSampleModel extended with extra top-level
+// fields, given as the inner body of a JSON object
+// (e.g. `"total":0,"enriched":false`).
+//
+// A processor's returned data passes the same model checks a client write does,
+// so a locked model must DECLARE every field the workflow's processors write.
+// Seeding a zero value states that contract explicitly while keeping the model
+// strict — raising the model's changeLevel instead would let the model absorb
+// any key, so a typo'd field name would silently widen the model rather than
+// fail the test.
+func workflowSampleWith(extraFieldsJSON string) string {
+	return `{"name": "Test Order", "amount": 100, "status": "draft", ` + extraFieldsJSON + `}`
+}
+
 const workflowV1 = `{
 	"importMode": "REPLACE",
 	"workflows": [
@@ -59,8 +73,14 @@ const workflowV2 = `{
 // importModelE2E imports a model via the REST API and asserts a 200 response.
 func importModelE2E(t *testing.T, entityName string, modelVersion int) {
 	t.Helper()
+	importModelSampleE2E(t, entityName, modelVersion, workflowSampleModel)
+}
+
+// importModelSampleE2E is importModelE2E from a CUSTOM sample.
+func importModelSampleE2E(t *testing.T, entityName string, modelVersion int, sample string) {
+	t.Helper()
 	path := fmt.Sprintf("/api/model/import/JSON/SAMPLE_DATA/%s/%d", entityName, modelVersion)
-	resp := doAuth(t, http.MethodPost, path, workflowSampleModel)
+	resp := doAuth(t, http.MethodPost, path, sample)
 	body := readBody(t, resp)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("importModel %s/%d: expected 200, got %d: %s", entityName, modelVersion, resp.StatusCode, body)

--- a/internal/e2e/zzz_errorcode_matrix_test.go
+++ b/internal/e2e/zzz_errorcode_matrix_test.go
@@ -74,7 +74,7 @@ var EntityErrorCodeMatrix = map[string][]codeCell{
 	// transition-error surface belongs to a follow-on.
 	// CONFLICT (409) is exempt from all rows: it is a retryable serialization
 	// abort emitted non-deterministically by any write op under concurrency and
-	// is therefore not a per-endpoint documented code (see universalConcurrencyCodes).
+	// is therefore not a per-endpoint documented code (see universalCrossCuttingCodes).
 	"create": {
 		{Status: 400, Code: "BAD_REQUEST"},        // invalid payload, transactionWindow out of range
 		{Status: 400, Code: "INCOMPATIBLE_TYPE"},  // payload type mismatches the model
@@ -92,7 +92,7 @@ var EntityErrorCodeMatrix = map[string][]codeCell{
 	"updateSingleWithLoopback": {
 		{Status: 409, Code: "UNIQUE_VIOLATION"},   // TestUniqueKeys_UpdateMovesKey
 		{Status: 422, Code: "INVALID_UNIQUE_KEY"}, // TestUniqueKeys_LoopbackUpdatePartialKey
-		// 409 CONFLICT is exempt (universalConcurrencyCodes)
+		// 409 CONFLICT is exempt (universalCrossCuttingCodes)
 	},
 	"updateSingle": {
 		{Status: 400, Code: "TRANSITION_NOT_FOUND"}, // named transition absent from the model
@@ -136,25 +136,33 @@ func producibleGaps(matrix map[string][]codeCell, observed []openapivalidator.Er
 	return gaps
 }
 
-// universalConcurrencyCodes is the set of error codes that any write operation
-// may emit non-deterministically under concurrency. They are retryable,
-// cross-cutting serialization outcomes — not part of any endpoint's per-code
-// documented contract — and are exempt from the declared check.
+// universalCrossCuttingCodes is the set of error codes that are not part of any
+// endpoint's per-code documented contract — they arise from layers that sit in
+// front of, or underneath, every operation — and are exempt from the declared
+// check.
+//
 // CONFLICT (409) is a retryable SERIALIZABLE serialization abort: whichever
 // concurrent writer loses the optimistic-lock race emits it, so it can appear
 // on any write endpoint depending on timing and is not pin-able to a specific op.
-var universalConcurrencyCodes = map[string]bool{
-	"CONFLICT": true,
+//
+// UNAUTHORIZED (401) is emitted by the auth middleware before the request ever
+// reaches a handler, so it is producible on every authenticated route and
+// belongs to the middleware's contract rather than any one endpoint's. Its
+// coverage is pinned across representative routes by
+// TestAuth_MissingOrInvalidCredentials_401 (auth_failures_test.go).
+var universalCrossCuttingCodes = map[string]bool{
+	"CONFLICT":     true,
+	"UNAUTHORIZED": true,
 }
 
 // declaredGaps returns "op status code" strings for every observed error triple
 // whose operation is IN the matrix but whose (status, code) is undocumented.
-// Triples whose Code is in universalConcurrencyCodes are exempt: they are
-// cross-cutting, non-deterministic concurrency outcomes, not per-endpoint codes.
+// Triples whose Code is in universalCrossCuttingCodes are exempt: they belong
+// to the auth middleware or the concurrency layer, not to any one endpoint.
 func declaredGaps(matrix map[string][]codeCell, observed []openapivalidator.ErrorTriple) []string {
 	var gaps []string
 	for _, tr := range observed {
-		if universalConcurrencyCodes[tr.ErrorCode] {
+		if universalCrossCuttingCodes[tr.ErrorCode] {
 			continue // cross-cutting concurrency code; not endpoint-specific
 		}
 		cells, inScope := matrix[tr.Operation]

--- a/internal/e2e/zzz_errorcode_matrix_test.go
+++ b/internal/e2e/zzz_errorcode_matrix_test.go
@@ -90,6 +90,7 @@ var EntityErrorCodeMatrix = map[string][]codeCell{
 		{Status: 422, Code: "INVALID_UNIQUE_KEY"}, // TestUniqueKeys_CollectionPartialKeyCreate
 	},
 	"updateSingleWithLoopback": {
+		{Status: 400, Code: "BAD_REQUEST"},        // unparseable body, or a payload carrying U+0000 (TestEntity_NulInPayload_400)
 		{Status: 409, Code: "UNIQUE_VIOLATION"},   // TestUniqueKeys_UpdateMovesKey
 		{Status: 422, Code: "INVALID_UNIQUE_KEY"}, // TestUniqueKeys_LoopbackUpdatePartialKey
 		// 409 CONFLICT is exempt (universalCrossCuttingCodes)

--- a/plugins/postgres/entity_doc.go
+++ b/plugins/postgres/entity_doc.go
@@ -107,8 +107,17 @@ func unmarshalEntityDoc(raw []byte) (*spi.Entity, error) {
 
 	delete(doc, "_meta")
 
+	// A document with no domain keys left after removing _meta is either a
+	// legitimate empty payload or a DELETED version that carries none. Those
+	// are different things and the difference is observable, so report the
+	// empty payload as `{}` and only a deleted version as no data at all.
+	//
+	// Reporting `{}` as no data was a defect: the consumer decodes Data
+	// directly, decoding a zero-length slice is io.EOF, and the entity — plus
+	// every list of the model containing it — then failed permanently with a
+	// 500. memory and sqlite always round-tripped `{}` as `{}`.
 	var data []byte
-	if len(doc) > 0 {
+	if len(doc) > 0 || !meta.Deleted {
 		var err error
 		data, err = json.Marshal(doc)
 		if err != nil {

--- a/plugins/postgres/entity_doc.go
+++ b/plugins/postgres/entity_doc.go
@@ -82,6 +82,15 @@ func marshalEntityDoc(entity *spi.Entity, validTime, txTime, wallClockTime time.
 	if err := json.Unmarshal(entity.Data, &doc); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal entity data: %w", err)
 	}
+	// The JSON literal `null` unmarshals into a NIL map without error, and
+	// assigning into a nil map panics. That is reachable — a processor
+	// returning {"data":null} produces exactly these bytes — and the panic is
+	// only recovered several packages up, unwinding past the caller's
+	// non-deferred rollback, so the transaction is neither committed nor rolled
+	// back and its pooled connection is never returned. Fail cleanly instead.
+	if doc == nil {
+		return nil, fmt.Errorf("entity data must be a JSON object, got null")
+	}
 	doc["_meta"] = metaJSON
 	return json.Marshal(doc)
 }

--- a/plugins/postgres/entity_doc_empty_test.go
+++ b/plugins/postgres/entity_doc_empty_test.go
@@ -1,0 +1,92 @@
+package postgres
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestEntityDoc_EmptyObjectDataRoundTripsAsDecodableJSON pins the round-trip for
+// an entity whose domain payload is a legitimate empty object.
+//
+// marshalEntityDoc merges _meta into the domain data, so `{}` is stored as
+// `{"_meta":{...}}`. On read, _meta is deleted and — before this was fixed —
+// nothing remained, so Data was left nil. The consumer decodes Data directly
+// (internal/domain/entity/service.go), and decoding a zero-length slice is
+// io.EOF, which the service reports as an internal error. The observable
+// result was that `{}` wrote successfully and then returned 500 forever, on
+// the entity AND on the whole model's list endpoint.
+//
+// Data must therefore come back as decodable JSON, never as a zero-length
+// slice.
+func TestEntityDoc_EmptyObjectDataRoundTripsAsDecodableJSON(t *testing.T) {
+	ent := testEntity()
+	ent.Data = []byte(`{}`)
+
+	raw, err := marshalEntityDoc(ent, testTime, testTime, testTime, false)
+	if err != nil {
+		t.Fatalf("marshalEntityDoc: %v", err)
+	}
+
+	got, err := unmarshalEntityDoc(raw)
+	if err != nil {
+		t.Fatalf("unmarshalEntityDoc: %v", err)
+	}
+
+	if len(got.Data) == 0 {
+		t.Fatalf("Data came back empty; the consumer decodes it directly and a zero-length slice is io.EOF -> 500")
+	}
+	var m map[string]any
+	if err := json.Unmarshal(got.Data, &m); err != nil {
+		t.Fatalf("Data is not decodable JSON (%q): %v", got.Data, err)
+	}
+	if len(m) != 0 {
+		t.Errorf("Data = %q, want an empty object", got.Data)
+	}
+}
+
+// TestEntityDoc_EmptyObjectVersionRoundTrips covers the same property on the
+// version-history read path, which the model-wide list endpoint uses.
+func TestEntityDoc_EmptyObjectVersionRoundTrips(t *testing.T) {
+	ent := testEntity()
+	ent.Data = []byte(`{}`)
+
+	raw, err := marshalEntityDoc(ent, testTime, testTime, testTime, false)
+	if err != nil {
+		t.Fatalf("marshalEntityDoc: %v", err)
+	}
+
+	ver, err := unmarshalEntityVersion(raw, 1, testTime)
+	if err != nil {
+		t.Fatalf("unmarshalEntityVersion: %v", err)
+	}
+	if len(ver.Entity.Data) == 0 {
+		t.Fatalf("version Data came back empty; decoding it is io.EOF -> 500 on the list path")
+	}
+	var m map[string]any
+	if err := json.Unmarshal(ver.Entity.Data, &m); err != nil {
+		t.Fatalf("version Data is not decodable JSON (%q): %v", ver.Entity.Data, err)
+	}
+}
+
+// TestEntityDoc_DeletedVersionKeepsNoDomainData guards the fix from
+// over-reaching. A DELETED version legitimately carries no domain data — that
+// is distinct from an empty object, and the distinction is load-bearing for
+// version-history consumers. Only a non-deleted document with no domain keys
+// may be reported as `{}`.
+func TestEntityDoc_DeletedVersionKeepsNoDomainData(t *testing.T) {
+	ent := testEntity()
+	ent.Data = nil
+
+	raw, err := marshalEntityDoc(ent, testTime, testTime, testTime, true /* deleted */)
+	if err != nil {
+		t.Fatalf("marshalEntityDoc: %v", err)
+	}
+
+	got, err := unmarshalEntityDoc(raw)
+	if err != nil {
+		t.Fatalf("unmarshalEntityDoc: %v", err)
+	}
+	if len(got.Data) != 0 {
+		t.Errorf("deleted version Data = %q, want no domain data", got.Data)
+	}
+}

--- a/plugins/postgres/entity_doc_null_test.go
+++ b/plugins/postgres/entity_doc_null_test.go
@@ -1,0 +1,64 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEntityDoc_JSONNullDataIsRejectedNotPanic pins the handling of an entity
+// whose Data is the JSON literal `null`.
+//
+// This is reachable from the processor return path: a compute node's response
+// carries `data` as a json.RawMessage, so a processor returning {"data":null}
+// yields Data = []byte("null"). That is non-empty, so it passes the
+// len(entity.Data) == 0 branch above, and json.Unmarshal succeeds — into a NIL
+// map. Assigning _meta into a nil map panics.
+//
+// The panic is only recovered by the HTTP middleware three packages up, and it
+// unwinds past the explicit (non-deferred) h.rollbackOwned call on the save
+// error path in internal/domain/entity/service.go, so the transaction is
+// neither committed nor rolled back and its pooled connection is never
+// returned. Repeated, that exhausts the pool and the node stops serving.
+//
+// marshalEntityDoc must therefore return an error, letting the caller's normal
+// error path run.
+func TestEntityDoc_JSONNullDataIsRejectedNotPanic(t *testing.T) {
+	ent := testEntity()
+	ent.Data = []byte("null")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("marshalEntityDoc panicked on Data=null (%v); it must return an error so the caller can roll back", r)
+		}
+	}()
+
+	_, err := marshalEntityDoc(ent, testTime, testTime, testTime, false)
+	if err == nil {
+		t.Fatal("marshalEntityDoc accepted Data=null; want an error naming the problem")
+	}
+	if !strings.Contains(err.Error(), "object") {
+		t.Errorf("error %q does not explain that entity data must be a JSON object", err)
+	}
+}
+
+// TestEntityDoc_NonObjectDataIsRejected covers the sibling shapes. A top-level
+// array, string or number is not a valid entity document either; those already
+// fail to unmarshal into a map, so this only guards against a regression that
+// starts accepting them.
+func TestEntityDoc_NonObjectDataIsRejected(t *testing.T) {
+	for _, data := range []string{`[1,2]`, `"hello"`, `42`, `true`} {
+		ent := testEntity()
+		ent.Data = []byte(data)
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("marshalEntityDoc panicked on Data=%s: %v", data, r)
+				}
+			}()
+			if _, err := marshalEntityDoc(ent, testTime, testTime, testTime, false); err == nil {
+				t.Errorf("marshalEntityDoc accepted non-object Data=%s; want an error", data)
+			}
+		}()
+	}
+}


### PR DESCRIPTION
Closes #25.

Started as the E2E goroutine-safety work in #25 and grew, because the new coverage kept finding production defects. Seven commits, each one self-contained; the history is worth reading in order.

## What #25 asked for

**`t.Fatal` from goroutines — real, and broader than recorded.** 17 violations across 6 files, not just `doAuth`/`getToken`. `Fatal` only stops the calling goroutine, so a failing concurrent request left the test running past the failure it believed it had aborted on, and the failure was attributed to whichever test happened to be running.

The HTTP helpers are now split into a `t`-taking form and a context-taking `Raw` form returning an error, with the `t` form wrapping the `Raw` one so auth and the retry-on-retryable-409 loop stay defined exactly once. `internal/e2e/goroutinesafety` is a static guard against regression — it runs under `-short` without Docker, and its own fixtures pin that it actually fires, including the forms an earlier revision of it missed. Its blind spots are stated in the source rather than overclaimed.

**Shared `tenantBToken` — obsolete.** The variable and its file no longer exist.

**Coverage gaps — mostly overtaken.** The list predates ~80 E2E files. Genuinely missing and now added: auth failures (401 across five routes × five malformed-credential shapes, plus no-enumeration-signal), admin log-level, concurrent messaging, concurrent model lock, malformed JSON on create. `t.Parallel` is deliberately not adopted — the suite shares one database and a process-global log level.

## Production defects the coverage found

Each fixed under TDD, with the guard verified non-vacuous by reverting it.

| Defect | Was | Now |
|---|---|---|
| Trailing content after a valid JSON value | 500 | 400 |
| NUL (U+0000) in a payload | 500 pg / 200 memory+sqlite | 400 everywhere |
| Unpaired surrogate, invalid UTF-8 | 500 pg / 200 memory+sqlite | 400 everywhere |
| Empty payload `{}` | 200, then **500 forever** | 200 |
| Duplicate object names | 200, wrong workflow state | 400 |
| Number outside PostgreSQL `numeric` range | 500 pg / 200 others | 400 everywhere |
| Processor returning `{"data":null}` | panic → leaked connection | clean error |
| Processor returning off-model data | stored, then un-`PUT`-able | transition fails, rolls back |

Two deserve detail.

**`{}` made data permanently unreadable.** It wrote with 200 and then returned 500 forever — not only for that entity but for `GET /entity/{model}/{version}` across the *whole model*, because one unreadable row failed the entire listing. A `PUT {}` bricked a healthy entity the same way. postgres merges its `_meta` block into the domain data, so `{}` stored as `{"_meta":…}`; on read `_meta` was removed, nothing remained, and decoding empty data is `io.EOF`. Fixed in the plugin, distinguishing the two cases the old guard conflated: an empty payload reports `{}`, a DELETED version still reports no domain data.

**Duplicate keys silently corrupted workflow state.** Validation, `GET` and unique-key computation use `encoding/json` (last occurrence wins); the criterion evaluator, search and grouped statistics use `gjson` (first wins) — same bytes, same request. Measured with a criterion `amount == 5`:

```
control  {"amount":5}                        -> criterion fired,     PREMIUM
subject  {"amount":"not-a-number","amount":5} -> criterion did NOT fire, CREATED
                                              GET reports amount = 5
```

The API reported a value the engine never acted on. All three backends — the criterion runs against the request bytes before any store normalisation.

## Why the root cause was not fixed the obvious way

Every write path validates the *decoded* value and persists the *raw bytes*. The obvious fix — persist a re-serialisation of the validated value — was investigated and rejected on evidence.

It would have been permissible: byte preservation already does not happen (postgres re-marshals twice into `jsonb`, sqlite minifies, XML/PATCH/gRPC already store a re-marshal; only the memory store is byte-exact). But Go's decoder silently rewrites unpaired surrogates and invalid UTF-8 to U+FFFD, so re-serialising would store a character the client never sent — turning loud 500s into silent corruption. It also fixes neither the empty-payload bug nor numeric overflow, since `UseNumber()` re-emits the literal byte-identically.

So the guard reads the **raw request bytes** and rejects at the boundary. It walks with `json.RawMessage` so it still reports the offending field path, and reads objects with a token decoder — a map would collapse duplicate names before anything could see them.

## Processor output is now governed by the model

A processor's returned data passes the same storability guard and the same `validateOrExtend` as a client write. It may extend an entity beyond its model exactly where a client could — governed by `changeLevel` — and never otherwise. On failure the transition fails and rolls back, rather than returning 400 to a caller who sent nothing wrong.

This required extracting the shared checks into `internal/domain/model/ingest` (committed separately as a pure refactor): `entity` imports `workflow`, so the engine can never call back into the entity handler, and the scheduled ingress has no handler at all.

Two implementation notes:

- **Two hook points, not three.** Both commit-before-dispatch branches converge before their shared save, so each stages its result and it is checked once on `TX_post`. Checking earlier would run a schema extension outside any transaction — the context there still carries the already-committed `TX_pre`.
- **The descriptor resolves lazily, at most once.** Lazily because a pipeline whose processors never return data needs no descriptor; resolving eagerly broke 34 tests instead of 19, mostly for that reason alone. At most once because the model cache is not transaction-aware and `ExtendSchema` invalidates it before commit, so re-reading between processors could reject the *next* processor's legitimate field.

**This conforms to Cloud, it does not change the contract.** `ExternalizedProcessHandlerService.applyDataPayloadResponse` routes processor output through `parseEntities(modelKey = …)` → `completeAndValidate` → `validateEntity(modelKey, allowedChangeLevel, …)`. Cloud already validates processor output against the model, governed by the same lever. Gate 7 is therefore not triggered and no `docs/cloud-parity/` note is needed.

~60 test fixtures had processors writing fields their models did not declare. All fixed by declaring the field in the model sample, never by raising `changeLevel` — raising it makes the model absorb *any* new key, so a typo'd field name would silently widen the model instead of failing, weakening the assertions those tests exist for.

## Deliberate omissions

- **No new error codes.** Every rejection reuses `BAD_REQUEST` or `WORKFLOW_FAILED`, so no `errors/<CODE>.md` and no `TestErrCode_Parity` change.
- **No parity scenario for processor-output governance.** Every check there runs above the SPI before any store is called, so no backend can answer differently — unlike the storability guard, where backends genuinely disagreed. Reason recorded at the rule.
- **Rollback is still not panic-safe.** The known trigger is fixed, but `rollbackOwned` is a plain error-path call at ~20 sites, so any panic in a write path leaks its connection. Filed as #466 for v0.8.4; it changes the transaction lifecycle and wants its own review.
- **`ExtendSchema` is rollback-bound only on postgres.** Pre-existing for client writes; inherited here by design rather than worked around.

Also recorded, unrelated and unfixed: `openapivalidator.WithTestT` is dead plumbing — the helpers attach `t` to the *client* context while the middleware reads the *server's* across a real TCP listener, so conformance mismatches are all attributed to `"unknown"` and enforce mode is unreachable. The misleading comment was corrected rather than inherited as a true claim.

## Verification

`gofmt` and `go vet` clean · `go test ./...` 61 packages · `make test-all` 64 including plugin submodules · `make race` 0 data races · parity scenarios 223 → 225, green on memory, sqlite and postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcbMZuZc3cbxZTevKpeL7w
