### PR TITLE
fix(workflow): resolve the workflow by criterion on every engine door (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   Where definitions share state names — the normal shape for a per-kind machine — that
   is always the *first* declared workflow, for every entity: the wrong guards,
   processors and target states, silently and fail-open. Entities admitted past guards
-  belonging to another kind, and transitions declared on one kind only answered **409**
-  for everything. Selection at creation was correct, which is why the binding looked
+  belonging to another kind, and a transition declared on one kind only was reported as
+  absent (**400 TRANSITION_NOT_FOUND**) for every entity. Selection at creation was correct, which is why the binding looked
   right in the creation audit. All four doors now resolve through the documented
   criterion rules on every call, and the `WORKFLOW_SKIP` / `WORKFLOW_FOUND` audit
   events — previously emitted only on creation — record which definition ran on each
@@ -43,8 +43,12 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   changes can re-bind to a different definition. If its current state is not declared
   there, the engine no longer falls through to a definition that happens to declare it:
   the transition is rejected with **400 WORKFLOW_FAILED**, a loopback settles as a
-  no-op, and an obsolete scheduled task is discarded. Prefer selection criteria that
-  stay true for an entity's whole lifetime.
+  no-op, and a scheduled task the selected workflow no longer declares as a scheduled
+  transition of that state is discarded and recorded as `SCHEDULED_TRANSITION_CANCEL`.
+  Prefer selection criteria that stay true for an entity's whole lifetime, and that read
+  fields a caller cannot rewrite in the same request — the criterion is evaluated
+  against the payload of the request being served, so where definitions differ in what
+  they permit, the selection field is a security control.
   ([#465](https://github.com/Cyoda-platform/cyoda-go/issues/465))
 
 - **`GET /entity/{entityId}/transitions` no longer answers from the wrong workflow when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,39 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **On a model with several imported workflows, every operation after creation ran the
+  wrong workflow's definition.** A named transition, a loopback re-evaluation and a
+  scheduled transition firing all resolved the workflow by "the first active definition
+  that declares the entity's current state", ignoring the entity's selection criterion.
+  Where definitions share state names — the normal shape for a per-kind machine — that
+  is always the *first* declared workflow, for every entity: the wrong guards,
+  processors and target states, silently and fail-open. Entities admitted past guards
+  belonging to another kind, and transitions declared on one kind only answered **409**
+  for everything. Selection at creation was correct, which is why the binding looked
+  right in the creation audit. All four doors now resolve through the documented
+  criterion rules on every call, and the `WORKFLOW_SKIP` / `WORKFLOW_FOUND` audit
+  events — previously emitted only on creation — record which definition ran on each
+  of them.
+
+  **Integrators:** because selection is re-evaluated per call, an entity whose payload
+  changes can re-bind to a different definition. If its current state is not declared
+  there, the engine no longer falls through to a definition that happens to declare it:
+  the transition is rejected with **400 WORKFLOW_FAILED**, a loopback settles as a
+  no-op, and an obsolete scheduled task is discarded. Prefer selection criteria that
+  stay true for an entity's whole lifetime.
+  ([#465](https://github.com/Cyoda-platform/cyoda-go/issues/465))
+
+- **`GET /entity/{entityId}/transitions` no longer answers from the wrong workflow when
+  a selection criterion cannot be evaluated, and no longer writes to the audit trail.**
+  A criterion that failed to evaluate — a `function` criterion with no compute member
+  for its tags, for instance — was swallowed and the *default* workflow's transitions
+  were returned instead: a wrong-but-available answer. It now fails the request. The
+  same read was also recording `WORKFLOW_SKIP` / `WORKFLOW_FOUND` events against an
+  empty transaction id, despite intending not to; it now records nothing. A criterion
+  that merely does not *match* still resolves to the default workflow, which is
+  selection working as documented.
+  ([#465](https://github.com/Cyoda-platform/cyoda-go/issues/465))
+
 - **A payload that repeats a name within one object is now rejected with 400.**
   A duplicated name was read as the *last* occurrence by schema validation, the `GET`
   response and unique-key computation, and as the *first* by the workflow criterion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,14 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   **Integrators:** because selection is re-evaluated per call, an entity whose payload
   changes can re-bind to a different definition. If its current state is not declared
   there, the engine no longer falls through to a definition that happens to declare it:
-  the transition is rejected with **400 WORKFLOW_FAILED**, a loopback settles as a
-  no-op, and a scheduled task the selected workflow no longer declares as a scheduled
-  transition of that state is discarded and recorded as `SCHEDULED_TRANSITION_CANCEL`.
-  Prefer selection criteria that stay true for an entity's whole lifetime, and that read
-  fields a caller cannot rewrite in the same request — the criterion is evaluated
-  against the payload of the request being served, so where definitions differ in what
-  they permit, the selection field is a security control.
+  the transition is rejected with **400 WORKFLOW_FAILED** and a loopback settles as a
+  no-op. A scheduled task the newly selected workflow no longer declares is not
+  cancelled by that write — it is discarded when it next comes due, recorded as
+  `SCHEDULED_TRANSITION_CANCEL`. Prefer selection criteria that stay true for an
+  entity's whole lifetime, and that read fields a caller cannot rewrite in the same
+  request: the criterion is evaluated against the payload of the request being served,
+  so where definitions differ in what they permit, the selection field is a security
+  control.
   ([#465](https://github.com/Cyoda-platform/cyoda-go/issues/465))
 
 - **`GET /entity/{entityId}/transitions` no longer answers from the wrong workflow when

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1576,9 +1576,11 @@ paths:
         consistency time is used.
 
 
-        The transitions list is derived from the workflow definition that
-        matches the entity's model. If no workflow matches, the default
-        workflow is used.
+        The transitions list is derived from the workflow definition the
+        entity's selection criterion binds it to — the same definition a
+        subsequent transition will run. If no workflow criterion matches,
+        the default workflow is used; if a criterion cannot be evaluated,
+        the request fails rather than answering from another workflow.
       operationId: getEntityTransitions
       parameters:
         - name: entityId

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1621,7 +1621,8 @@ paths:
                 - REJECT
         "400":
           description: Bad request — invalid entityId, mutually exclusive parameters
-            supplied, or invalid format
+            supplied, invalid format, or the workflow selection criterion could not
+            be evaluated (WORKFLOW_FAILED)
           content:
             application/problem+json:
               schema:
@@ -1643,6 +1644,19 @@ paths:
                 title: Not Found
                 status: 404
                 detail: entity 1d1e1b10-1155-11f0-bcd5-ae468cd3ed16 not found
+                instance: /api/entity/1d1e1b10-1155-11f0-bcd5-ae468cd3ed16/transitions
+        "503":
+          description: A `function` workflow selection criterion needs a compute member
+            for its tags and none is connected. Retryable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+              example:
+                type: about:blank
+                title: Service Unavailable
+                status: 503
+                detail: "no calculation member registered for tags: selector-service"
                 instance: /api/entity/1d1e1b10-1155-11f0-bcd5-ae468cd3ed16/transitions
         default:
           $ref: '#/components/responses/InternalServerError'

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -16,6 +16,7 @@ see_also:
   - errors.IDEMPOTENCY_CONFLICT
   - errors.TRANSITION_NOT_FOUND
   - errors.WORKFLOW_FAILED
+  - errors.NO_COMPUTE_MEMBER_FOR_TAG
   - errors.UNIQUE_VIOLATION
   - errors.INVALID_UNIQUE_KEY
   - messages
@@ -395,7 +396,7 @@ Response: `200 OK`, `application/json`, array of change entries in reverse-chron
 
 Response: `200 OK`, `application/json`, array of available transition names (as returned by the workflow engine).
 
-The names come from the workflow the entity's criterion selects — the same definition a subsequent transition will run (see `cyoda help workflows`, *Workflow-level selection*). A workflow criterion that cannot be evaluated (e.g. a `function` criterion with no compute member for its tags) fails the request rather than answering from a different workflow.
+The names come from the workflow the entity's criterion selects — the same definition a subsequent transition will run (see `cyoda help workflows`, *Workflow-level selection*). Because selection is evaluated here, this read carries the same failure modes as a write: `400 WORKFLOW_FAILED` when a criterion cannot be evaluated, `503 NO_COMPUTE_MEMBER_FOR_TAG` when the cause is specifically an unavailable compute member for a `function` criterion's tags. The request fails rather than answering from a different workflow. The read records no audit events.
 
 **GET /api/platform-api/entity/fetch/transitions** — List available transitions (platform-api format)
 
@@ -639,7 +640,8 @@ See `cyoda help errors ENTITY_MODIFIED` for the recovery flow on a `412`.
 - `errors.UNIQUE_VIOLATION` — `409` — a declared composite unique key already holds this field-value combination
 - `errors.INVALID_UNIQUE_KEY` — `422` — a unique-key field is null, missing, or has an out-of-range value
 - `errors.TRANSITION_NOT_FOUND` — `400` — named transition does not exist in the workflow
-- `errors.WORKFLOW_FAILED` — `400` — the workflow engine rejected the write: a transition criterion did not match, a processor failed, or the workflow selected for the entity does not declare its current state. Applies to create, a named transition, and a transition-less (loopback) update alike
+- `errors.WORKFLOW_FAILED` — `400` — the workflow engine rejected the operation: a transition criterion did not match, a processor failed, the workflow selected for the entity does not declare its current state, or a workflow selection criterion could not be evaluated. Reachable on create, a named transition, a transition-less (loopback) update, and both transitions reads — selection runs on every door
+- `errors.NO_COMPUTE_MEMBER_FOR_TAG` — `503` — retryable — a `function` criterion or processor needs a compute member for its tags and none is connected. Reachable on the transitions reads too, since they evaluate workflow selection criteria
 - `errors.BAD_REQUEST` — `400` — malformed request, invalid UUID, conflicting query parameters, states filter exceeds 1000 entries
 - Grouped-stats query (`POST /api/entity/stats/{entityName}/{modelVersion}/query`) — `404 MODEL_NOT_FOUND` when the model is not registered for the calling tenant; `400` for validation failures (`MALFORMED_REQUEST`, `MISSING_GROUP_BY`, `INVALID_GROUP_BY_PATH`, `DUPLICATE_GROUP_BY`, `INVALID_AGGREGATION_OP`, `INVALID_AGGREGATION_FIELD`, `DUPLICATE_AGGREGATION_ALIAS`, `INVALID_POINT_IN_TIME`, `INVALID_LIMIT`); `400` propagated from the search-condition validator (`INVALID_OPERATOR`, `INVALID_CONDITION`, `INVALID_FIELD_PATH`, `CONDITION_TYPE_MISMATCH`); `422 GROUP_CARDINALITY_EXCEEDED` when distinct buckets would exceed `CYODA_STATS_GROUP_MAX`; `501 NOT_IMPLEMENTED_BY_BACKEND` when the storage backend implements neither `Iterable` nor `GroupedAggregator`. The full enumeration with descriptions is in the grouped-stats endpoint section above.
 

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -15,6 +15,7 @@ see_also:
   - errors.CONFLICT
   - errors.IDEMPOTENCY_CONFLICT
   - errors.TRANSITION_NOT_FOUND
+  - errors.WORKFLOW_FAILED
   - errors.UNIQUE_VIOLATION
   - errors.INVALID_UNIQUE_KEY
   - messages
@@ -637,7 +638,8 @@ See `cyoda help errors ENTITY_MODIFIED` for the recovery flow on a `412`.
 - `errors.IDEMPOTENCY_CONFLICT` — `409` — reserved; not yet implemented. Future contract: returned on collection create/update when the `Idempotency-Key` header is re-used with a different payload body
 - `errors.UNIQUE_VIOLATION` — `409` — a declared composite unique key already holds this field-value combination
 - `errors.INVALID_UNIQUE_KEY` — `422` — a unique-key field is null, missing, or has an out-of-range value
-- `errors.TRANSITION_NOT_FOUND` — `404` — named transition does not exist in the workflow
+- `errors.TRANSITION_NOT_FOUND` — `400` — named transition does not exist in the workflow
+- `errors.WORKFLOW_FAILED` — `400` — the workflow engine rejected the write: a transition criterion did not match, a processor failed, or the workflow selected for the entity does not declare its current state. Applies to create, a named transition, and a transition-less (loopback) update alike
 - `errors.BAD_REQUEST` — `400` — malformed request, invalid UUID, conflicting query parameters, states filter exceeds 1000 entries
 - Grouped-stats query (`POST /api/entity/stats/{entityName}/{modelVersion}/query`) — `404 MODEL_NOT_FOUND` when the model is not registered for the calling tenant; `400` for validation failures (`MALFORMED_REQUEST`, `MISSING_GROUP_BY`, `INVALID_GROUP_BY_PATH`, `DUPLICATE_GROUP_BY`, `INVALID_AGGREGATION_OP`, `INVALID_AGGREGATION_FIELD`, `DUPLICATE_AGGREGATION_ALIAS`, `INVALID_POINT_IN_TIME`, `INVALID_LIMIT`); `400` propagated from the search-condition validator (`INVALID_OPERATOR`, `INVALID_CONDITION`, `INVALID_FIELD_PATH`, `CONDITION_TYPE_MISMATCH`); `422 GROUP_CARDINALITY_EXCEEDED` when distinct buckets would exceed `CYODA_STATS_GROUP_MAX`; `501 NOT_IMPLEMENTED_BY_BACKEND` when the storage backend implements neither `Iterable` nor `GroupedAggregator`. The full enumeration with descriptions is in the grouped-stats endpoint section above.
 

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -394,6 +394,8 @@ Response: `200 OK`, `application/json`, array of change entries in reverse-chron
 
 Response: `200 OK`, `application/json`, array of available transition names (as returned by the workflow engine).
 
+The names come from the workflow the entity's criterion selects — the same definition a subsequent transition will run (see `cyoda help workflows`, *Workflow-level selection*). A workflow criterion that cannot be evaluated (e.g. a `function` criterion with no compute member for its tags) fails the request rather than answering from a different workflow.
+
 **GET /api/platform-api/entity/fetch/transitions** — List available transitions (platform-api format)
 
 - `entityClass` (query, required): string in `Name.Version` format, e.g., `Offer.1`

--- a/cmd/cyoda/help/content/errors.md
+++ b/cmd/cyoda/help/content/errors.md
@@ -94,7 +94,7 @@ The `retryable` property is present and `true` only when the operation is safe t
 - `errors.TRANSACTION_EXPIRED` — `400` — not retryable — transaction token's `exp` claim is in the past
 - `errors.TRANSACTION_NODE_UNAVAILABLE` — `503` — retryable — cluster node that owns the open transaction is unreachable
 - `errors.TRANSACTION_NOT_FOUND` — `404` — not retryable — transaction ID does not correspond to an active transaction on this node
-- `errors.TRANSITION_NOT_FOUND` — `404` — not retryable — requested workflow transition is not defined for the entity's current state
+- `errors.TRANSITION_NOT_FOUND` — `400` — not retryable — requested workflow transition is not defined for the entity's current state
 - `errors.TRUSTED_KEY_CAP_REACHED` — `400` — not retryable — Per-tenant trusted-key cap reached.
 - `errors.TRUSTED_KEY_NOT_FOUND` — `404` — not retryable — referenced trusted-key KID is not present in the registry (delete / invalidate / reactivate target missing)
 - `errors.TX_CONFLICT` — `409` — retryable — transaction aborted due to storage-level serialization conflict

--- a/cmd/cyoda/help/content/errors/TRANSITION_NOT_FOUND.md
+++ b/cmd/cyoda/help/content/errors/TRANSITION_NOT_FOUND.md
@@ -16,11 +16,13 @@ TRANSITION_NOT_FOUND — the requested workflow transition is not defined for th
 
 ## SYNOPSIS
 
-HTTP: `404` `Not Found`. Retryable: `no`.
+HTTP: `400` `Bad Request`. Retryable: `no`.
 
 ## DESCRIPTION
 
-Entity workflow state machines define explicit transitions between states. This error fires when a transition is triggered that does not exist in the model's workflow definition for the entity's current state. Also occurs when the transition name is misspelled or when the entity is in a terminal state that allows no further transitions.
+Entity workflow state machines define explicit transitions between states. This error fires when a transition is triggered that does not exist in the model's workflow definition for the entity's current state. Also occurs when the transition name is misspelled, when the transition is disabled, when it is a scheduled transition (those fire on their timer and are never manually fireable), or when the entity is in a terminal state that allows no further transitions.
+
+The workflow consulted is the one the entity's selection criterion binds it to, not merely one that declares the state — see `cyoda help workflows`, *Workflow-level selection*. On a model with several workflows, a transition can therefore be valid for one entity and absent for another in the same state.
 
 Not retryable. The workflow definition and the entity's current state determine which transition names are valid.
 

--- a/cmd/cyoda/help/content/errors/WORKFLOW_FAILED.md
+++ b/cmd/cyoda/help/content/errors/WORKFLOW_FAILED.md
@@ -6,6 +6,7 @@ see_also:
   - errors
   - errors.WORKFLOW_NOT_FOUND
   - errors.TRANSITION_NOT_FOUND
+  - errors.NO_COMPUTE_MEMBER_FOR_TAG
 ---
 
 # errors.WORKFLOW_FAILED
@@ -22,7 +23,12 @@ HTTP: `400` `Bad Request`. Retryable: `no`.
 
 During an entity create or transition operation the associated workflow processors (pre-processors, post-processors) or guard conditions ran but one of them signalled failure. The failure message from the processor is included in the error detail.
 
-Not retryable unless the underlying condition has changed. The failure originates from application logic in the processor; the data, the processor implementation, or the workflow configuration determines the outcome.
+Two further causes are not processor failures at all, and reach the read endpoints `GET /entity/{entityId}/transitions` and `GET /platform-api/entity/fetch/transitions` as well as the write paths:
+
+- The workflow selected for the entity does not declare its current state. Selection is by criterion and is re-evaluated on every call, so a data change can bind an entity to a definition that does not model the state it is parked in. The engine rejects rather than falling through to another definition that happens to declare it.
+- A workflow selection criterion could not be evaluated. Where the cause is an unavailable compute member the error is `NO_COMPUTE_MEMBER_FOR_TAG` (`503`, retryable) instead.
+
+Not retryable unless the underlying condition has changed. The failure originates from application logic in the processor, or from the workflow configuration; the data, the processor implementation, or the workflow configuration determines the outcome.
 
 ## SEE ALSO
 

--- a/cmd/cyoda/help/content/workflows.md
+++ b/cmd/cyoda/help/content/workflows.md
@@ -365,12 +365,17 @@ evaluation and of any other API call touching the entity.
   currently dispatchable from the caller's POV." The entity remains
   in the source state. To allow early firing, give the state an
   ordinary manual transition alongside the scheduled one.
-- **Audit trail.** Arming, firing, expiry, and cancellation (the
-  entity leaving the source state before the timer fires) each emit a
+- **Audit trail.** Arming, firing, expiry, and cancellation each emit a
   dedicated event: `SCHEDULED_TRANSITION_ARM`, `SCHEDULED_TRANSITION_FIRE`
   (alongside the ordinary `TRANSITION_MAKE`), `SCHEDULED_TRANSITION_EXPIRE`,
   `SCHEDULED_TRANSITION_CANCEL`. A loopback that re-arms the same state
-  emits only `ARM`, not `CANCEL`.
+  emits only `ARM`, not `CANCEL`. `CANCEL` has two causes: the entity left
+  the source state before the timer fired, or the task came due and the
+  workflow now selected for the entity does not declare it as a scheduled
+  transition of that state (see *Workflow-level selection*). A task that is
+  both obsolete and past its `timeoutMs` grace band records `EXPIRE`, not
+  `CANCEL` — expiry is decided from the stored task and the clock alone,
+  before the workflow is consulted.
 
 **One-shot vs. polling.** The criterion is evaluated once per fire —
 there is no built-in retry-until-true. Three shapes cover the common
@@ -432,7 +437,9 @@ Place a `null`-criterion (or otherwise unconditional) workflow last in the impor
 
 Workflow-level selection is independent of transition-level selection: once a workflow is chosen, the engine then applies the transition-evaluation rules above against that workflow's `states` map.
 
-Because selection is re-evaluated per call, editing an entity's payload can re-bind it to a different definition. If its current state is not declared in the newly selected workflow, the engine does **not** fall through to another definition that happens to declare it: a named transition is rejected with `400 WORKFLOW_FAILED`, a loopback settles as a no-op, and a pending scheduled task the selected workflow no longer declares as a scheduled transition of that state is discarded and recorded as `SCHEDULED_TRANSITION_CANCEL`.
+Because selection is re-evaluated per call, editing an entity's payload can re-bind it to a different definition. If its current state is not declared in the newly selected workflow, the engine does **not** fall through to another definition that happens to declare it: a named transition is rejected with `400 WORKFLOW_FAILED`, and a loopback settles as a no-op.
+
+A pending scheduled task the newly selected workflow no longer declares as a scheduled transition of that state is **not** cancelled by the write that caused the re-bind: cancellation on re-arm only removes tasks for a state the entity has left, and this one names the state the entity is still in. The task is discarded when it next comes due — the fire door re-resolves the workflow, finds no such scheduled transition, deletes the row and records `SCHEDULED_TRANSITION_CANCEL`. Nothing wrong fires in the meantime, but a timer retired this way is reported at its scheduled time, not at the write, and is attributed to the system principal.
 
 Two consequences worth designing for:
 

--- a/cmd/cyoda/help/content/workflows.md
+++ b/cmd/cyoda/help/content/workflows.md
@@ -432,7 +432,12 @@ Place a `null`-criterion (or otherwise unconditional) workflow last in the impor
 
 Workflow-level selection is independent of transition-level selection: once a workflow is chosen, the engine then applies the transition-evaluation rules above against that workflow's `states` map.
 
-Because selection is re-evaluated per call, editing an entity's payload can re-bind it to a different definition. If its current state is not declared in the newly selected workflow, the engine does **not** fall through to another definition that happens to declare it: a named transition is rejected with `400 WORKFLOW_FAILED`, a loopback settles as a no-op, and a pending scheduled task for a transition the selected workflow no longer declares is discarded. Give per-kind workflows criteria that stay true for the entity's whole lifetime — a criterion over a mutable field can strand entities mid-flow.
+Because selection is re-evaluated per call, editing an entity's payload can re-bind it to a different definition. If its current state is not declared in the newly selected workflow, the engine does **not** fall through to another definition that happens to declare it: a named transition is rejected with `400 WORKFLOW_FAILED`, a loopback settles as a no-op, and a pending scheduled task the selected workflow no longer declares as a scheduled transition of that state is discarded and recorded as `SCHEDULED_TRANSITION_CANCEL`.
+
+Two consequences worth designing for:
+
+- **Select on fields the caller cannot rewrite.** The criterion is evaluated against the payload of the request being served, so a criterion over a client-writable field lets one request choose which definition's guards apply to itself. Where definitions differ in what they permit, select on immutable fields or on lifecycle metadata.
+- **Select on something that stays true for the entity's whole lifetime.** A criterion over a field that changes mid-flow can strand an entity in a state its new definition does not declare, and can silently retire a scheduled transition that was acting as a time-based control.
 
 Selection is audited: each skipped workflow records a `WORKFLOW_SKIP` event (with the criterion's rejection reason) and the chosen one a `WORKFLOW_FOUND` event, under the transaction driving the call. `GET /entity/{entityId}/transitions` is a pure read and records nothing.
 
@@ -524,7 +529,7 @@ Per-state visit limit (default 10) and total cascade depth limit (100) are enfor
 
 ## ERRORS
 
-- `errors.TRANSITION_NOT_FOUND` — `404` — named transition does not exist in the current state's workflow
+- `errors.TRANSITION_NOT_FOUND` — `400` — named transition does not exist in the current state's workflow
 - `errors.WORKFLOW_NOT_FOUND` — `404` — no workflows found for the model (export endpoint)
 - `errors.WORKFLOW_FAILED` — workflow engine encountered an unrecoverable error during execution
 - `errors.NO_COMPUTE_MEMBER_FOR_TAG` — no registered calculation node matches the required `calculationNodesTags`

--- a/cmd/cyoda/help/content/workflows.md
+++ b/cmd/cyoda/help/content/workflows.md
@@ -420,7 +420,7 @@ A `null` criterion on a workflow means the workflow matches any entity. A `null`
 
 ### Workflow-level selection
 
-When a model has more than one imported workflow definition, the engine picks the workflow per entity at execution time using these rules — applied in order on every `Execute` / `ManualTransition` / `Loopback` (no caching across calls):
+When a model has more than one imported workflow definition, the engine picks the workflow per entity at execution time using these rules — applied in order on **every** door onto the engine, with no caching across calls: entity creation, a named transition, a loopback re-evaluation, a scheduled transition firing, and `GET /entity/{entityId}/transitions`:
 
 1. Iterate workflows in their stored declaration order. (Storage preserves the order from the most recent import; MERGE inserts new workflows at the tail.)
 2. Skip any workflow whose `active` flag is `false`. Inactive workflows are invisible to selection, regardless of their criterion.
@@ -431,6 +431,10 @@ When a model has more than one imported workflow definition, the engine picks th
 Place a `null`-criterion (or otherwise unconditional) workflow last in the import array if you want it to act as a catch-all. Any active workflows declared after it are unreachable for the same reason an unguarded automated transition shadows successors at the transition level.
 
 Workflow-level selection is independent of transition-level selection: once a workflow is chosen, the engine then applies the transition-evaluation rules above against that workflow's `states` map.
+
+Because selection is re-evaluated per call, editing an entity's payload can re-bind it to a different definition. If its current state is not declared in the newly selected workflow, the engine does **not** fall through to another definition that happens to declare it: a named transition is rejected with `400 WORKFLOW_FAILED`, a loopback settles as a no-op, and a pending scheduled task for a transition the selected workflow no longer declares is discarded. Give per-kind workflows criteria that stay true for the entity's whole lifetime — a criterion over a mutable field can strand entities mid-flow.
+
+Selection is audited: each skipped workflow records a `WORKFLOW_SKIP` event (with the criterion's rejection reason) and the chosen one a `WORKFLOW_FOUND` event, under the transaction driving the call. `GET /entity/{entityId}/transitions` is a pure read and records nothing.
 
 ## IMPORT REQUEST
 

--- a/docs/cloud-parity/scheduled-transitions.md
+++ b/docs/cloud-parity/scheduled-transitions.md
@@ -119,6 +119,18 @@ time-based control (auto-expire, escalate-if-not-approved). A vanished timer
 must be attributable. The silent guards above are self-healing race outcomes;
 this one is a lifecycle event.
 
+Expiry takes precedence over this classification: a task that is both obsolete
+and past `TimeoutMs` + grace records `SCHEDULED_TRANSITION_EXPIRE`, because the
+expiry gate runs before the workflow is resolved. Which of the two an obsolete
+late task records therefore depends on scan timing; both delete the row.
+
+The cancellation is **lazy** — it happens when the task comes due, not at the
+write that re-bound the entity. `ReconcileForEntity` cancels only rows whose
+`SourceState` the entity has left, so a task naming the state the entity is
+still in survives the re-bind. Nothing wrong fires in the meantime (the fire
+door re-resolves and refuses), but the event lands at the scheduled time and is
+attributed to the system principal rather than to the causing write.
+
 Workflow selection itself records `WORKFLOW_SKIP` / `WORKFLOW_FOUND` on the
 fire door, as on every other door. Resolution is ordered **after** the silent
 guards and after the expiry gate, so those events appear only on an attempt

--- a/docs/cloud-parity/scheduled-transitions.md
+++ b/docs/cloud-parity/scheduled-transitions.md
@@ -103,11 +103,30 @@ write) and must not regress to an entry-time-only timer.
 | Fired | `SCHEDULED_TRANSITION_FIRE` + `TRANSITION_MAKE` | Scheduler-origin marker alongside the ordinary transition-made event. |
 | Declined | `TRANSITION_NOT_MATCH_CRITERION` | Existing event, reused — no dedicated "declined" event. |
 | Expired | `SCHEDULED_TRANSITION_EXPIRE` | Delete-gated: only the worker whose `Delete` actually removed the row emits it. |
-| Cancelled | `SCHEDULED_TRANSITION_CANCEL` | Only when the entity genuinely left `sourceState`; a same-state loopback never cancels. |
+| Cancelled | `SCHEDULED_TRANSITION_CANCEL` | Two causes: the entity genuinely left `sourceState` (a same-state loopback never cancels), or the fire found the task obsolete — see below. |
 
 A guard-fail drop during a fire attempt (task already gone, entity already
 moved on, task re-armed to the future) is **silent** — no audit event — by
 design; it is not a distinct outcome from Cloud's point of view.
+
+An **obsolete** task — one whose transition the workflow selected for the
+entity does not declare as a scheduled, non-manual, enabled transition of
+`sourceState` — is deleted and recorded as `SCHEDULED_TRANSITION_CANCEL`.
+This is deliberately NOT silent: workflow selection is criterion-based and
+re-evaluated on every call, so an ordinary client write can re-bind an entity
+to a definition without that timer, and a scheduled transition is often a
+time-based control (auto-expire, escalate-if-not-approved). A vanished timer
+must be attributable. The silent guards above are self-healing race outcomes;
+this one is a lifecycle event.
+
+Workflow selection itself records `WORKFLOW_SKIP` / `WORKFLOW_FOUND` on the
+fire door, as on every other door. Resolution is ordered **after** the silent
+guards and after the expiry gate, so those events appear only on an attempt
+that genuinely reached a definition — an expired or silently-dropped task
+records no selection events. Expiry is decided from the durable row and the
+clock alone, never gated behind resolution: otherwise a task whose selection
+criterion cannot be evaluated (compute member down) would be unexpirable and
+re-dispatched indefinitely.
 
 ## 7. Multi-node correctness contract
 

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 225 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 226 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -133,8 +133,10 @@ var allTests = []NamedTest{
 	// fail-closed rather than the pre-fix silent empty-result degradation.
 	{"SearchScalarOnContainerPath400", RunSearchScalarOnContainerPath400},
 
-	// Phase 4b — workflow selection (Task 4b.7)
+	// Phase 4b — workflow selection (Task 4b.7). Selection applies on every
+	// engine door, so the post-creation doors are pinned alongside creation.
 	{"WorkflowCriteriaSelectingWorkflow", RunWorkflowCriteriaSelectingWorkflow},
+	{"WorkflowSelectionAfterCreation", RunWorkflowSelectionAfterCreation},
 
 	// Phase 4b — distributed-safety contracts (Tasks 4b.9-10)
 	{"ConcurrentConflictingUpdate", RunConcurrentConflictingUpdate},

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 225
+const wantParityScenarioCount = 226
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/e2e/parity/workflow_proc.go
+++ b/e2e/parity/workflow_proc.go
@@ -281,3 +281,100 @@ func RunWorkflowManualTransition(t *testing.T, fixture BackendFixture) {
 		t.Errorf("expected data.tag=\"foo\" (tag-with-foo processor), got %v", got.Data["tag"])
 	}
 }
+
+// wfSelectionSample declares the fields the per-kind selection criteria read
+// by RunWorkflowSelectionAfterCreation. A locked model rejects undeclared
+// fields, so both must appear in the sample.
+const wfSelectionSample = `{"name":"Test","kind":"a","go":false}`
+
+// wfSelectionWorkflows imports two active workflows that declare THE SAME
+// STATE NAMES — the normal shape for a per-kind machine — distinguished only
+// by their `criterion`. kind-a-wf is declared first, so a resolver that picks
+// "the first active workflow declaring the entity's current state" returns it
+// for every entity regardless of kind. Each workflow's transitions land in
+// differently-named target states, so the observed state alone identifies
+// which definition ran. The criteria are inline predicates over the payload,
+// so no compute node is involved.
+const wfSelectionWorkflows = `{
+	"importMode": "REPLACE",
+	"workflows": [
+		{
+			"version": "1.1", "name": "kind-a-wf", "initialState": "NONE", "active": true,
+			"criterion": {"type": "simple", "jsonPath": "$.kind", "operatorType": "EQUALS", "value": "a"},
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [
+					{"name": "check", "next": "A_CHECKED", "manual": true},
+					{"name": "a-advance", "next": "A_ADVANCED", "manual": false,
+						"criterion": {"type": "simple", "jsonPath": "$.go", "operatorType": "EQUALS", "value": true}}
+				]},
+				"A_CHECKED": {},
+				"A_ADVANCED": {}
+			}
+		},
+		{
+			"version": "1.1", "name": "kind-b-wf", "initialState": "NONE", "active": true,
+			"criterion": {"type": "simple", "jsonPath": "$.kind", "operatorType": "EQUALS", "value": "b"},
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [
+					{"name": "check", "next": "B_CHECKED", "manual": true},
+					{"name": "b-advance", "next": "B_ADVANCED", "manual": false,
+						"criterion": {"type": "simple", "jsonPath": "$.go", "operatorType": "EQUALS", "value": true}}
+				]},
+				"B_CHECKED": {},
+				"B_ADVANCED": {}
+			}
+		}
+	]
+}`
+
+// RunWorkflowSelectionAfterCreation asserts that workflow-level selection is
+// applied on the post-creation doors too, not only on creation: a manual
+// transition and a loopback re-evaluation must both run the definition the
+// entity's criterion binds it to.
+//
+// RunWorkflowCriteriaSelectingWorkflow already covers selection at creation.
+// This is the backend-agnostic companion for the later doors — the engine
+// resolves the workflow the same way on every backend, so a divergence here
+// would be a backend bug, not a modelling choice.
+func RunWorkflowSelectionAfterCreation(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "parity-wf-selection-doors"
+	const modelVersion = 1
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wfSelectionSample, wfSelectionWorkflows)
+
+	// --- Manual transition ---
+	manualID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Test","kind":"b","go":false}`)
+	if err != nil {
+		t.Fatalf("CreateEntity (manual): %v", err)
+	}
+	if err := c.UpdateEntity(t, manualID, "check", `{"name":"Test","kind":"b","go":false}`); err != nil {
+		t.Fatalf("UpdateEntity (check): %v", err)
+	}
+	got, err := c.GetEntity(t, manualID)
+	if err != nil {
+		t.Fatalf("GetEntity (manual): %v", err)
+	}
+	if got.Meta.State != "B_CHECKED" {
+		t.Errorf("state after manual transition = %s, want B_CHECKED (kind-b-wf selected by criterion)", got.Meta.State)
+	}
+
+	// --- Loopback (transition-less update) ---
+	loopbackID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Test","kind":"b","go":false}`)
+	if err != nil {
+		t.Fatalf("CreateEntity (loopback): %v", err)
+	}
+	if err := c.UpdateEntityData(t, loopbackID, `{"name":"Test","kind":"b","go":true}`); err != nil {
+		t.Fatalf("UpdateEntityData (loopback): %v", err)
+	}
+	got, err = c.GetEntity(t, loopbackID)
+	if err != nil {
+		t.Fatalf("GetEntity (loopback): %v", err)
+	}
+	if got.Meta.State != "B_ADVANCED" {
+		t.Errorf("state after loopback = %s, want B_ADVANCED (kind-b-wf selected by criterion)", got.Meta.State)
+	}
+}

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -1975,6 +1975,8 @@ func classifyError(err error) *common.AppError {
 //   - ErrCommitBeforeDispatchInfra (Begin/Commit/Save plugin failure inside
 //     the engine's segment-boundary code) → sanitized 5xx via common.Internal,
 //     so internal pgx text never leaks to clients via 4xx WORKFLOW_FAILED.
+//   - ErrCriterionTypingInfra (the model store a criterion needs for
+//     type-directed comparison is unavailable) → sanitized 5xx, same reason.
 //   - ErrAuthContextUnavailable (AttachAuthContext could not populate a
 //     dispatch CloudEvent's Auth Context — no UserContext, unset/unrecognized
 //     principal Kind, or nil CloudEvent) → sanitized 5xx via common.Internal.
@@ -1994,6 +1996,9 @@ func classifyWorkflowError(err error) *common.AppError {
 	}
 	if errors.Is(err, wfengine.ErrProcessorOutputInfra) {
 		return common.Internal("processor output check failed", err)
+	}
+	if errors.Is(err, wfengine.ErrCriterionTypingInfra) {
+		return common.Internal("criterion typing failed", err)
 	}
 	if errors.Is(err, wfengine.ErrCommitBeforeDispatchInfra) {
 		return common.Internal("workflow segment boundary failed", err)

--- a/internal/domain/entity/service_classify_test.go
+++ b/internal/domain/entity/service_classify_test.go
@@ -200,3 +200,51 @@ func TestClassifyWorkflowError_AuthContextUnavailableMapsTo5xx(t *testing.T) {
 		t.Errorf("client response missing ticket correlation field: %s", body)
 	}
 }
+
+// TestClassifyWorkflowError_CriterionTypingInfraMapsTo5xx is the companion
+// for the criterion-typing sentinel: the model store a type-directed
+// criterion needs being unavailable is a server-side condition, so it must
+// be sanitized rather than echoed into a 400 WORKFLOW_FAILED body carrying
+// raw store text.
+func TestClassifyWorkflowError_CriterionTypingInfraMapsTo5xx(t *testing.T) {
+	const innerSecret = "pgx: connection refused on host=db-master.internal"
+	prod := fmt.Errorf("%w: model order/1.0: %w",
+		wfengine.ErrCriterionTypingInfra, errors.New(innerSecret))
+
+	appErr := classifyWorkflowError(prod)
+	if appErr.Status < 500 {
+		t.Errorf("status = %d, want 5xx (a model-store outage is not client-attributable)", appErr.Status)
+	}
+	if strings.Contains(appErr.Message, innerSecret) {
+		t.Errorf("client-facing message leaks store detail: %q", appErr.Message)
+	}
+	if !errors.Is(appErr, prod) {
+		t.Error("the original error must stay wrapped for server-side logging")
+	}
+}
+
+// TestClassifyWorkflowError_NoMatchingMemberMapsTo503 pins the mapping the
+// transitions read doors depend on. GET /entity/{id}/transitions evaluates
+// workflow selection criteria, so a FUNCTION selection criterion whose tag
+// no compute member serves surfaces there exactly as it does on a write:
+// a retryable 503 NO_COMPUTE_MEMBER_FOR_TAG, never an opaque 500.
+//
+// Both transitions handlers classify through classifyWorkflowError for this
+// reason; the bare sentinel below is what the non-cluster dispatcher
+// returns (the cluster dispatcher pre-classifies it into the same AppError,
+// which passes through unchanged).
+func TestClassifyWorkflowError_NoMatchingMemberMapsTo503(t *testing.T) {
+	prod := fmt.Errorf("failed to evaluate workflow criterion for %q: %w",
+		"kind-a-wf", contract.ErrNoMatchingMember)
+
+	appErr := classifyWorkflowError(prod)
+	if appErr.Status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", appErr.Status)
+	}
+	if appErr.Code != common.ErrCodeNoComputeMemberForTag {
+		t.Errorf("code = %q, want %s", appErr.Code, common.ErrCodeNoComputeMemberForTag)
+	}
+	if !appErr.Retryable {
+		t.Error("a missing compute member is a transient infra condition; want retryable")
+	}
+}

--- a/internal/domain/entity/transitions_handler.go
+++ b/internal/domain/entity/transitions_handler.go
@@ -74,7 +74,15 @@ func (h *Handler) HandleGetTransitions(w http.ResponseWriter, r *http.Request) {
 
 	transitions, err := h.engine.GetAvailableTransitionsForEntity(r.Context(), entity)
 	if err != nil {
-		common.WriteError(w, r, classifyError(err))
+		// classifyWorkflowError, not classifyError: this is a workflow-engine
+		// failure and must be reported exactly as the write doors report the
+		// identical condition. In particular an unresolvable compute member
+		// for a FUNCTION workflow criterion is a retryable 503
+		// NO_COMPUTE_MEMBER_FOR_TAG, not an opaque 500 — and classifyError
+		// would additionally have made the status depend on whether cluster
+		// mode is enabled, since only the cluster dispatcher pre-classifies
+		// that sentinel into an AppError.
+		common.WriteError(w, r, classifyWorkflowError(err))
 		return
 	}
 
@@ -106,7 +114,9 @@ func (h *Handler) HandleFetchTransitions(w http.ResponseWriter, r *http.Request)
 
 	transitions, err := h.engine.GetAvailableTransitions(r.Context(), entityID, modelRef)
 	if err != nil {
-		common.WriteError(w, r, classifyError(err))
+		// Same classifier as HandleGetTransitions — this endpoint is an alias
+		// over the same engine call and must not diverge on status.
+		common.WriteError(w, r, classifyWorkflowError(err))
 		return
 	}
 

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -70,6 +70,14 @@ func (e *criterionNotMatchedError) Is(target error) bool {
 	return target == ErrCriterionNotMatched
 }
 
+// ErrCriterionTypingInfra marks a server-side failure while loading the
+// model schema a criterion needs to compare data leaves by their declared
+// types. The model store being unavailable is not attributable to the
+// caller's input, so callers map this to a sanitized 5xx instead of letting
+// raw store text reach a 4xx body — the same treatment
+// ErrProcessorOutputInfra and ErrCommitBeforeDispatchInfra already get.
+var ErrCriterionTypingInfra = errors.New("criterion typing failed")
+
 // scheduledReason is the human-readable cause emitted by both the audit
 // event Details and the wrapped error message when an explicit fire of a
 // scheduled transition is rejected: a scheduled transition fires
@@ -458,7 +466,7 @@ func (e *Engine) Loopback(ctx context.Context, entity *spi.Entity) (*EngineResul
 
 // selectWorkflow iterates active workflows and returns the first whose criterion
 // matches the entity. Workflows without a criterion match unconditionally.
-func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDefinition, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string) (*spi.WorkflowDefinition, error) {
+func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDefinition, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string, logFallback bool) (*spi.WorkflowDefinition, error) {
 	for i := range workflows {
 		wf := &workflows[i]
 		if !wf.Active {
@@ -496,7 +504,9 @@ func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDef
 	// default. Both channels (body warning + slog.Warn) fire.
 	if len(e.defaultWorkflows) > 0 {
 		common.AddWarning(ctx, "no imported workflow matched entity — using default workflow")
-		e.logDefaultFallback(ctx, entity, "no_criterion_matched")
+		if logFallback {
+			e.logDefaultFallback(ctx, entity, "no_criterion_matched")
+		}
 		defaultWF := &e.defaultWorkflows[0]
 		e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
 			spi.SMEventWorkflowFound, fmt.Sprintf("No imported workflow matched; using default workflow %q", defaultWF.Name), nil)
@@ -532,9 +542,34 @@ func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDef
 // the entity as it is right now, which is what makes a data change able to
 // re-bind an entity to a different definition.
 func (e *Engine) resolveWorkflow(ctx context.Context, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string) (*spi.WorkflowDefinition, error) {
+	return e.resolveWorkflowWith(ctx, entity, auditStore, txID, true)
+}
+
+// resolveWorkflowForQuery is resolveWorkflow for read-only callers. It
+// records no audit events and emits no operator-facing default-substitution
+// log line: a query executes nothing, so nothing is being substituted for a
+// write, and the same misconfiguration is already logged on every door that
+// actually runs the entity. Without this, a client read loop against a
+// mis-modelled entity turns into one WARN per request.
+//
+// The client-facing warning (common.AddWarning) is still raised — that one
+// answers the caller's question about why they were given the default
+// workflow's transitions.
+func (e *Engine) resolveWorkflowForQuery(ctx context.Context, entity *spi.Entity) (*spi.WorkflowDefinition, error) {
+	return e.resolveWorkflowWith(ctx, entity, discardedAuditStore{}, "", false)
+}
+
+func (e *Engine) resolveWorkflowWith(ctx context.Context, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string, logFallback bool) (*spi.WorkflowDefinition, error) {
+	// Store failures are server-side conditions, never attributable to the
+	// caller's input, so they are minted as sanitized 5xx AppErrors here
+	// rather than left as bare errors: callers classify a bare engine error
+	// as 400 WORKFLOW_FAILED with err.Error() in the body, which would put
+	// raw store text (pgx messages, connection detail) into a 4xx response.
+	// Same treatment the engine already gives its other infra failures
+	// (ErrCommitBeforeDispatchInfra, ErrProcessorOutputInfra).
 	wfStore, err := e.factory.WorkflowStore(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get workflow store: %w", err)
+		return nil, common.Internal("failed to access workflow store", err)
 	}
 
 	// Load workflows for model. A "not found" error is treated as empty.
@@ -542,18 +577,20 @@ func (e *Engine) resolveWorkflow(ctx context.Context, entity *spi.Entity, auditS
 	if err != nil && errors.Is(err, spi.ErrNotFound) {
 		workflows = nil
 	} else if err != nil {
-		return nil, fmt.Errorf("failed to load workflows: %w", err)
+		return nil, common.Internal("failed to load workflows", err)
 	}
 
 	// No workflows defined → use embedded default. Body warning surfaces to
 	// the client; slog.Warn surfaces to operators.
 	if len(workflows) == 0 {
 		common.AddWarning(ctx, "no workflows imported for model — using default workflow")
-		e.logDefaultFallback(ctx, entity, "no_workflows_imported")
+		if logFallback {
+			e.logDefaultFallback(ctx, entity, "no_workflows_imported")
+		}
 		workflows = e.defaultWorkflows
 	}
 
-	return e.selectWorkflow(ctx, workflows, entity, auditStore, txID)
+	return e.selectWorkflow(ctx, workflows, entity, auditStore, txID, logFallback)
 }
 
 // discardedAuditStore is the audit sink used by read-only paths. Workflow
@@ -843,12 +880,12 @@ func (e *Engine) evaluateCriterion(criterion []byte, entity *spi.Entity, cc *cri
 			loaded = true
 			modelStore, err := e.factory.ModelStore(cc.ctx)
 			if err != nil {
-				loadErr = fmt.Errorf("criterion typing: model store unavailable: %w", err)
+				loadErr = fmt.Errorf("%w: model store unavailable: %w", ErrCriterionTypingInfra, err)
 				return nil
 			}
 			f, err := search.LoadFieldsMap(cc.ctx, modelStore, entity.Meta.ModelRef)
 			if err != nil {
-				loadErr = fmt.Errorf("criterion typing: failed to load model %s/%s: %w",
+				loadErr = fmt.Errorf("%w: model %s/%s: %w", ErrCriterionTypingInfra,
 					entity.Meta.ModelRef.EntityName, entity.Meta.ModelRef.ModelVersion, err)
 				return nil
 			}
@@ -884,16 +921,21 @@ func (e *Engine) resolveAuditTxID(entity *spi.Entity) string {
 }
 
 // logDefaultFallback emits a single slog.Warn line whenever the engine
-// substitutes the embedded default workflow. The four call sites map to
-// two cause groups via the reason argument:
-//   - "no_workflows_imported": cold-path (Execute/ManualTransition/Loopback)
-//     with no stored workflows for the model — three call sites.
-//   - "no_criterion_matched":  workflows exist but no criterion matched the
-//     entity (selectWorkflow tail) — one call site.
+// substitutes the embedded default workflow on a door that actually runs the
+// entity. Two call sites, one per cause group, both in the shared resolution
+// path:
+//   - "no_workflows_imported": the model has no stored workflows
+//     (resolveWorkflowWith).
+//   - "no_criterion_matched":  workflows exist but none matched the entity
+//     (selectWorkflow tail).
 //
-// The body-level warning via common.AddWarning is retained at each call
-// site for client-facing surfacing; this log line is purely additive for
-// operational observability.
+// Read-only callers pass logFallback=false (see resolveWorkflowForQuery): a
+// query substitutes nothing, and logging per read would turn a client read
+// loop into a WARN stream.
+//
+// The body-level warning via common.AddWarning is raised on every path, read
+// included, for client-facing surfacing; this log line is purely additive
+// for operational observability.
 func (e *Engine) logDefaultFallback(ctx context.Context, entity *spi.Entity, reason string) {
 	slog.WarnContext(ctx, "default workflow substituted",
 		slog.String("pkg", "workflow"),

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -228,10 +228,6 @@ func (e *Engine) Execute(ctx context.Context, entity *spi.Entity, transitionName
 	))
 	defer span.End()
 
-	wfStore, err := e.factory.WorkflowStore(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get workflow store: %w", err)
-	}
 	auditStore, err := e.factory.StateMachineAuditStore(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get audit store: %w", err)
@@ -243,24 +239,7 @@ func (e *Engine) Execute(ctx context.Context, entity *spi.Entity, transitionName
 	e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
 		spi.SMEventStarted, "State machine started", nil)
 
-	// Load workflows for model. A "not found" error is treated as empty.
-	workflows, err := wfStore.Get(ctx, entity.Meta.ModelRef)
-	if err != nil && errors.Is(err, spi.ErrNotFound) {
-		workflows = nil
-	} else if err != nil {
-		return nil, fmt.Errorf("failed to load workflows: %w", err)
-	}
-
-	// No workflows defined → use embedded default. Body warning surfaces to
-	// the client; slog.Warn surfaces to operators.
-	if len(workflows) == 0 {
-		common.AddWarning(ctx, "no workflows imported for model — using default workflow")
-		e.logDefaultFallback(ctx, entity, "no_workflows_imported")
-		workflows = e.defaultWorkflows
-	}
-
-	// Select matching workflow.
-	selectedWF, err := e.selectWorkflow(ctx, workflows, entity, auditStore, txID)
+	selectedWF, err := e.resolveWorkflow(ctx, entity, auditStore, txID)
 	if err != nil {
 		return nil, err
 	}
@@ -341,10 +320,6 @@ func (e *Engine) ManualTransition(ctx context.Context, entity *spi.Entity, trans
 	))
 	defer span.End()
 
-	wfStore, err := e.factory.WorkflowStore(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get workflow store: %w", err)
-	}
 	auditStore, err := e.factory.StateMachineAuditStore(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get audit store: %w", err)
@@ -355,25 +330,13 @@ func (e *Engine) ManualTransition(ctx context.Context, entity *spi.Entity, trans
 	e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
 		spi.SMEventStarted, "Manual transition started", nil)
 
-	// Load workflows, find the one whose states contain the entity's current state.
-	workflows, err := wfStore.Get(ctx, entity.Meta.ModelRef)
-	if err != nil && errors.Is(err, spi.ErrNotFound) {
-		workflows = nil
-	} else if err != nil {
-		return nil, fmt.Errorf("failed to load workflows: %w", err)
-	}
-
-	// No workflows defined → use embedded default. Body warning surfaces to
-	// the client; slog.Warn surfaces to operators.
-	if len(workflows) == 0 {
-		common.AddWarning(ctx, "no workflows imported for model — using default workflow")
-		e.logDefaultFallback(ctx, entity, "no_workflows_imported")
-		workflows = e.defaultWorkflows
-	}
-
-	wf := e.findWorkflowForState(workflows, entity.Meta.State)
-	if wf == nil {
-		return nil, fmt.Errorf("no workflow contains state %q for model %s", entity.Meta.State, entity.Meta.ModelRef)
+	// Select the workflow the entity's criterion binds it to. If the
+	// entity's current state is absent from that definition, attemptTransition
+	// below rejects the call — the engine never falls through to another
+	// definition that happens to declare the state.
+	wf, err := e.resolveWorkflow(ctx, entity, auditStore, txID)
+	if err != nil {
+		return nil, err
 	}
 
 	currentCtx, currentTxID, err := e.attemptTransition(ctx, entity, wf, transitionName, auditStore, txID)
@@ -431,10 +394,6 @@ func (e *Engine) Loopback(ctx context.Context, entity *spi.Entity) (*EngineResul
 	))
 	defer span.End()
 
-	wfStore, err := e.factory.WorkflowStore(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get workflow store: %w", err)
-	}
 	auditStore, err := e.factory.StateMachineAuditStore(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get audit store: %w", err)
@@ -445,27 +404,19 @@ func (e *Engine) Loopback(ctx context.Context, entity *spi.Entity) (*EngineResul
 	e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
 		spi.SMEventStarted, "Loopback started", nil)
 
-	// Load workflows, find the one whose states contain the entity's current state.
-	workflows, err := wfStore.Get(ctx, entity.Meta.ModelRef)
-	if err != nil && errors.Is(err, spi.ErrNotFound) {
-		workflows = nil
-	} else if err != nil {
-		return nil, fmt.Errorf("failed to load workflows: %w", err)
+	wf, err := e.resolveWorkflow(ctx, entity, auditStore, txID)
+	if err != nil {
+		return nil, err
 	}
 
-	// No workflows defined → use embedded default. Body warning surfaces to
-	// the client; slog.Warn surfaces to operators.
-	if len(workflows) == 0 {
-		common.AddWarning(ctx, "no workflows imported for model — using default workflow")
-		e.logDefaultFallback(ctx, entity, "no_workflows_imported")
-		workflows = e.defaultWorkflows
-	}
-
-	wf := e.findWorkflowForState(workflows, entity.Meta.State)
-	if wf == nil {
-		// Current state not in any workflow — stable, nothing to do.
+	if _, ok := wf.States[entity.Meta.State]; !ok {
+		// Current state not in the SELECTED workflow — stable, nothing to
+		// do. Another definition declaring the state is not a reason to
+		// cascade it: the entity is bound to the workflow its criterion
+		// selected.
 		e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
-			spi.SMEventForcedSuccess, "No workflow contains current state for loopback", nil)
+			spi.SMEventForcedSuccess,
+			fmt.Sprintf("Current state is not declared in the selected workflow %q — nothing to loop back", wf.Name), nil)
 		e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
 			spi.SMEventFinished, "Loopback finished (state not in workflow)", map[string]any{"success": true})
 		return &EngineResult{
@@ -557,19 +508,70 @@ func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDef
 	return nil, fmt.Errorf("no matching workflow for model %s", entity.Meta.ModelRef)
 }
 
-// findWorkflowForState returns the first active workflow whose state map contains
-// the given state name.
-func (e *Engine) findWorkflowForState(workflows []spi.WorkflowDefinition, state string) *spi.WorkflowDefinition {
-	for i := range workflows {
-		wf := &workflows[i]
-		if !wf.Active {
-			continue
-		}
-		if _, ok := wf.States[state]; ok {
-			return wf
-		}
+// resolveWorkflow loads the model's workflow definitions and returns the one
+// that applies to entity, per the documented workflow-level selection rules
+// (`cyoda help workflows`): stored declaration order, active definitions
+// only, the first matching `criterion` wins, and the embedded default
+// workflow as the fallback when nothing matches.
+//
+// This is the ONLY workflow-resolution path in the engine. Every door goes
+// through it — creation (Execute), manual firing (ManualTransition),
+// re-evaluation (Loopback), the scheduler's fire door
+// (FireScheduledTransition) and the transitions query
+// (GetAvailableTransitionsForEntity) — so an entity always runs the
+// definition its own criterion selects, and the WORKFLOW_SKIP /
+// WORKFLOW_FOUND audit trail is recorded identically on all of them.
+//
+// Resolving instead by "the first active workflow that happens to declare
+// the entity's current state" cannot distinguish definitions that share
+// state names — the normal shape for a per-kind machine — and silently
+// binds every entity to the first declared workflow, running the wrong
+// guards, processors and target states.
+//
+// Selection is per call and never cached: the criterion is evaluated against
+// the entity as it is right now, which is what makes a data change able to
+// re-bind an entity to a different definition.
+func (e *Engine) resolveWorkflow(ctx context.Context, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string) (*spi.WorkflowDefinition, error) {
+	wfStore, err := e.factory.WorkflowStore(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workflow store: %w", err)
 	}
-	return nil
+
+	// Load workflows for model. A "not found" error is treated as empty.
+	workflows, err := wfStore.Get(ctx, entity.Meta.ModelRef)
+	if err != nil && errors.Is(err, spi.ErrNotFound) {
+		workflows = nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to load workflows: %w", err)
+	}
+
+	// No workflows defined → use embedded default. Body warning surfaces to
+	// the client; slog.Warn surfaces to operators.
+	if len(workflows) == 0 {
+		common.AddWarning(ctx, "no workflows imported for model — using default workflow")
+		e.logDefaultFallback(ctx, entity, "no_workflows_imported")
+		workflows = e.defaultWorkflows
+	}
+
+	return e.selectWorkflow(ctx, workflows, entity, auditStore, txID)
+}
+
+// discardedAuditStore is the audit sink used by read-only paths. Workflow
+// selection records WORKFLOW_SKIP / WORKFLOW_FOUND against the transaction
+// that is executing the entity; a query has no such transaction, so the
+// events would land keyed to an empty transaction ID and pollute the
+// entity's trail. Recording is discarded rather than skipped by a nil check
+// so resolveWorkflow keeps one unconditional code path.
+type discardedAuditStore struct{}
+
+func (discardedAuditStore) Record(context.Context, string, spi.StateMachineEvent) error { return nil }
+
+func (discardedAuditStore) GetEvents(context.Context, string) ([]spi.StateMachineEvent, error) {
+	return nil, nil
+}
+
+func (discardedAuditStore) GetEventsByTransaction(context.Context, string, string) ([]spi.StateMachineEvent, error) {
+	return nil, nil
 }
 
 // attemptTransition finds and fires a named transition from the entity's

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -76,6 +76,13 @@ func (e *criterionNotMatchedError) Is(target error) bool {
 // caller's input, so callers map this to a sanitized 5xx instead of letting
 // raw store text reach a 4xx body — the same treatment
 // ErrProcessorOutputInfra and ErrCommitBeforeDispatchInfra already get.
+//
+// This deliberately covers "model not found" as well as a store outage: an
+// entity whose model has been deleted out from under it is a server-side
+// inconsistency, not something the caller's request got wrong. Detail is
+// still available to operators — the cause stays wrapped and is logged with
+// the ticket UUID — it just no longer ships in a 4xx body. Same call
+// ErrProcessorOutputInfra already makes for its missing-descriptor case.
 var ErrCriterionTypingInfra = errors.New("criterion typing failed")
 
 // scheduledReason is the human-readable cause emitted by both the audit
@@ -466,7 +473,7 @@ func (e *Engine) Loopback(ctx context.Context, entity *spi.Entity) (*EngineResul
 
 // selectWorkflow iterates active workflows and returns the first whose criterion
 // matches the entity. Workflows without a criterion match unconditionally.
-func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDefinition, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string, logFallback bool) (*spi.WorkflowDefinition, error) {
+func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDefinition, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string) (*spi.WorkflowDefinition, error) {
 	for i := range workflows {
 		wf := &workflows[i]
 		if !wf.Active {
@@ -504,9 +511,7 @@ func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDef
 	// default. Both channels (body warning + slog.Warn) fire.
 	if len(e.defaultWorkflows) > 0 {
 		common.AddWarning(ctx, "no imported workflow matched entity — using default workflow")
-		if logFallback {
-			e.logDefaultFallback(ctx, entity, "no_criterion_matched")
-		}
+		e.logDefaultFallback(ctx, entity, "no_criterion_matched")
 		defaultWF := &e.defaultWorkflows[0]
 		e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
 			spi.SMEventWorkflowFound, fmt.Sprintf("No imported workflow matched; using default workflow %q", defaultWF.Name), nil)
@@ -542,24 +547,27 @@ func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDef
 // the entity as it is right now, which is what makes a data change able to
 // re-bind an entity to a different definition.
 func (e *Engine) resolveWorkflow(ctx context.Context, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string) (*spi.WorkflowDefinition, error) {
-	return e.resolveWorkflowWith(ctx, entity, auditStore, txID, true)
+	return e.resolveWorkflowWith(ctx, entity, auditStore, txID)
 }
 
-// resolveWorkflowForQuery is resolveWorkflow for read-only callers. It
-// records no audit events and emits no operator-facing default-substitution
-// log line: a query executes nothing, so nothing is being substituted for a
-// write, and the same misconfiguration is already logged on every door that
-// actually runs the entity. Without this, a client read loop against a
-// mis-modelled entity turns into one WARN per request.
+// resolveWorkflowForQuery is resolveWorkflow for read-only callers: it
+// discards the selection audit events, which belong to the transaction
+// executing the entity and have nothing to key to on a read.
 //
-// The client-facing warning (common.AddWarning) is still raised — that one
-// answers the caller's question about why they were given the default
-// workflow's transitions.
+// It deliberately does NOT suppress the operator-facing
+// default-substitution WARN. Emitting one per read is more log volume than
+// an execution path produces, and that was reason enough to consider
+// silencing it — but common.AddWarning cannot compensate here: the
+// diagnostics bag is installed only on the gRPC entry points
+// (internal/grpc/*), the transitions endpoints are HTTP-only, and
+// common.WriteJSON emits a bare array with no warnings field. Silencing the
+// log would leave a read that answered from the default workflow with no
+// signal on any channel at all.
 func (e *Engine) resolveWorkflowForQuery(ctx context.Context, entity *spi.Entity) (*spi.WorkflowDefinition, error) {
-	return e.resolveWorkflowWith(ctx, entity, discardedAuditStore{}, "", false)
+	return e.resolveWorkflowWith(ctx, entity, discardedAuditStore{}, "")
 }
 
-func (e *Engine) resolveWorkflowWith(ctx context.Context, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string, logFallback bool) (*spi.WorkflowDefinition, error) {
+func (e *Engine) resolveWorkflowWith(ctx context.Context, entity *spi.Entity, auditStore spi.StateMachineAuditStore, txID string) (*spi.WorkflowDefinition, error) {
 	// Store failures are server-side conditions, never attributable to the
 	// caller's input, so they are minted as sanitized 5xx AppErrors here
 	// rather than left as bare errors: callers classify a bare engine error
@@ -584,13 +592,11 @@ func (e *Engine) resolveWorkflowWith(ctx context.Context, entity *spi.Entity, au
 	// the client; slog.Warn surfaces to operators.
 	if len(workflows) == 0 {
 		common.AddWarning(ctx, "no workflows imported for model — using default workflow")
-		if logFallback {
-			e.logDefaultFallback(ctx, entity, "no_workflows_imported")
-		}
+		e.logDefaultFallback(ctx, entity, "no_workflows_imported")
 		workflows = e.defaultWorkflows
 	}
 
-	return e.selectWorkflow(ctx, workflows, entity, auditStore, txID, logFallback)
+	return e.selectWorkflow(ctx, workflows, entity, auditStore, txID)
 }
 
 // discardedAuditStore is the audit sink used by read-only paths. Workflow
@@ -929,13 +935,14 @@ func (e *Engine) resolveAuditTxID(entity *spi.Entity) string {
 //   - "no_criterion_matched":  workflows exist but none matched the entity
 //     (selectWorkflow tail).
 //
-// Read-only callers pass logFallback=false (see resolveWorkflowForQuery): a
-// query substitutes nothing, and logging per read would turn a client read
-// loop into a WARN stream.
+// Read paths log too (see resolveWorkflowForQuery): on the HTTP-only
+// transitions endpoints this line is the ONLY channel the substitution
+// surfaces on, since the diagnostics bag common.AddWarning writes to is
+// installed on the gRPC entry points only.
 //
-// The body-level warning via common.AddWarning is raised on every path, read
-// included, for client-facing surfacing; this log line is purely additive
-// for operational observability.
+// The body-level warning via common.AddWarning is raised on every path for
+// client-facing surfacing wherever a diagnostics bag exists; this log line
+// is purely additive for operational observability.
 func (e *Engine) logDefaultFallback(ctx context.Context, entity *spi.Entity, reason string) {
 	slog.WarnContext(ctx, "default workflow substituted",
 		slog.String("pkg", "workflow"),

--- a/internal/domain/workflow/fire_scheduled.go
+++ b/internal/domain/workflow/fire_scheduled.go
@@ -232,15 +232,17 @@ func (e *Engine) FireScheduledTransition(ctx context.Context, task spi.Scheduled
 	}
 
 	// --- Resolve the workflow + transition (design §5.2) ---
-	wfStore, err := e.factory.WorkflowStore(txCtx)
+	//
+	// Selection is criterion-based, exactly as on the client-facing doors
+	// (Engine.resolveWorkflow): a scheduled fire must run the definition the
+	// entity is bound to now, not whichever one happens to declare its
+	// source state. A resolution failure — including a workflow criterion
+	// that cannot be evaluated — leaves the task in place and is retried on
+	// the next scan; it never falls through to another definition.
+	wf, err := e.resolveWorkflow(txCtx, entity, auditStore, txID)
 	if err != nil {
-		return OutcomeDropped, fmt.Errorf("failed to get workflow store: %w", err)
+		return OutcomeDropped, fmt.Errorf("failed to resolve workflow for scheduled fire: %w", err)
 	}
-	workflows, err := wfStore.Get(txCtx, entity.Meta.ModelRef)
-	if err != nil && !errors.Is(err, spi.ErrNotFound) {
-		return OutcomeDropped, fmt.Errorf("failed to load workflows: %w", err)
-	}
-	wf := e.findWorkflowForState(workflows, entity.Meta.State)
 	transition := findTransitionInState(wf, entity.Meta.State, cur.Transition)
 	if transition == nil {
 		// The workflow was re-imported and the state or transition this

--- a/internal/domain/workflow/fire_scheduled.go
+++ b/internal/domain/workflow/fire_scheduled.go
@@ -231,34 +231,25 @@ func (e *Engine) FireScheduledTransition(ctx context.Context, task spi.Scheduled
 		return OutcomeDropped, nil
 	}
 
-	// --- Resolve the workflow + transition (design §5.2) ---
-	//
-	// Selection is criterion-based, exactly as on the client-facing doors
-	// (Engine.resolveWorkflow): a scheduled fire must run the definition the
-	// entity is bound to now, not whichever one happens to declare its
-	// source state. A resolution failure — including a workflow criterion
-	// that cannot be evaluated — leaves the task in place and is retried on
-	// the next scan; it never falls through to another definition.
-	wf, err := e.resolveWorkflow(txCtx, entity, auditStore, txID)
-	if err != nil {
-		return OutcomeDropped, fmt.Errorf("failed to resolve workflow for scheduled fire: %w", err)
-	}
-	transition := findTransitionInState(wf, entity.Meta.State, cur.Transition)
-	if transition == nil {
-		// The workflow was re-imported and the state or transition this
-		// task references no longer exists. The task is obsolete — drop it
-		// rather than retry forever.
-		slog.DebugContext(txCtx, "scheduled task references a transition no longer present in the workflow; dropping",
-			slog.String("pkg", "workflow"),
-			slog.String("entityId", cur.EntityID),
-			slog.String("sourceState", cur.SourceState),
-			slog.String("transition", cur.Transition))
-		_, _ = sts.Delete(txCtx, task.ID)
-		committed = true
-		return OutcomeDropped, e.txMgr.Commit(ctx, txID)
-	}
-
 	// --- Grace-band lateness gate (design §5.5) ---
+	//
+	// Ordered BEFORE workflow resolution deliberately. Expiry is a pure
+	// function of the durable row and the clock — it needs nothing from the
+	// workflow — so gating it behind resolution would make a task
+	// unexpirable and unreclaimable for exactly as long as its workflow
+	// criterion cannot be evaluated (e.g. the compute member serving a
+	// FUNCTION criterion's tag is down): resolution fails, the row survives,
+	// and the coordinator re-dispatches it every backoff interval forever.
+	// Resolving first would also mean a criterion callout — and, on the
+	// grace-band branch, a rolled-back one — for a task that is not going to
+	// fire at all.
+	//
+	// It also keeps the fire door's audit contract intact: the three guards
+	// that resolve a task silently (row gone, entity moved on, re-armed to
+	// the future) plus expiry all complete before selection records
+	// anything, so WORKFLOW_SKIP / WORKFLOW_FOUND appear only on an attempt
+	// that genuinely reached the definition. See
+	// docs/cloud-parity/scheduled-transitions.md §6.
 	lateness := nowMs - cur.ScheduledTime
 	if cur.TimeoutMs != nil {
 		if lateness > *cur.TimeoutMs+e.expiryGraceMs {
@@ -278,6 +269,49 @@ func (e *Engine) FireScheduledTransition(ctx context.Context, task spi.Scheduled
 			// scan resolves it once past the band (design §5.5, §15 F4).
 			return OutcomeDropped, nil
 		}
+	}
+
+	// --- Resolve the workflow + transition (design §5.2) ---
+	//
+	// Selection is criterion-based, exactly as on the client-facing doors
+	// (Engine.resolveWorkflow): a scheduled fire must run the definition the
+	// entity is bound to now, not whichever one happens to declare its
+	// source state. A resolution failure — including a workflow criterion
+	// that cannot be evaluated — leaves the task in place and is retried on
+	// the next scan; it never falls through to another definition.
+	wf, err := e.resolveWorkflow(txCtx, entity, auditStore, txID)
+	if err != nil {
+		return OutcomeDropped, fmt.Errorf("failed to resolve workflow for scheduled fire: %w", err)
+	}
+	transition := findFireableTransitionInState(wf, entity.Meta.State, cur.Transition)
+	if transition == nil {
+		// The selected workflow no longer declares this state/transition as
+		// a scheduled one — either it was re-imported, or the entity's data
+		// changed and re-bound it to a different definition. The task is
+		// obsolete: drop it rather than retry forever.
+		//
+		// Audited, not silent. A scheduled transition is often a time-based
+		// control (auto-expire, escalate-if-not-approved); a client write
+		// that re-binds the entity can make one vanish, and a vanished timer
+		// must be attributable. The guards above stay silent because they
+		// are self-healing race outcomes, not lifecycle events.
+		slog.DebugContext(txCtx, "scheduled task references a transition the selected workflow does not declare as scheduled; dropping",
+			slog.String("pkg", "workflow"),
+			slog.String("entityId", cur.EntityID),
+			slog.String("workflowName", wf.Name),
+			slog.String("sourceState", cur.SourceState),
+			slog.String("transition", cur.Transition))
+		if removed, delErr := sts.Delete(txCtx, task.ID); delErr != nil {
+			return OutcomeDropped, fmt.Errorf("failed to delete obsolete scheduled task: %w", delErr)
+		} else if removed {
+			e.recordEvent(auditStore, txCtx, entity.Meta.ID, txID, entity.Meta.State,
+				spi.SMEventScheduledTransitionCancelled,
+				fmt.Sprintf("Scheduled transition %q cancelled (not a scheduled transition of state %q in the selected workflow %q)",
+					cur.Transition, cur.SourceState, wf.Name),
+				map[string]any{"transition": cur.Transition, "sourceState": cur.SourceState, "workflowName": wf.Name})
+		}
+		committed = true
+		return OutcomeDropped, e.txMgr.Commit(ctx, txID)
 	}
 
 	// --- Anchor stamp: attribute the fire's write to the arming principal
@@ -428,9 +462,23 @@ func (e *Engine) FireScheduledTransition(ctx context.Context, task spi.Scheduled
 	return OutcomeFired, e.txMgr.Commit(ctx, finalTxID)
 }
 
-// findTransitionInState returns the named transition from wf's given state,
-// or nil if wf, the state, or the transition itself is absent.
-func findTransitionInState(wf *spi.WorkflowDefinition, state, transitionName string) *spi.TransitionDefinition {
+// findFireableTransitionInState returns the named transition from wf's given
+// state, but only if the scheduler is allowed to fire it: it must carry a
+// Schedule and be neither manual nor disabled. Returns nil if wf, the state,
+// or the transition is absent, or if a transition of that name exists but is
+// not scheduler-fireable.
+//
+// The eligibility test is the exact complement of the arm-side filter in
+// reconcileScheduledTasks (`tr.Schedule == nil || tr.Manual || tr.Disabled`
+// → skip). Arm and fire MUST agree: a name match alone would let the
+// scheduler fire a MANUAL transition — running its processors and moving the
+// entity with no client asking for it — whenever the definition holding the
+// name changed under a live task. That is reachable through the ordinary
+// API, because a write that changes the entity's data can re-bind it to a
+// definition where the same name is manual, and a task armed for the
+// entity's CURRENT state is not cancelled by reconcile (which only cancels
+// rows whose SourceState the entity has left).
+func findFireableTransitionInState(wf *spi.WorkflowDefinition, state, transitionName string) *spi.TransitionDefinition {
 	if wf == nil {
 		return nil
 	}
@@ -439,9 +487,14 @@ func findTransitionInState(wf *spi.WorkflowDefinition, state, transitionName str
 		return nil
 	}
 	for i := range stateDef.Transitions {
-		if stateDef.Transitions[i].Name == transitionName {
-			return &stateDef.Transitions[i]
+		tr := &stateDef.Transitions[i]
+		if tr.Name != transitionName {
+			continue
 		}
+		if tr.Schedule == nil || tr.Manual || tr.Disabled {
+			return nil
+		}
+		return tr
 	}
 	return nil
 }

--- a/internal/domain/workflow/fire_scheduled.go
+++ b/internal/domain/workflow/fire_scheduled.go
@@ -206,8 +206,13 @@ func (e *Engine) FireScheduledTransition(ctx context.Context, task spi.Scheduled
 	if err != nil {
 		if errors.Is(err, spi.ErrNotFound) {
 			// The entity is gone (hard-deleted); the task is stale.
-			// Self-heal silently — no audit, nothing left to retry.
-			_, _ = sts.Delete(txCtx, task.ID)
+			// Self-heal silently — no audit, nothing left to retry. The
+			// delete's error is checked, not swallowed: committing after a
+			// failed delete would leave the row live for endless
+			// re-dispatch.
+			if _, delErr := sts.Delete(txCtx, task.ID); delErr != nil {
+				return OutcomeDropped, fmt.Errorf("failed to delete scheduled task for a deleted entity: %w", delErr)
+			}
 			committed = true
 			return OutcomeDropped, e.txMgr.Commit(ctx, txID)
 		}
@@ -217,8 +222,11 @@ func (e *Engine) FireScheduledTransition(ctx context.Context, task spi.Scheduled
 		// The entity already left sourceState — transitioned out, or
 		// already fired by a racing worker. Silent drop, no audit (design
 		// §5.3 step 2; §8 Cancelled is reserved for the explicit-exit
-		// reconcile, not this guard).
-		_, _ = sts.Delete(txCtx, task.ID)
+		// reconcile, not this guard). The delete's error is checked for the
+		// same reason as the branch above.
+		if _, delErr := sts.Delete(txCtx, task.ID); delErr != nil {
+			return OutcomeDropped, fmt.Errorf("failed to delete scheduled task for an entity that moved on: %w", delErr)
+		}
 		committed = true
 		return OutcomeDropped, e.txMgr.Commit(ctx, txID)
 	}

--- a/internal/domain/workflow/transitions.go
+++ b/internal/domain/workflow/transitions.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -37,34 +36,23 @@ func (e *Engine) GetAvailableTransitions(ctx context.Context, entityID string, m
 
 // GetAvailableTransitionsForEntity returns transition names for a pre-fetched entity.
 // Use this when the caller already has the entity to avoid a redundant store lookup.
+//
+// Resolution goes through the engine's single selection path, so the answer
+// names the transitions of the definition the entity is actually bound to —
+// the same one a subsequent ManualTransition will run.
+//
+// Two properties matter here and are pinned by tests:
+//   - The query records no audit events. Selection events belong to the
+//     transaction executing the entity, and a read has none to key them to.
+//   - A criterion that cannot be evaluated fails the request. Answering with
+//     some other workflow's transitions would be a wrong-but-available
+//     result (.claude/rules/correctness-over-availability.md); a criterion
+//     that merely does not MATCH still resolves to the default workflow,
+//     which is selection working as documented, not a degradation.
 func (e *Engine) GetAvailableTransitionsForEntity(ctx context.Context, entity *spi.Entity) ([]string, error) {
-	wfStore, err := e.factory.WorkflowStore(ctx)
+	selectedWF, err := e.resolveWorkflow(ctx, entity, discardedAuditStore{}, "")
 	if err != nil {
-		return nil, common.Internal("failed to access workflow store", err)
-	}
-
-	workflows, err := wfStore.Get(ctx, entity.Meta.ModelRef)
-	if err != nil && errors.Is(err, spi.ErrNotFound) {
-		workflows = nil
-	} else if err != nil {
-		return nil, common.Internal("failed to load workflows", err)
-	}
-
-	if len(workflows) == 0 {
-		common.AddWarning(ctx, "no imported workflow matched — using default workflow")
-		workflows = e.defaultWorkflows
-	}
-
-	// Find matching workflow. Use a no-op audit approach since we're just querying.
-	smStore, _ := e.factory.StateMachineAuditStore(ctx)
-	selectedWF, err := e.selectWorkflow(ctx, workflows, entity, smStore, "")
-	if err != nil {
-		// No workflow matched — use default
-		if len(e.defaultWorkflows) > 0 {
-			selectedWF = &e.defaultWorkflows[0]
-		} else {
-			return []string{}, nil
-		}
+		return nil, err
 	}
 
 	stateDef, ok := selectedWF.States[entity.Meta.State]

--- a/internal/domain/workflow/transitions.go
+++ b/internal/domain/workflow/transitions.go
@@ -50,7 +50,7 @@ func (e *Engine) GetAvailableTransitions(ctx context.Context, entityID string, m
 //     that merely does not MATCH still resolves to the default workflow,
 //     which is selection working as documented, not a degradation.
 func (e *Engine) GetAvailableTransitionsForEntity(ctx context.Context, entity *spi.Entity) ([]string, error) {
-	selectedWF, err := e.resolveWorkflow(ctx, entity, discardedAuditStore{}, "")
+	selectedWF, err := e.resolveWorkflowForQuery(ctx, entity)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/workflow/transitions.go
+++ b/internal/domain/workflow/transitions.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -27,6 +28,13 @@ func (e *Engine) GetAvailableTransitions(ctx context.Context, entityID string, m
 
 	entity, err := entityStore.Get(ctx, entityID)
 	if err != nil {
+		if !errors.Is(err, spi.ErrNotFound) {
+			// A store outage is not "no such entity". Reporting 404 for it
+			// would be a wrong-but-available answer
+			// (.claude/rules/correctness-over-availability.md); surface it
+			// as a sanitized 5xx instead.
+			return nil, common.Internal("failed to read entity", err)
+		}
 		return nil, common.Operational(http.StatusNotFound, common.ErrCodeEntityNotFound,
 			fmt.Sprintf("entity %s not found", entityID))
 	}

--- a/internal/domain/workflow/workflow_selection_test.go
+++ b/internal/domain/workflow/workflow_selection_test.go
@@ -1,0 +1,460 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+)
+
+// Workflow-level selection is criterion-driven and applies on EVERY engine
+// entry point, not just creation (`cyoda help workflows`, "Workflow-level
+// selection"). The tests below all use the same shape: two active workflows
+// on one model that DECLARE THE SAME STATE NAMES — the normal shape for a
+// per-kind machine — distinguished only by their `criterion`. Resolving by
+// "first active workflow that declares the entity's current state" cannot
+// tell them apart and always picks the first, so every assertion here fails
+// under that resolver and passes only under criterion-based selection.
+//
+// The transitions carry different `next` states per workflow, so the
+// observed end state alone identifies which definition ran. No compute node
+// is involved: the criteria are inline predicates over the payload.
+
+// kindWorkflows builds two workflows selected on $.kind, both declaring
+// state VALIDATE with a transition named `transitionName`, but landing in
+// different target states. wfA is declared FIRST, so it is what a
+// state-based resolver returns for every entity.
+func kindWorkflows(transitionName string, manual bool) []spi.WorkflowDefinition {
+	mk := func(name, kind, next string) spi.WorkflowDefinition {
+		return spi.WorkflowDefinition{
+			Version: "1.1", Name: name, InitialState: "VALIDATE", Active: true,
+			Criterion: simpleCriterion("$.kind", "EQUALS", kind),
+			States: map[string]spi.StateDefinition{
+				"VALIDATE": {Transitions: []spi.TransitionDefinition{
+					{Name: transitionName, Next: next, Manual: manual},
+				}},
+				next: {},
+			},
+		}
+	}
+	return []spi.WorkflowDefinition{
+		mk("kind-a-wf", "a", "A_DONE"),
+		mk("kind-b-wf", "b", "B_DONE"),
+	}
+}
+
+// setupKindModel saves the two kind workflows and registers the $.kind field
+// so inline criteria type-resolve.
+func setupKindModel(t *testing.T, factory spi.StoreFactory, ctx context.Context, modelRef spi.ModelRef, workflows []spi.WorkflowDefinition) {
+	t.Helper()
+	saveWorkflow(t, factory, ctx, modelRef, workflows)
+	registerModelFields(t, ctx, factory, modelRef, map[string]schema.DataType{"kind": schema.String})
+}
+
+// auditDetailsFor returns the Details strings of entityID's audit events of
+// the given type, in recorded order.
+func auditDetailsFor(t *testing.T, factory spi.StoreFactory, ctx context.Context, entityID string, eventType spi.StateMachineEventType) []string {
+	t.Helper()
+	auditStore, err := factory.StateMachineAuditStore(ctx)
+	if err != nil {
+		t.Fatalf("StateMachineAuditStore: %v", err)
+	}
+	events, err := auditStore.GetEvents(ctx, entityID)
+	if err != nil {
+		t.Fatalf("GetEvents: %v", err)
+	}
+	var out []string
+	for _, ev := range events {
+		if ev.EventType == eventType {
+			out = append(out, ev.Details)
+		}
+	}
+	return out
+}
+
+// TestManualTransition_ResolvesWorkflowByCriterion pins the defect from the
+// report: a manual transition on a multi-workflow model must run the
+// definition the entity's criterion selects, not the first one that happens
+// to declare its current state.
+func TestManualTransition_ResolvesWorkflowByCriterion(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "manual-select", ModelVersion: "1.0"}
+	setupKindModel(t, factory, ctx, modelRef, kindWorkflows("check", true))
+
+	entity := makeEntity("manual-b", modelRef, map[string]any{"kind": "b"})
+	entity.Meta.State = "VALIDATE"
+
+	if _, err := engine.ManualTransition(ctx, entity, "check"); err != nil {
+		t.Fatalf("ManualTransition: %v", err)
+	}
+	if entity.Meta.State != "B_DONE" {
+		t.Errorf("state = %q, want B_DONE (kind-b-wf selected by criterion); "+
+			"A_DONE means the first workflow declaring VALIDATE was used instead", entity.Meta.State)
+	}
+}
+
+// TestManualTransition_EmitsWorkflowSelectionAudit asserts the selection
+// audit trail is restored on the manual path: the skipped workflow is
+// recorded as WORKFLOW_SKIP and the selected one as WORKFLOW_FOUND, so an
+// operator can see which definition ran.
+func TestManualTransition_EmitsWorkflowSelectionAudit(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "manual-audit", ModelVersion: "1.0"}
+	setupKindModel(t, factory, ctx, modelRef, kindWorkflows("check", true))
+
+	entity := makeEntity("manual-audit-b", modelRef, map[string]any{"kind": "b"})
+	entity.Meta.State = "VALIDATE"
+
+	if _, err := engine.ManualTransition(ctx, entity, "check"); err != nil {
+		t.Fatalf("ManualTransition: %v", err)
+	}
+
+	skipped := auditDetailsFor(t, factory, ctx, "manual-audit-b", spi.SMEventWorkflowSkipped)
+	if len(skipped) != 1 {
+		t.Fatalf("WORKFLOW_SKIP events = %d (%v), want 1 (kind-a-wf)", len(skipped), skipped)
+	}
+	found := auditDetailsFor(t, factory, ctx, "manual-audit-b", spi.SMEventWorkflowFound)
+	if len(found) != 1 {
+		t.Fatalf("WORKFLOW_FOUND events = %d (%v), want 1 (kind-b-wf)", len(found), found)
+	}
+}
+
+// TestManualTransition_StateAbsentFromSelectedWorkflow_Fails asserts the
+// engine does NOT hop to another definition that happens to declare the
+// entity's state. The entity selects kind-a-wf, which has no ORPHAN state;
+// kind-b-wf does. That must fail, not silently run kind-b-wf's transition.
+func TestManualTransition_StateAbsentFromSelectedWorkflow_Fails(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "manual-orphan", ModelVersion: "1.0"}
+
+	wfA := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-a-wf", InitialState: "START", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "a"),
+		States: map[string]spi.StateDefinition{
+			"START": {},
+		},
+	}
+	wfB := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-b-wf", InitialState: "ORPHAN", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "b"),
+		States: map[string]spi.StateDefinition{
+			"ORPHAN": {Transitions: []spi.TransitionDefinition{{Name: "check", Next: "B_DONE", Manual: true}}},
+			"B_DONE": {},
+		},
+	}
+	setupKindModel(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wfA, wfB})
+
+	entity := makeEntity("manual-orphan-a", modelRef, map[string]any{"kind": "a"})
+	entity.Meta.State = "ORPHAN"
+
+	if _, err := engine.ManualTransition(ctx, entity, "check"); err == nil {
+		t.Fatalf("ManualTransition succeeded and moved to %q; want an error — "+
+			"ORPHAN is not in the criterion-selected workflow kind-a-wf", entity.Meta.State)
+	}
+	if entity.Meta.State != "ORPHAN" {
+		t.Errorf("state = %q, want ORPHAN (unchanged)", entity.Meta.State)
+	}
+}
+
+// TestLoopback_ResolvesWorkflowByCriterion is the automated-cascade
+// counterpart: a loopback re-evaluation must cascade the definition the
+// criterion selects.
+func TestLoopback_ResolvesWorkflowByCriterion(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "loopback-select", ModelVersion: "1.0"}
+	setupKindModel(t, factory, ctx, modelRef, kindWorkflows("advance", false))
+
+	entity := makeEntity("loopback-b", modelRef, map[string]any{"kind": "b"})
+	entity.Meta.State = "VALIDATE"
+
+	if _, err := engine.Loopback(ctx, entity); err != nil {
+		t.Fatalf("Loopback: %v", err)
+	}
+	if entity.Meta.State != "B_DONE" {
+		t.Errorf("state = %q, want B_DONE (kind-b-wf selected by criterion)", entity.Meta.State)
+	}
+}
+
+// TestLoopback_EmitsWorkflowSelectionAudit mirrors the manual-path audit
+// assertion for the loopback door.
+func TestLoopback_EmitsWorkflowSelectionAudit(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "loopback-audit", ModelVersion: "1.0"}
+	setupKindModel(t, factory, ctx, modelRef, kindWorkflows("advance", false))
+
+	entity := makeEntity("loopback-audit-b", modelRef, map[string]any{"kind": "b"})
+	entity.Meta.State = "VALIDATE"
+
+	if _, err := engine.Loopback(ctx, entity); err != nil {
+		t.Fatalf("Loopback: %v", err)
+	}
+
+	if skipped := auditDetailsFor(t, factory, ctx, "loopback-audit-b", spi.SMEventWorkflowSkipped); len(skipped) != 1 {
+		t.Errorf("WORKFLOW_SKIP events = %d (%v), want 1", len(skipped), skipped)
+	}
+	if found := auditDetailsFor(t, factory, ctx, "loopback-audit-b", spi.SMEventWorkflowFound); len(found) != 1 {
+		t.Errorf("WORKFLOW_FOUND events = %d (%v), want 1", len(found), found)
+	}
+}
+
+// TestLoopback_StateAbsentFromSelectedWorkflow_IsStable asserts loopback
+// keeps its STATE_NOT_IN_WORKFLOW stable-state contract when the state is
+// absent from the SELECTED workflow — rather than cascading some other
+// definition that declares it.
+func TestLoopback_StateAbsentFromSelectedWorkflow_IsStable(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "loopback-orphan", ModelVersion: "1.0"}
+
+	wfA := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-a-wf", InitialState: "START", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "a"),
+		States:    map[string]spi.StateDefinition{"START": {}},
+	}
+	wfB := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-b-wf", InitialState: "ORPHAN", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "b"),
+		States: map[string]spi.StateDefinition{
+			"ORPHAN": {Transitions: []spi.TransitionDefinition{{Name: "advance", Next: "B_DONE", Manual: false}}},
+			"B_DONE": {},
+		},
+	}
+	setupKindModel(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wfA, wfB})
+
+	entity := makeEntity("loopback-orphan-a", modelRef, map[string]any{"kind": "a"})
+	entity.Meta.State = "ORPHAN"
+
+	res, err := engine.Loopback(ctx, entity)
+	if err != nil {
+		t.Fatalf("Loopback: %v", err)
+	}
+	if entity.Meta.State != "ORPHAN" {
+		t.Errorf("state = %q, want ORPHAN (unchanged — kind-b-wf must not cascade)", entity.Meta.State)
+	}
+	if res.StopReason != "STATE_NOT_IN_WORKFLOW" {
+		t.Errorf("StopReason = %q, want STATE_NOT_IN_WORKFLOW", res.StopReason)
+	}
+}
+
+// TestFireScheduled_ResolvesWorkflowByCriterion is the scheduler-door
+// counterpart. Both workflows declare OPEN with a scheduled AutoClose, but
+// land in different states; the fire must run the criterion-selected one.
+func TestFireScheduled_ResolvesWorkflowByCriterion(t *testing.T) {
+	const armMs = int64(1_700_000_000_000)
+	const delayMs = int64(1000)
+	engine, factory, advance := setupEngineWithSteppableClock(t, armMs)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "fire-select", ModelVersion: "1.0"}
+
+	mk := func(name, kind, next string) spi.WorkflowDefinition {
+		return spi.WorkflowDefinition{
+			Version: "1.1", Name: name, InitialState: "OPEN", Active: true,
+			Criterion: simpleCriterion("$.kind", "EQUALS", kind),
+			States: map[string]spi.StateDefinition{
+				"OPEN": {Transitions: []spi.TransitionDefinition{
+					{Name: "AutoClose", Next: next, Schedule: &spi.TransitionSchedule{DelayMs: delayMs}},
+				}},
+				next: {},
+			},
+		}
+	}
+	setupKindModel(t, factory, ctx, modelRef, []spi.WorkflowDefinition{
+		mk("kind-a-wf", "a", "A_CLOSED"),
+		mk("kind-b-wf", "b", "B_CLOSED"),
+	})
+	seedFireEntity(t, factory, ctx, "fire-select-b", modelRef, "OPEN", "seed-tx-1", map[string]any{"kind": "b"})
+
+	id := taskID(testTenant, "fire-select-b", "OPEN", "AutoClose")
+	armTask(t, factory, ctx, spi.ScheduledTask{
+		ID: id, TenantID: testTenant, Type: spi.ScheduledTaskFireTransition,
+		ScheduledTime: armMs + delayMs, EntityID: "fire-select-b", ModelName: modelRef.EntityName,
+		Transition: "AutoClose", SourceState: "OPEN", ArmedAt: armMs,
+	})
+	advance(delayMs)
+
+	outcome, err := engine.FireScheduledTransition(ctx, spi.ScheduledTask{ID: id, TenantID: testTenant})
+	if err != nil {
+		t.Fatalf("FireScheduledTransition: %v", err)
+	}
+	if outcome != OutcomeFired {
+		t.Fatalf("outcome = %v, want Fired", outcome)
+	}
+	if got := getEntityState(t, factory, ctx, "fire-select-b"); got != "B_CLOSED" {
+		t.Errorf("entity state = %q, want B_CLOSED (kind-b-wf selected by criterion)", got)
+	}
+}
+
+// TestFireScheduled_TransitionAbsentFromSelectedWorkflow_Dropped asserts the
+// scheduler door drops (and self-heals) a task whose transition is not in
+// the criterion-selected workflow, instead of firing another definition's
+// same-named transition.
+func TestFireScheduled_TransitionAbsentFromSelectedWorkflow_Dropped(t *testing.T) {
+	const armMs = int64(1_700_000_000_000)
+	const delayMs = int64(1000)
+	engine, factory, advance := setupEngineWithSteppableClock(t, armMs)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "fire-orphan", ModelVersion: "1.0"}
+
+	// kind-b-wf is declared FIRST and owns the AutoClose the stale task
+	// names, so a state-based resolver fires it for every entity. kind-a-wf
+	// — the one this entity's criterion selects — declares OPEN with no
+	// scheduled transition at all.
+	wfA := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-a-wf", InitialState: "OPEN", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "a"),
+		States:    map[string]spi.StateDefinition{"OPEN": {}},
+	}
+	wfB := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-b-wf", InitialState: "OPEN", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "b"),
+		States: map[string]spi.StateDefinition{
+			"OPEN": {Transitions: []spi.TransitionDefinition{
+				{Name: "AutoClose", Next: "B_CLOSED", Schedule: &spi.TransitionSchedule{DelayMs: delayMs}},
+			}},
+			"B_CLOSED": {},
+		},
+	}
+	setupKindModel(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wfB, wfA})
+	seedFireEntity(t, factory, ctx, "fire-orphan-a", modelRef, "OPEN", "seed-tx-1", map[string]any{"kind": "a"})
+
+	id := taskID(testTenant, "fire-orphan-a", "OPEN", "AutoClose")
+	armTask(t, factory, ctx, spi.ScheduledTask{
+		ID: id, TenantID: testTenant, Type: spi.ScheduledTaskFireTransition,
+		ScheduledTime: armMs + delayMs, EntityID: "fire-orphan-a", ModelName: modelRef.EntityName,
+		Transition: "AutoClose", SourceState: "OPEN", ArmedAt: armMs,
+	})
+	advance(delayMs)
+
+	outcome, err := engine.FireScheduledTransition(ctx, spi.ScheduledTask{ID: id, TenantID: testTenant})
+	if err != nil {
+		t.Fatalf("FireScheduledTransition: %v", err)
+	}
+	if outcome != OutcomeDropped {
+		t.Fatalf("outcome = %v, want Dropped", outcome)
+	}
+	if got := getEntityState(t, factory, ctx, "fire-orphan-a"); got != "OPEN" {
+		t.Errorf("entity state = %q, want OPEN (kind-b-wf's AutoClose must not fire)", got)
+	}
+	if _, found := getTask(t, factory, ctx, id); found {
+		t.Error("expected the obsolete task to be deleted (self-heal)")
+	}
+}
+
+// TestGetAvailableTransitions_ResolvesByCriterion pins that the query door
+// reports the criterion-selected workflow's transitions.
+func TestGetAvailableTransitions_ResolvesByCriterion(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "query-select", ModelVersion: "1.0"}
+	setupKindModel(t, factory, ctx, modelRef, kindWorkflows("check", true))
+
+	entity := makeEntity("query-b", modelRef, map[string]any{"kind": "b"})
+	entity.Meta.State = "VALIDATE"
+
+	names, err := engine.GetAvailableTransitionsForEntity(ctx, entity)
+	if err != nil {
+		t.Fatalf("GetAvailableTransitionsForEntity: %v", err)
+	}
+	if len(names) != 1 || names[0] != "check" {
+		t.Fatalf("transitions = %v, want [check]", names)
+	}
+}
+
+// TestGetAvailableTransitions_WritesNoAuditEvents asserts the query door is
+// a pure read: workflow-selection events belong to an execution and have no
+// transaction to key them to here, so none may be recorded.
+func TestGetAvailableTransitions_WritesNoAuditEvents(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "query-audit", ModelVersion: "1.0"}
+	setupKindModel(t, factory, ctx, modelRef, kindWorkflows("check", true))
+
+	entity := makeEntity("query-audit-b", modelRef, map[string]any{"kind": "b"})
+	entity.Meta.State = "VALIDATE"
+
+	if _, err := engine.GetAvailableTransitionsForEntity(ctx, entity); err != nil {
+		t.Fatalf("GetAvailableTransitionsForEntity: %v", err)
+	}
+
+	auditStore, err := factory.StateMachineAuditStore(ctx)
+	if err != nil {
+		t.Fatalf("StateMachineAuditStore: %v", err)
+	}
+	events, err := auditStore.GetEvents(ctx, "query-audit-b")
+	if err != nil {
+		t.Fatalf("GetEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("audit events after a transitions query = %d, want 0: %+v", len(events), events)
+	}
+}
+
+// TestGetAvailableTransitions_CriterionErrorFailsClosed asserts the query
+// door does not degrade to the default workflow when a workflow criterion
+// cannot be evaluated. Returning some other workflow's transitions would be
+// a wrong-but-available answer; the engine fails closed instead
+// (.claude/rules/correctness-over-availability.md).
+func TestGetAvailableTransitions_CriterionErrorFailsClosed(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "query-failclosed", ModelVersion: "1.0"}
+
+	// A FUNCTION workflow criterion with no external processing service
+	// configured: evaluateCriterion returns an error rather than a verdict.
+	wf := spi.WorkflowDefinition{
+		Version: "1.1", Name: "fn-wf", InitialState: "VALIDATE", Active: true,
+		Criterion: functionCriterion(),
+		States: map[string]spi.StateDefinition{
+			"VALIDATE": {Transitions: []spi.TransitionDefinition{{Name: "check", Next: "DONE", Manual: true}}},
+			"DONE":     {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	entity := makeEntity("query-failclosed-1", modelRef, map[string]any{"kind": "a"})
+	entity.Meta.State = "VALIDATE"
+
+	names, err := engine.GetAvailableTransitionsForEntity(ctx, entity)
+	if err == nil {
+		t.Fatalf("GetAvailableTransitionsForEntity returned %v with no error; "+
+			"want the criterion-evaluation failure surfaced, not a default-workflow fallback", names)
+	}
+}
+
+// TestManualTransition_CriterionErrorFailsClosed asserts the same fail-closed
+// rule on the manual door: an unevaluable workflow criterion rejects the
+// operation instead of running whichever definition declares the state.
+func TestManualTransition_CriterionErrorFailsClosed(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "manual-failclosed", ModelVersion: "1.0"}
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.1", Name: "fn-wf", InitialState: "VALIDATE", Active: true,
+		Criterion: functionCriterion(),
+		States: map[string]spi.StateDefinition{
+			"VALIDATE": {Transitions: []spi.TransitionDefinition{{Name: "check", Next: "DONE", Manual: true}}},
+			"DONE":     {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	entity := makeEntity("manual-failclosed-1", modelRef, map[string]any{"kind": "a"})
+	entity.Meta.State = "VALIDATE"
+
+	if _, err := engine.ManualTransition(ctx, entity, "check"); err == nil {
+		t.Fatal("ManualTransition succeeded; want the criterion-evaluation failure surfaced")
+	} else if errors.Is(err, ErrTransitionNotFound) {
+		t.Errorf("error wraps ErrTransitionNotFound; want a criterion-evaluation failure: %v", err)
+	}
+	if entity.Meta.State != "VALIDATE" {
+		t.Errorf("state = %q, want VALIDATE (unchanged)", entity.Meta.State)
+	}
+}

--- a/internal/domain/workflow/workflow_selection_test.go
+++ b/internal/domain/workflow/workflow_selection_test.go
@@ -458,3 +458,256 @@ func TestManualTransition_CriterionErrorFailsClosed(t *testing.T) {
 		t.Errorf("state = %q, want VALIDATE (unchanged)", entity.Meta.State)
 	}
 }
+
+// --- Scheduler-door guards ---
+
+// fnCriterionWorkflow builds a workflow whose SELECTION criterion is a
+// FUNCTION with no external processing service configured, so resolution
+// always fails. Used to exercise the fire door when the workflow cannot be
+// resolved at all.
+func fnCriterionWorkflow(transitionName string, delayMs int64) spi.WorkflowDefinition {
+	return spi.WorkflowDefinition{
+		Version: "1.1", Name: "fn-select-wf", InitialState: "OPEN", Active: true,
+		Criterion: functionCriterion(),
+		States: map[string]spi.StateDefinition{
+			"OPEN": {Transitions: []spi.TransitionDefinition{
+				{Name: transitionName, Next: "CLOSED", Schedule: &spi.TransitionSchedule{DelayMs: delayMs}},
+			}},
+			"CLOSED": {},
+		},
+	}
+}
+
+// TestFireScheduled_ExpiresEvenWhenWorkflowCannotBeResolved pins the ordering
+// of the grace-band gate against workflow resolution. Expiry is a pure
+// function of the durable row and the clock, so a task past
+// TimeoutMs+grace must expire even while its workflow criterion cannot be
+// evaluated. Resolving first made such a task unexpirable and
+// unreclaimable — re-dispatched by the coordinator every backoff interval
+// for as long as the compute member stayed down.
+func TestFireScheduled_ExpiresEvenWhenWorkflowCannotBeResolved(t *testing.T) {
+	const armMs = int64(1_700_000_000_000)
+	const delayMs = int64(1000)
+	const timeoutMs = int64(500)
+	engine, factory, advance := setupEngineWithSteppableClock(t, armMs)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "fire-expire-unresolvable", ModelVersion: "1.0"}
+
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{fnCriterionWorkflow("AutoClose", delayMs)})
+	seedFireEntity(t, factory, ctx, "fire-expire-1", modelRef, "OPEN", "seed-tx-1", map[string]any{})
+
+	timeout := timeoutMs
+	id := taskID(testTenant, "fire-expire-1", "OPEN", "AutoClose")
+	armTask(t, factory, ctx, spi.ScheduledTask{
+		ID: id, TenantID: testTenant, Type: spi.ScheduledTaskFireTransition,
+		ScheduledTime: armMs + delayMs, TimeoutMs: &timeout, EntityID: "fire-expire-1",
+		ModelName: modelRef.EntityName, Transition: "AutoClose", SourceState: "OPEN", ArmedAt: armMs,
+	})
+
+	// Well past TimeoutMs + the expiry grace band.
+	advance(delayMs + timeoutMs + defaultExpiryGraceMs + 1000)
+
+	outcome, err := engine.FireScheduledTransition(ctx, spi.ScheduledTask{ID: id, TenantID: testTenant})
+	if err != nil {
+		t.Fatalf("FireScheduledTransition: %v", err)
+	}
+	if outcome != OutcomeExpired {
+		t.Fatalf("outcome = %v, want Expired — expiry must not depend on resolving the workflow", outcome)
+	}
+	if _, found := getTask(t, factory, ctx, id); found {
+		t.Error("expected the expired task to be deleted; an unresolvable workflow must not make it immortal")
+	}
+}
+
+// TestFireScheduled_UnresolvableWorkflowLeavesTaskForRetry is the companion:
+// before expiry is due, an unresolvable workflow must NOT fire and must NOT
+// consume the task — it is left in place for the next scan (fail closed,
+// then retry).
+func TestFireScheduled_UnresolvableWorkflowLeavesTaskForRetry(t *testing.T) {
+	const armMs = int64(1_700_000_000_000)
+	const delayMs = int64(1000)
+	engine, factory, advance := setupEngineWithSteppableClock(t, armMs)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "fire-retry-unresolvable", ModelVersion: "1.0"}
+
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{fnCriterionWorkflow("AutoClose", delayMs)})
+	seedFireEntity(t, factory, ctx, "fire-retry-1", modelRef, "OPEN", "seed-tx-1", map[string]any{})
+
+	id := taskID(testTenant, "fire-retry-1", "OPEN", "AutoClose")
+	armTask(t, factory, ctx, spi.ScheduledTask{
+		ID: id, TenantID: testTenant, Type: spi.ScheduledTaskFireTransition,
+		ScheduledTime: armMs + delayMs, EntityID: "fire-retry-1",
+		ModelName: modelRef.EntityName, Transition: "AutoClose", SourceState: "OPEN", ArmedAt: armMs,
+	})
+	advance(delayMs)
+
+	outcome, err := engine.FireScheduledTransition(ctx, spi.ScheduledTask{ID: id, TenantID: testTenant})
+	if err == nil {
+		t.Fatal("expected the resolution failure to be surfaced")
+	}
+	if outcome != OutcomeDropped {
+		t.Errorf("outcome = %v, want Dropped", outcome)
+	}
+	if got := getEntityState(t, factory, ctx, "fire-retry-1"); got != "OPEN" {
+		t.Errorf("entity state = %q, want OPEN (nothing may fire)", got)
+	}
+	if _, found := getTask(t, factory, ctx, id); !found {
+		t.Error("expected the task to survive for the next scan")
+	}
+}
+
+// TestFireScheduled_NeverFiresAManualTransition pins that the scheduler and
+// the arm side agree on what is fireable. reconcileScheduledTasks arms only
+// transitions that carry a Schedule and are neither manual nor disabled; the
+// fire door must apply the same test, or a task that outlives the definition
+// that armed it can drive a MANUAL transition — running its processors and
+// moving the entity with nobody having asked.
+//
+// Reachable through the ordinary API: kind-b-wf arms AutoClose; a write
+// re-binds the entity to kind-a-wf, where the same name is manual. Reconcile
+// does not cancel the task, because it only cancels rows whose SourceState
+// the entity has left — and here it has not moved.
+func TestFireScheduled_NeverFiresAManualTransition(t *testing.T) {
+	const armMs = int64(1_700_000_000_000)
+	const delayMs = int64(1000)
+	engine, factory, advance := setupEngineWithSteppableClock(t, armMs)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "fire-manual-guard", ModelVersion: "1.0"}
+
+	wfA := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-a-wf", InitialState: "OPEN", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "a"),
+		States: map[string]spi.StateDefinition{
+			// Same NAME, but manual — the scheduler must never fire it.
+			"OPEN":     {Transitions: []spi.TransitionDefinition{{Name: "AutoClose", Next: "A_CLOSED", Manual: true}}},
+			"A_CLOSED": {},
+		},
+	}
+	wfB := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-b-wf", InitialState: "OPEN", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "b"),
+		States: map[string]spi.StateDefinition{
+			"OPEN": {Transitions: []spi.TransitionDefinition{
+				{Name: "AutoClose", Next: "B_CLOSED", Schedule: &spi.TransitionSchedule{DelayMs: delayMs}},
+			}},
+			"B_CLOSED": {},
+		},
+	}
+	setupKindModel(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wfA, wfB})
+	// Armed under kind-b-wf, but the payload now selects kind-a-wf.
+	seedFireEntity(t, factory, ctx, "fire-manual-1", modelRef, "OPEN", "seed-tx-1", map[string]any{"kind": "a"})
+
+	id := taskID(testTenant, "fire-manual-1", "OPEN", "AutoClose")
+	armTask(t, factory, ctx, spi.ScheduledTask{
+		ID: id, TenantID: testTenant, Type: spi.ScheduledTaskFireTransition,
+		ScheduledTime: armMs + delayMs, EntityID: "fire-manual-1",
+		ModelName: modelRef.EntityName, Transition: "AutoClose", SourceState: "OPEN", ArmedAt: armMs,
+	})
+	advance(delayMs)
+
+	outcome, err := engine.FireScheduledTransition(ctx, spi.ScheduledTask{ID: id, TenantID: testTenant})
+	if err != nil {
+		t.Fatalf("FireScheduledTransition: %v", err)
+	}
+	if outcome != OutcomeDropped {
+		t.Fatalf("outcome = %v, want Dropped", outcome)
+	}
+	if got := getEntityState(t, factory, ctx, "fire-manual-1"); got != "OPEN" {
+		t.Errorf("entity state = %q, want OPEN — the scheduler fired a manual transition", got)
+	}
+	if _, found := getTask(t, factory, ctx, id); found {
+		t.Error("expected the obsolete task to be deleted (self-heal)")
+	}
+}
+
+// TestFireScheduled_ObsoleteTaskDiscardIsAudited pins that a scheduled
+// transition vanishing because the entity re-bound to another definition is
+// attributable. A scheduled transition is often a time-based control
+// (auto-expire, escalate-if-not-approved); a client write that silently
+// deletes one must leave a trace.
+func TestFireScheduled_ObsoleteTaskDiscardIsAudited(t *testing.T) {
+	const armMs = int64(1_700_000_000_000)
+	const delayMs = int64(1000)
+	engine, factory, advance := setupEngineWithSteppableClock(t, armMs)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "fire-obsolete-audit", ModelVersion: "1.0"}
+
+	wfA := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-a-wf", InitialState: "OPEN", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "a"),
+		States:    map[string]spi.StateDefinition{"OPEN": {}},
+	}
+	wfB := spi.WorkflowDefinition{
+		Version: "1.1", Name: "kind-b-wf", InitialState: "OPEN", Active: true,
+		Criterion: simpleCriterion("$.kind", "EQUALS", "b"),
+		States: map[string]spi.StateDefinition{
+			"OPEN": {Transitions: []spi.TransitionDefinition{
+				{Name: "AutoClose", Next: "B_CLOSED", Schedule: &spi.TransitionSchedule{DelayMs: delayMs}},
+			}},
+			"B_CLOSED": {},
+		},
+	}
+	setupKindModel(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wfA, wfB})
+	seedFireEntity(t, factory, ctx, "fire-obsolete-1", modelRef, "OPEN", "seed-tx-1", map[string]any{"kind": "a"})
+
+	id := taskID(testTenant, "fire-obsolete-1", "OPEN", "AutoClose")
+	armTask(t, factory, ctx, spi.ScheduledTask{
+		ID: id, TenantID: testTenant, Type: spi.ScheduledTaskFireTransition,
+		ScheduledTime: armMs + delayMs, EntityID: "fire-obsolete-1",
+		ModelName: modelRef.EntityName, Transition: "AutoClose", SourceState: "OPEN", ArmedAt: armMs,
+	})
+	advance(delayMs)
+
+	if _, err := engine.FireScheduledTransition(ctx, spi.ScheduledTask{ID: id, TenantID: testTenant}); err != nil {
+		t.Fatalf("FireScheduledTransition: %v", err)
+	}
+	if n := countAuditEvents(t, factory, ctx, "fire-obsolete-1", spi.SMEventScheduledTransitionCancelled); n != 1 {
+		t.Errorf("SCHEDULED_TRANSITION_CANCEL events = %d, want 1 (the discarded timer must be attributable)", n)
+	}
+}
+
+// TestFireScheduled_SilentGuardsRecordNoSelectionEvents pins the fire door's
+// audit contract (docs/cloud-parity/scheduled-transitions.md §6): the guards
+// that resolve a task silently — here, the entity having already left the
+// task's source state — must stay silent. Resolving the workflow before
+// those guards would stamp WORKFLOW_SKIP / WORKFLOW_FOUND onto every one of
+// them.
+func TestFireScheduled_SilentGuardsRecordNoSelectionEvents(t *testing.T) {
+	const armMs = int64(1_700_000_000_000)
+	const delayMs = int64(1000)
+	engine, factory, advance := setupEngineWithSteppableClock(t, armMs)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "fire-silent-guard", ModelVersion: "1.0"}
+
+	setupKindModel(t, factory, ctx, modelRef, []spi.WorkflowDefinition{
+		{
+			Version: "1.1", Name: "kind-a-wf", InitialState: "OPEN", Active: true,
+			Criterion: simpleCriterion("$.kind", "EQUALS", "a"),
+			States: map[string]spi.StateDefinition{
+				"OPEN": {Transitions: []spi.TransitionDefinition{
+					{Name: "AutoClose", Next: "CLOSED", Schedule: &spi.TransitionSchedule{DelayMs: delayMs}},
+				}},
+				"CLOSED": {},
+			},
+		},
+	})
+	// The entity has already moved on — the task's SourceState no longer matches.
+	seedFireEntity(t, factory, ctx, "fire-silent-1", modelRef, "CLOSED", "seed-tx-1", map[string]any{"kind": "a"})
+
+	id := taskID(testTenant, "fire-silent-1", "OPEN", "AutoClose")
+	armTask(t, factory, ctx, spi.ScheduledTask{
+		ID: id, TenantID: testTenant, Type: spi.ScheduledTaskFireTransition,
+		ScheduledTime: armMs + delayMs, EntityID: "fire-silent-1",
+		ModelName: modelRef.EntityName, Transition: "AutoClose", SourceState: "OPEN", ArmedAt: armMs,
+	})
+	advance(delayMs)
+
+	if _, err := engine.FireScheduledTransition(ctx, spi.ScheduledTask{ID: id, TenantID: testTenant}); err != nil {
+		t.Fatalf("FireScheduledTransition: %v", err)
+	}
+	for _, et := range []spi.StateMachineEventType{spi.SMEventWorkflowSkipped, spi.SMEventWorkflowFound} {
+		if n := countAuditEvents(t, factory, ctx, "fire-silent-1", et); n != 0 {
+			t.Errorf("%s events = %d, want 0 — a silent guard must not record selection", et, n)
+		}
+	}
+}

--- a/internal/domain/workflow/workflow_selection_test.go
+++ b/internal/domain/workflow/workflow_selection_test.go
@@ -3,10 +3,13 @@ package workflow
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
 
 // Workflow-level selection is criterion-driven and applies on EVERY engine
@@ -672,6 +675,10 @@ func TestFireScheduled_ObsoleteTaskDiscardIsAudited(t *testing.T) {
 // task's source state — must stay silent. Resolving the workflow before
 // those guards would stamp WORKFLOW_SKIP / WORKFLOW_FOUND onto every one of
 // them.
+//
+// This guard already sat above resolution, so the test is a regression pin
+// rather than evidence for the expiry reorder; TestFireScheduled_ExpiresEven-
+// WhenWorkflowCannotBeResolved is what discriminates that.
 func TestFireScheduled_SilentGuardsRecordNoSelectionEvents(t *testing.T) {
 	const armMs = int64(1_700_000_000_000)
 	const delayMs = int64(1000)
@@ -709,5 +716,111 @@ func TestFireScheduled_SilentGuardsRecordNoSelectionEvents(t *testing.T) {
 		if n := countAuditEvents(t, factory, ctx, "fire-silent-1", et); n != 0 {
 			t.Errorf("%s events = %d, want 0 — a silent guard must not record selection", et, n)
 		}
+	}
+}
+
+// --- Infra-failure classification during selection ---
+
+// errWorkflowStoreFactory makes WorkflowStore fail, modelling a genuine
+// store outage during workflow resolution. Every other capability delegates
+// so the rest of the engine still works.
+type errWorkflowStoreFactory struct {
+	spi.StoreFactory
+	err error
+}
+
+func (f *errWorkflowStoreFactory) WorkflowStore(context.Context) (spi.WorkflowStore, error) {
+	return nil, f.err
+}
+
+// TestResolveWorkflow_StoreOutageIsSanitizedInfraError asserts a workflow-store
+// outage during selection is reported as a server-side condition, not as a
+// client-attributable one. Callers classify a bare engine error as
+// 400 WORKFLOW_FAILED with err.Error() in the response body, which would put
+// raw store text (pgx messages, connection detail) in front of the caller —
+// the output-sanitization rule in .claude/rules/security.md.
+func TestResolveWorkflow_StoreOutageIsSanitizedInfraError(t *testing.T) {
+	base := memory.NewStoreFactory()
+	t.Cleanup(func() { base.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := base.NewTransactionManager(uuids)
+	storeErr := errors.New("pgx: connection refused to 10.0.0.7:5432")
+	engine := NewEngine(&errWorkflowStoreFactory{StoreFactory: base, err: storeErr}, uuids, txMgr)
+
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "store-outage", ModelVersion: "1.0"}
+	entity := makeEntity("store-outage-1", modelRef, map[string]any{"kind": "a"})
+	entity.Meta.State = "VALIDATE"
+
+	_, err := engine.ManualTransition(ctx, entity, "check")
+	if err == nil {
+		t.Fatal("expected the store outage to fail the transition")
+	}
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected a classified *common.AppError so the caller cannot emit it as a 4xx detail; got %T: %v", err, err)
+	}
+	if appErr.Status < 500 {
+		t.Errorf("status = %d, want 5xx (a store outage is not client-attributable)", appErr.Status)
+	}
+	if strings.Contains(appErr.Message, "connection refused") {
+		t.Errorf("client-facing message leaks store detail: %q", appErr.Message)
+	}
+	if !errors.Is(err, storeErr) {
+		t.Error("the underlying store error must stay in the chain for server-side logging")
+	}
+}
+
+// TestResolveWorkflow_QueryDoorStoreOutageIsSanitized is the read-door
+// counterpart: the transitions query must not answer, and must not hand the
+// caller raw store text either.
+func TestResolveWorkflow_QueryDoorStoreOutageIsSanitized(t *testing.T) {
+	base := memory.NewStoreFactory()
+	t.Cleanup(func() { base.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := base.NewTransactionManager(uuids)
+	storeErr := errors.New("pgx: connection refused to 10.0.0.7:5432")
+	engine := NewEngine(&errWorkflowStoreFactory{StoreFactory: base, err: storeErr}, uuids, txMgr)
+
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "store-outage-query", ModelVersion: "1.0"}
+	entity := makeEntity("store-outage-q1", modelRef, map[string]any{"kind": "a"})
+	entity.Meta.State = "VALIDATE"
+
+	names, err := engine.GetAvailableTransitionsForEntity(ctx, entity)
+	if err == nil {
+		t.Fatalf("GetAvailableTransitionsForEntity returned %v; a store outage must fail the read", names)
+	}
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) || appErr.Status < 500 {
+		t.Fatalf("expected a 5xx *common.AppError; got %T: %v", err, err)
+	}
+}
+
+// TestEvaluateCriterion_TypingFailureIsMarkedInfra asserts the model-load
+// failure a type-directed criterion needs is tagged as infrastructure, so
+// callers map it to a sanitized 5xx rather than echoing store text in a
+// 400 body. The causal chain must survive for server-side logging.
+func TestEvaluateCriterion_TypingFailureIsMarkedInfra(t *testing.T) {
+	base := memory.NewStoreFactory()
+	t.Cleanup(func() { base.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := base.NewTransactionManager(uuids)
+	storeErr := errors.New("pgx: model store unreachable")
+	engine := NewEngine(&errModelStoreFactory{StoreFactory: base, err: storeErr}, uuids, txMgr)
+
+	ctx := ctxWithTenant(testTenant)
+	ref := spi.ModelRef{EntityName: "typing-infra", ModelVersion: "1.0"}
+	entity := makeEntity("typing-infra-1", ref, map[string]any{"age": 30})
+
+	_, _, err := engine.evaluateCriterion(simpleCriterion("$.age", "GREATER_THAN", 5), entity, &criterionContext{ctx: ctx})
+	if err == nil {
+		t.Fatal("expected the model-load failure to be surfaced")
+	}
+	if !errors.Is(err, ErrCriterionTypingInfra) {
+		t.Errorf("error must wrap ErrCriterionTypingInfra so callers can sanitize it; got: %v", err)
+	}
+	if !errors.Is(err, storeErr) {
+		t.Errorf("error must keep the store cause in the chain for logging; got: %v", err)
 	}
 }

--- a/internal/domain/workflow/workflow_selection_test.go
+++ b/internal/domain/workflow/workflow_selection_test.go
@@ -824,3 +824,135 @@ func TestEvaluateCriterion_TypingFailureIsMarkedInfra(t *testing.T) {
 		t.Errorf("error must keep the store cause in the chain for logging; got: %v", err)
 	}
 }
+
+// --- Guard-path store failures must not be swallowed ---
+
+// failingDeleteTaskStore delegates everything except Delete, which always
+// fails. Models a store error on the self-heal paths that resolve a task by
+// removing its row.
+type failingDeleteTaskStore struct {
+	spi.ScheduledTaskStore
+	err error
+}
+
+func (s *failingDeleteTaskStore) Delete(context.Context, string) (bool, error) {
+	return false, s.err
+}
+
+type failingDeleteTaskFactory struct {
+	spi.StoreFactory
+	err error
+}
+
+func (f *failingDeleteTaskFactory) ScheduledTaskStore(ctx context.Context) (spi.ScheduledTaskStore, error) {
+	real, err := f.StoreFactory.ScheduledTaskStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &failingDeleteTaskStore{ScheduledTaskStore: real, err: f.err}, nil
+}
+
+// TestFireScheduled_EntityMovedOnDeleteFailureIsSurfaced asserts the
+// entity-moved-on guard does not commit after a failed delete. Swallowing
+// the error and committing anyway would report the task resolved while its
+// row is still live, so the coordinator re-dispatches it on every scan
+// forever.
+func TestFireScheduled_EntityMovedOnDeleteFailureIsSurfaced(t *testing.T) {
+	const armMs = int64(1_700_000_000_000)
+	const delayMs = int64(1000)
+	realFactory := memory.NewStoreFactory()
+	t.Cleanup(func() { realFactory.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := realFactory.NewTransactionManager(uuids)
+	clock, advance := steppableClock(armMs)
+	deleteErr := errors.New("scheduled task store unavailable")
+	engine := NewEngine(&failingDeleteTaskFactory{StoreFactory: realFactory, err: deleteErr},
+		uuids, txMgr, WithScheduledClock(clock))
+
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "fire-del-fail", ModelVersion: "1.0"}
+	saveWorkflow(t, realFactory, ctx, modelRef, []spi.WorkflowDefinition{{
+		Version: "1.1", Name: "wf", InitialState: "OPEN", Active: true,
+		States: map[string]spi.StateDefinition{
+			"OPEN": {Transitions: []spi.TransitionDefinition{
+				{Name: "AutoClose", Next: "CLOSED", Schedule: &spi.TransitionSchedule{DelayMs: delayMs}},
+			}},
+			"CLOSED": {},
+		},
+	}})
+	// Entity has already left the task's SourceState — the guard fires.
+	seedFireEntity(t, realFactory, ctx, "fire-del-1", modelRef, "CLOSED", "seed-tx-1", map[string]any{})
+
+	id := taskID(testTenant, "fire-del-1", "OPEN", "AutoClose")
+	armTask(t, realFactory, ctx, spi.ScheduledTask{
+		ID: id, TenantID: testTenant, Type: spi.ScheduledTaskFireTransition,
+		ScheduledTime: armMs + delayMs, EntityID: "fire-del-1",
+		ModelName: modelRef.EntityName, Transition: "AutoClose", SourceState: "OPEN", ArmedAt: armMs,
+	})
+	advance(delayMs)
+
+	outcome, err := engine.FireScheduledTransition(ctx, spi.ScheduledTask{ID: id, TenantID: testTenant})
+	if err == nil {
+		t.Fatal("expected the delete failure to be surfaced, not swallowed before a commit")
+	}
+	if !errors.Is(err, deleteErr) {
+		t.Errorf("error must carry the store cause; got: %v", err)
+	}
+	if outcome != OutcomeDropped {
+		t.Errorf("outcome = %v, want Dropped", outcome)
+	}
+}
+
+// errEntityStoreFactory makes EntityStore.Get fail with a non-ErrNotFound
+// error, modelling a store outage rather than a missing entity.
+type errEntityStoreFactory struct {
+	spi.StoreFactory
+	err error
+}
+
+func (f *errEntityStoreFactory) EntityStore(ctx context.Context) (spi.EntityStore, error) {
+	real, err := f.StoreFactory.EntityStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &errEntityStore{EntityStore: real, err: f.err}, nil
+}
+
+type errEntityStore struct {
+	spi.EntityStore
+	err error
+}
+
+func (s *errEntityStore) Get(context.Context, string) (*spi.Entity, error) { return nil, s.err }
+
+// TestGetAvailableTransitions_StoreOutageIsNot404 asserts an entity-store
+// outage is not reported as "entity not found". Answering 404 for an entity
+// that may well exist is a wrong-but-available result
+// (.claude/rules/correctness-over-availability.md) and would send a caller
+// down a create-it-again path against live data.
+func TestGetAvailableTransitions_StoreOutageIsNot404(t *testing.T) {
+	base := memory.NewStoreFactory()
+	t.Cleanup(func() { base.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := base.NewTransactionManager(uuids)
+	storeErr := errors.New("pgx: connection refused")
+	engine := NewEngine(&errEntityStoreFactory{StoreFactory: base, err: storeErr}, uuids, txMgr)
+
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "outage-404", ModelVersion: "1.0"}
+
+	_, err := engine.GetAvailableTransitions(ctx, "some-entity-id", modelRef)
+	if err == nil {
+		t.Fatal("expected the store outage to fail the read")
+	}
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected a classified *common.AppError; got %T: %v", err, err)
+	}
+	if appErr.Status == 404 {
+		t.Errorf("status = 404 %q; a store outage is not a missing entity", appErr.Message)
+	}
+	if appErr.Status < 500 {
+		t.Errorf("status = %d, want 5xx", appErr.Status)
+	}
+}

--- a/internal/e2e/workflow_selection_test.go
+++ b/internal/e2e/workflow_selection_test.go
@@ -1,0 +1,224 @@
+package e2e_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Workflow-level selection is criterion-driven and applies on every engine
+// door, not just creation (`cyoda help workflows`). These tests drive the
+// full HTTP stack against a model carrying two active workflows that declare
+// THE SAME STATE NAMES — the normal shape for a per-kind machine —
+// distinguished only by their `criterion`.
+//
+// kind-a-wf is declared first, so a resolver that picks "the first active
+// workflow declaring the entity's current state" returns it for every
+// entity. Each workflow's transitions land in a differently-named target
+// state, so the observed state alone identifies which definition ran. The
+// criteria are inline predicates over the payload — no compute node needed.
+
+// wfSelectionSample declares every field the selection criteria read. A
+// locked model rejects undeclared fields, so `kind` and `go` must both be
+// present with representative values.
+const wfSelectionSample = `{"name": "Test", "kind": "a", "go": false}`
+
+// wfSelectionWorkflows is the two-workflow import used by the tests below.
+// Both declare NONE / VALIDATE; only the target states differ.
+const wfSelectionWorkflows = `{
+	"importMode": "REPLACE",
+	"workflows": [
+		{
+			"version": "1.1", "name": "kind-a-wf", "initialState": "NONE", "active": true,
+			"criterion": {"type": "simple", "jsonPath": "$.kind", "operatorType": "EQUALS", "value": "a"},
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [
+					{"name": "check", "next": "A_CHECKED", "manual": true},
+					{"name": "a-advance", "next": "A_ADVANCED", "manual": false,
+						"criterion": {"type": "simple", "jsonPath": "$.go", "operatorType": "EQUALS", "value": true}}
+				]},
+				"A_CHECKED": {},
+				"A_ADVANCED": {}
+			}
+		},
+		{
+			"version": "1.1", "name": "kind-b-wf", "initialState": "NONE", "active": true,
+			"criterion": {"type": "simple", "jsonPath": "$.kind", "operatorType": "EQUALS", "value": "b"},
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [
+					{"name": "check", "next": "B_CHECKED", "manual": true},
+					{"name": "b-advance", "next": "B_ADVANCED", "manual": false,
+						"criterion": {"type": "simple", "jsonPath": "$.go", "operatorType": "EQUALS", "value": true}}
+				]},
+				"B_CHECKED": {},
+				"B_ADVANCED": {}
+			}
+		}
+	]
+}`
+
+// TestWorkflowSelection_ManualTransitionUsesCriterionSelectedWorkflow is the
+// end-to-end reproduction of the reported defect: a manual transition on a
+// multi-workflow model must fire the definition the entity's criterion
+// selects. A_CHECKED here would mean the first workflow declaring VALIDATE
+// was used for a `kind=b` entity.
+func TestWorkflowSelection_ManualTransitionUsesCriterionSelectedWorkflow(t *testing.T) {
+	const model = "e2e-wfsel-manual"
+	setupModelSampleWithWorkflow(t, model, wfSelectionSample, wfSelectionWorkflows)
+
+	entityID := createEntityE2E(t, model, 1, `{"name":"Test","kind":"b","go":false}`)
+	if got := getEntityState(t, entityID); got != "VALIDATE" {
+		t.Fatalf("state after create = %q, want VALIDATE", got)
+	}
+
+	updateEntityE2E(t, entityID, "check", `{"name":"Test","kind":"b","go":false}`)
+
+	if got := getEntityState(t, entityID); got != "B_CHECKED" {
+		t.Errorf("state after manual transition = %q, want B_CHECKED (kind-b-wf)", got)
+	}
+}
+
+// TestWorkflowSelection_ManualTransitionRecordsSelectionAudit asserts the
+// manual door records the same WORKFLOW_SKIP / WORKFLOW_FOUND trail the
+// creation door does, so the audit shows which definition ran.
+func TestWorkflowSelection_ManualTransitionRecordsSelectionAudit(t *testing.T) {
+	const model = "e2e-wfsel-audit"
+	setupModelSampleWithWorkflow(t, model, wfSelectionSample, wfSelectionWorkflows)
+
+	entityID := createEntityE2E(t, model, 1, `{"name":"Test","kind":"b","go":false}`)
+	before := countEventTypes(t, entityID)
+
+	updateEntityE2E(t, entityID, "check", `{"name":"Test","kind":"b","go":false}`)
+	after := countEventTypes(t, entityID)
+
+	if got := after["WORKFLOW_SKIP"] - before["WORKFLOW_SKIP"]; got != 1 {
+		t.Errorf("WORKFLOW_SKIP events added by the manual transition = %d, want 1 (kind-a-wf)", got)
+	}
+	if got := after["WORKFLOW_FOUND"] - before["WORKFLOW_FOUND"]; got != 1 {
+		t.Errorf("WORKFLOW_FOUND events added by the manual transition = %d, want 1 (kind-b-wf)", got)
+	}
+}
+
+// TestWorkflowSelection_LoopbackUsesCriterionSelectedWorkflow is the
+// automated-cascade counterpart, driven through a transition-less PUT.
+func TestWorkflowSelection_LoopbackUsesCriterionSelectedWorkflow(t *testing.T) {
+	const model = "e2e-wfsel-loopback"
+	setupModelSampleWithWorkflow(t, model, wfSelectionSample, wfSelectionWorkflows)
+
+	entityID := createEntityE2E(t, model, 1, `{"name":"Test","kind":"b","go":false}`)
+	if got := getEntityState(t, entityID); got != "VALIDATE" {
+		t.Fatalf("state after create = %q, want VALIDATE", got)
+	}
+
+	// Transition-less PUT: the engine re-evaluates automated transitions
+	// from the current state. go=true now satisfies the `b-advance` criterion.
+	path := fmt.Sprintf("/api/entity/JSON/%s", entityID)
+	resp := doAuth(t, http.MethodPut, path, `{"name":"Test","kind":"b","go":true}`)
+	if body := readBody(t, resp); resp.StatusCode != http.StatusOK {
+		t.Fatalf("loopback update: expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	if got := getEntityState(t, entityID); got != "B_ADVANCED" {
+		t.Errorf("state after loopback = %q, want B_ADVANCED (kind-b-wf)", got)
+	}
+}
+
+// TestWorkflowSelection_TransitionsQueryUsesCriterionSelectedWorkflow pins
+// that GET /entity/{id}/transitions answers for the same definition a
+// subsequent transition will run — the automated transition is named per
+// workflow (a-advance / b-advance), so the returned names identify it — and
+// that the query records no audit events of its own.
+func TestWorkflowSelection_TransitionsQueryUsesCriterionSelectedWorkflow(t *testing.T) {
+	const model = "e2e-wfsel-query"
+	setupModelSampleWithWorkflow(t, model, wfSelectionSample, wfSelectionWorkflows)
+
+	entityID := createEntityE2E(t, model, 1, `{"name":"Test","kind":"b","go":false}`)
+
+	resp := doAuth(t, http.MethodGet, fmt.Sprintf("/api/entity/%s/transitions", entityID), "")
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET transitions: expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "b-advance") || strings.Contains(body, "a-advance") {
+		t.Errorf("transitions = %s, want kind-b-wf's VALIDATE transitions (check, b-advance)", body)
+	}
+
+	// A read must not write: the query records no state-machine audit
+	// events of its own.
+	before := countEventTypes(t, entityID)
+	resp = doAuth(t, http.MethodGet, fmt.Sprintf("/api/entity/%s/transitions", entityID), "")
+	readBody(t, resp)
+	after := countEventTypes(t, entityID)
+	for et, n := range after {
+		if n != before[et] {
+			t.Errorf("transitions query added %d %s audit event(s); a read must record none", n-before[et], et)
+		}
+	}
+}
+
+// TestWorkflowSelection_StateAbsentFromSelectedWorkflowIsRejected asserts
+// the engine does not hop to a definition that merely declares the state.
+// The `kind=a` entity selects kind-a-only-wf, whose ONLY state is NONE;
+// kind-b-wf declares the ORPHAN state the entity is parked in. Firing must
+// be rejected, not silently served by kind-b-wf.
+func TestWorkflowSelection_StateAbsentFromSelectedWorkflowIsRejected(t *testing.T) {
+	const model = "e2e-wfsel-orphan"
+
+	// kind-b-wf is declared FIRST so a state-based resolver picks it for
+	// every entity, including the kind=a one created below.
+	const wf = `{
+		"importMode": "REPLACE",
+		"workflows": [
+			{
+				"version": "1.1", "name": "kind-b-wf", "initialState": "NONE", "active": true,
+				"criterion": {"type": "simple", "jsonPath": "$.kind", "operatorType": "EQUALS", "value": "b"},
+				"states": {
+					"NONE": {"transitions": [{"name": "init", "next": "ORPHAN", "manual": false}]},
+					"ORPHAN": {"transitions": [{"name": "check", "next": "B_CHECKED", "manual": true}]},
+					"B_CHECKED": {}
+				}
+			},
+			{
+				"version": "1.1", "name": "kind-a-wf", "initialState": "NONE", "active": true,
+				"criterion": {"type": "simple", "jsonPath": "$.kind", "operatorType": "EQUALS", "value": "a"},
+				"states": {"NONE": {}}
+			}
+		]
+	}`
+	setupModelSampleWithWorkflow(t, model, wfSelectionSample, wf)
+
+	// kind=b reaches ORPHAN through its own workflow; then flip the payload
+	// to kind=a so the entity re-binds to kind-a-wf, which has no ORPHAN.
+	entityID := createEntityE2E(t, model, 1, `{"name":"Test","kind":"b","go":false}`)
+	if got := getEntityState(t, entityID); got != "ORPHAN" {
+		t.Fatalf("state after create = %q, want ORPHAN", got)
+	}
+
+	path := fmt.Sprintf("/api/entity/JSON/%s/check", entityID)
+	resp := doAuth(t, http.MethodPut, path, `{"name":"Test","kind":"a","go":false}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("manual transition on a state absent from the selected workflow: "+
+			"expected 400, got %d: %s", resp.StatusCode, body)
+	}
+	if got := getEntityState(t, entityID); got != "ORPHAN" {
+		t.Errorf("state = %q, want ORPHAN (rejected transitions must not advance the entity)", got)
+	}
+}
+
+// countEventTypes returns a histogram of an entity's state-machine audit
+// event types. The limit is raised well above the endpoint default so a
+// multi-write entity's whole history is counted.
+func countEventTypes(t *testing.T, entityID string) map[string]int {
+	t.Helper()
+	counts := make(map[string]int)
+	for _, ev := range getSMAuditEventsWithLimit(t, entityID, 200) {
+		if et, ok := ev["eventType"].(string); ok {
+			counts[et]++
+		}
+	}
+	return counts
+}

--- a/internal/e2e/workflow_selection_test.go
+++ b/internal/e2e/workflow_selection_test.go
@@ -222,3 +222,125 @@ func countEventTypes(t *testing.T, entityID string) map[string]int {
 	}
 	return counts
 }
+
+// TestWorkflowSelection_UnevaluableCriterionFailsClosedOnEveryDoor covers the
+// error cell the fail-closed change introduces: when a workflow's SELECTION
+// criterion cannot be evaluated, no door may answer from a different
+// definition. Before the fix, the transitions read silently returned the
+// default workflow's transitions — a wrong-but-available answer — while the
+// write doors already failed.
+//
+// The entity is created under a workflow with no criterion, then a second
+// import puts an unevaluable FUNCTION criterion in front of it, so selection
+// itself is what fails rather than anything about the entity.
+func TestWorkflowSelection_UnevaluableCriterionFailsClosedOnEveryDoor(t *testing.T) {
+	const model = "e2e-wfsel-failclosed"
+
+	const workable = `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "plain-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [{"name": "check", "next": "CHECKED", "manual": true}]},
+				"CHECKED": {}
+			}
+		}]
+	}`
+	setupModelSampleWithWorkflow(t, model, wfSelectionSample, workable)
+	entityID := createEntityE2E(t, model, 1, `{"name":"Test","kind":"a","go":false}`)
+	if got := getEntityState(t, entityID); got != "VALIDATE" {
+		t.Fatalf("state after create = %q, want VALIDATE", got)
+	}
+
+	// Re-import the same states behind a selection criterion that dispatches
+	// to a compute function nothing serves, so resolution fails outright.
+	const unevaluable = `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "plain-wf", "initialState": "NONE", "active": true,
+			"criterion": {"type": "function", "function": {"name": "no-such-selector"}},
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [{"name": "check", "next": "CHECKED", "manual": true}]},
+				"CHECKED": {}
+			}
+		}]
+	}`
+	if status, body := importWorkflowE2E(t, model, 1, unevaluable); status != http.StatusOK {
+		t.Fatalf("workflow re-import: expected 200, got %d: %s", status, body)
+	}
+
+	// Read door: must fail, not fall back to the default workflow's list.
+	resp := doAuth(t, http.MethodGet, fmt.Sprintf("/api/entity/%s/transitions", entityID), "")
+	body := readBody(t, resp)
+	if resp.StatusCode == http.StatusOK {
+		t.Errorf("GET transitions returned 200 %s; an unevaluable selection criterion must fail the request, "+
+			"not answer from another workflow", body)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("GET transitions: status = %d, want 400 (same classification as the write doors): %s",
+			resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "WORKFLOW_FAILED") {
+		t.Errorf("GET transitions body missing WORKFLOW_FAILED: %s", body)
+	}
+
+	// Named-transition door: same condition, same classification.
+	resp = doAuth(t, http.MethodPut, fmt.Sprintf("/api/entity/JSON/%s/check", entityID),
+		`{"name":"Test","kind":"a","go":false}`)
+	body = readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("PUT with transition: status = %d, want 400: %s", resp.StatusCode, body)
+	}
+
+	// Loopback door: a transition-less PUT must fail closed too.
+	resp = doAuth(t, http.MethodPut, fmt.Sprintf("/api/entity/JSON/%s", entityID),
+		`{"name":"Test","kind":"a","go":true}`)
+	body = readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("loopback PUT: status = %d, want 400: %s", resp.StatusCode, body)
+	}
+
+	// Nothing may have moved.
+	if got := getEntityState(t, entityID); got != "VALIDATE" {
+		t.Errorf("state = %q, want VALIDATE (no door may advance the entity)", got)
+	}
+}
+
+// TestWorkflowSelection_FetchTransitionsAliasFailsClosed pins the
+// platform-api alias on the same contract — it is a second route onto the
+// same engine call and must not diverge on status.
+func TestWorkflowSelection_FetchTransitionsAliasFailsClosed(t *testing.T) {
+	const model = "e2e-wfsel-failclosed-alias"
+
+	const unevaluable = `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "plain-wf", "initialState": "NONE", "active": true,
+			"criterion": {"type": "function", "function": {"name": "no-such-selector"}},
+			"states": {"NONE": {}}
+		}]
+	}`
+	// Create first under a criterion-free workflow so the entity exists.
+	const workable = `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "plain-wf", "initialState": "NONE", "active": true,
+			"states": {"NONE": {}}
+		}]
+	}`
+	setupModelSampleWithWorkflow(t, model, wfSelectionSample, workable)
+	entityID := createEntityE2E(t, model, 1, `{"name":"Test","kind":"a","go":false}`)
+	if status, body := importWorkflowE2E(t, model, 1, unevaluable); status != http.StatusOK {
+		t.Fatalf("workflow re-import: expected 200, got %d: %s", status, body)
+	}
+
+	path := fmt.Sprintf("/api/platform-api/entity/fetch/transitions?entityClass=%s.1&entityId=%s", model, entityID)
+	resp := doAuth(t, http.MethodGet, path, "")
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("fetch-transitions alias: status = %d, want 400 (same as GET /entity/{id}/transitions): %s",
+			resp.StatusCode, body)
+	}
+}

--- a/internal/e2e/zzz_errorcode_matrix_test.go
+++ b/internal/e2e/zzz_errorcode_matrix_test.go
@@ -91,6 +91,7 @@ var EntityErrorCodeMatrix = map[string][]codeCell{
 	},
 	"updateSingleWithLoopback": {
 		{Status: 400, Code: "BAD_REQUEST"},        // unparseable body, or a payload carrying U+0000 (TestEntity_NulInPayload_400)
+		{Status: 400, Code: "WORKFLOW_FAILED"},    // engine rejected the loopback — e.g. an unevaluable workflow selection criterion (TestWorkflowSelection_UnevaluableCriterionFailsClosedOnEveryDoor)
 		{Status: 409, Code: "UNIQUE_VIOLATION"},   // TestUniqueKeys_UpdateMovesKey
 		{Status: 422, Code: "INVALID_UNIQUE_KEY"}, // TestUniqueKeys_LoopbackUpdatePartialKey
 		// 409 CONFLICT is exempt (universalCrossCuttingCodes)

--- a/internal/grpc/workflow_selection_test.go
+++ b/internal/grpc/workflow_selection_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	events "github.com/cyoda-platform/cyoda-go/api/grpc/events"
@@ -98,5 +99,104 @@ func TestRPC_EntityTransition_ResolvesWorkflowByCriterion(t *testing.T) {
 	}
 	if state, _ := envelope.Meta["state"].(string); state != "B_CHECKED" {
 		t.Errorf("state after gRPC transition = %q, want B_CHECKED (kind-b-wf selected by criterion)", state)
+	}
+}
+
+// TestRPC_EntityTransition_UnevaluableSelectionCriterionFailsClosed covers
+// the selection-failure error class on the gRPC surface. When a workflow's
+// SELECTION criterion cannot be evaluated the engine must reject rather than
+// answer from another definition, and the rejection must reach the caller as
+// a domain error in the CloudEvent envelope — not as a success, and not as a
+// transport error.
+func TestRPC_EntityTransition_UnevaluableSelectionCriterionFailsClosed(t *testing.T) {
+	const modelName = "grpc-workflow-selection-failclosed"
+	svc, wfHandler, ctx := newTestEnvWithWorkflow(t)
+
+	importAndLockModel(t, svc, ctx, modelName, "1",
+		map[string]any{"name": "Test", "kind": "a"})
+
+	importWF := func(body string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/api/model/"+modelName+"/1/workflow/import",
+			bytes.NewReader([]byte(body))).WithContext(ctx)
+		rec := httptest.NewRecorder()
+		wfHandler.ImportEntityModelWorkflow(rec, req, modelName, 1)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("workflow import: expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+	}
+
+	// Create under a criterion-free workflow so the entity exists and rests
+	// in VALIDATE.
+	importWF(`{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "plain-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [{"name": "check", "next": "CHECKED", "manual": true}]},
+				"CHECKED": {}
+			}
+		}]
+	}`)
+
+	createCE := makeCE(EntityCreateRequest, map[string]any{
+		"id":         "create-1",
+		"dataFormat": "JSON",
+		"payload": map[string]any{
+			"model": map[string]any{"name": modelName, "version": 1},
+			"data":  map[string]any{"name": "Test", "kind": "a"},
+		},
+	})
+	createResp, err := svc.EntityManage(ctx, createCE)
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	txInfo := parseResponsePayload(t, createResp)["transactionInfo"].(map[string]any)
+	entityID := txInfo["entityIds"].([]any)[0].(string)
+
+	// Now put an unevaluable FUNCTION selection criterion in front of the
+	// same states — no external processing service is configured in this
+	// harness, so resolution fails outright.
+	importWF(`{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "plain-wf", "initialState": "NONE", "active": true,
+			"criterion": {"type": "function", "function": {"name": "no-such-selector"}},
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [{"name": "check", "next": "CHECKED", "manual": true}]},
+				"CHECKED": {}
+			}
+		}]
+	}`)
+
+	transitionCE := makeCE(EntityTransitionRequest, map[string]any{
+		"id":         "transition-1",
+		"entityId":   entityID,
+		"transition": "check",
+	})
+	resp, err := svc.EntityManage(ctx, transitionCE)
+	if err != nil {
+		t.Fatalf("unexpected gRPC transport error: %v", err)
+	}
+	var typed events.EntityTransitionResponseJson
+	validateResponse(t, resp, &typed)
+	if typed.Success {
+		t.Fatal("expected the unevaluable selection criterion to fail the transition")
+	}
+	if typed.Error == nil {
+		t.Fatal("expected the error field to be populated")
+	}
+	if !strings.Contains(typed.Error.Message, "WORKFLOW_FAILED") {
+		t.Errorf("expected WORKFLOW_FAILED in the envelope message, got %s", typed.Error.Message)
+	}
+
+	envelope, err := svc.entityHandler.GetEntity(ctx, entity.GetOneEntityInput{EntityID: entityID})
+	if err != nil {
+		t.Fatalf("failed to re-fetch entity: %v", err)
+	}
+	if state, _ := envelope.Meta["state"].(string); state != "VALIDATE" {
+		t.Errorf("state = %q, want VALIDATE (a rejected transition must not advance the entity)", state)
 	}
 }

--- a/internal/grpc/workflow_selection_test.go
+++ b/internal/grpc/workflow_selection_test.go
@@ -1,0 +1,102 @@
+package grpc
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	events "github.com/cyoda-platform/cyoda-go/api/grpc/events"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/entity"
+)
+
+// grpcSelectionWorkflows imports two active workflows that declare THE SAME
+// STATE NAMES, distinguished only by their `criterion` — the normal shape for
+// a per-kind machine. kind-a-wf is declared first, so a resolver that returns
+// "the first active workflow declaring the entity's current state" picks it
+// for every entity; the differently-named target states make the observed
+// state identify which definition ran.
+const grpcSelectionWorkflows = `{
+	"importMode": "REPLACE",
+	"workflows": [
+		{
+			"version": "1.1", "name": "kind-a-wf", "initialState": "NONE", "active": true,
+			"criterion": {"type": "simple", "jsonPath": "$.kind", "operatorType": "EQUALS", "value": "a"},
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [{"name": "check", "next": "A_CHECKED", "manual": true}]},
+				"A_CHECKED": {}
+			}
+		},
+		{
+			"version": "1.1", "name": "kind-b-wf", "initialState": "NONE", "active": true,
+			"criterion": {"type": "simple", "jsonPath": "$.kind", "operatorType": "EQUALS", "value": "b"},
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "VALIDATE", "manual": false}]},
+				"VALIDATE": {"transitions": [{"name": "check", "next": "B_CHECKED", "manual": true}]},
+				"B_CHECKED": {}
+			}
+		}
+	]
+}`
+
+// TestRPC_EntityTransition_ResolvesWorkflowByCriterion drives a manual
+// transition through the gRPC entry point (EntityManage /
+// EntityTransitionRequest) on a multi-workflow model. gRPC and HTTP are
+// separate entry points onto the same engine, so the selection contract is
+// pinned on both: the transition must run the definition the entity's
+// criterion selects (B_CHECKED), not the first one declaring VALIDATE
+// (A_CHECKED).
+func TestRPC_EntityTransition_ResolvesWorkflowByCriterion(t *testing.T) {
+	const modelName = "grpc-workflow-selection"
+	svc, wfHandler, ctx := newTestEnvWithWorkflow(t)
+
+	importAndLockModel(t, svc, ctx, modelName, "1",
+		map[string]any{"name": "Test", "kind": "a"})
+	req := httptest.NewRequest(http.MethodPost, "/api/model/"+modelName+"/1/workflow/import",
+		bytes.NewReader([]byte(grpcSelectionWorkflows))).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	wfHandler.ImportEntityModelWorkflow(rec, req, modelName, 1)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("workflow import: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	createCE := makeCE(EntityCreateRequest, map[string]any{
+		"id":         "create-1",
+		"dataFormat": "JSON",
+		"payload": map[string]any{
+			"model": map[string]any{"name": modelName, "version": 1},
+			"data":  map[string]any{"name": "Test", "kind": "b"},
+		},
+	})
+	createResp, err := svc.EntityManage(ctx, createCE)
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	createPayload := parseResponsePayload(t, createResp)
+	txInfo := createPayload["transactionInfo"].(map[string]any)
+	entityID := txInfo["entityIds"].([]any)[0].(string)
+
+	transitionCE := makeCE(EntityTransitionRequest, map[string]any{
+		"id":         "transition-1",
+		"entityId":   entityID,
+		"transition": "check",
+	})
+	resp, err := svc.EntityManage(ctx, transitionCE)
+	if err != nil {
+		t.Fatalf("unexpected gRPC error: %v", err)
+	}
+	var typed events.EntityTransitionResponseJson
+	validateResponse(t, resp, &typed)
+	if !typed.Success {
+		t.Fatalf("transition failed: %+v", typed.Error)
+	}
+
+	envelope, err := svc.entityHandler.GetEntity(ctx, entity.GetOneEntityInput{EntityID: entityID})
+	if err != nil {
+		t.Fatalf("failed to re-fetch entity: %v", err)
+	}
+	if state, _ := envelope.Meta["state"].(string); state != "B_CHECKED" {
+		t.Errorf("state after gRPC transition = %q, want B_CHECKED (kind-b-wf selected by criterion)", state)
+	}
+}

--- a/internal/grpc/workflow_selection_test.go
+++ b/internal/grpc/workflow_selection_test.go
@@ -188,6 +188,9 @@ func TestRPC_EntityTransition_UnevaluableSelectionCriterionFailsClosed(t *testin
 	if typed.Error == nil {
 		t.Fatal("expected the error field to be populated")
 	}
+	if typed.Error.Code != "CLIENT_ERROR" {
+		t.Errorf("envelope code = %s, want CLIENT_ERROR", typed.Error.Code)
+	}
 	if !strings.Contains(typed.Error.Message, "WORKFLOW_FAILED") {
 		t.Errorf("expected WORKFLOW_FAILED in the envelope message, got %s", typed.Error.Message)
 	}


### PR DESCRIPTION
Fixes #465. (Auto-close does not fire on a merge into a release branch — carry `Closes #465` in the release-merge body.)

## What was wrong

`internal/domain/workflow/engine.go` had two workflow resolvers, and three of the four engine doors called the wrong one:

| Door | Resolver before | |
|---|---|---|
| `Execute` (creation) | `selectWorkflow` — evaluates each workflow's `criterion` | correct |
| `ManualTransition` | `findWorkflowForState` | **wrong** |
| `Loopback` | `findWorkflowForState` | **wrong** |
| `FireScheduledTransition` | `findWorkflowForState` | **wrong** |

`findWorkflowForState` returned the first active workflow whose `states` map contained the entity's current state. Where several definitions share state names — the normal shape for a per-kind machine — that is always `workflows[0]`, for every entity: the wrong guards, processors and target states, silently and fail-open. A second symptom followed: no `WORKFLOW_SKIP` / `WORKFLOW_FOUND` events were recorded on those paths, because `selectWorkflow` is what emits them, so the audit gave no sign a different definition had run.

The contract was already documented (`cyoda help workflows`, *Workflow-level selection*), so this is cyoda-go conforming to its own published behaviour — a bug fix, not a contract change. No new `docs/cloud-parity/` entry; the existing scheduled-transitions doc is updated where the fire door's audit set changed.

## The fix

All five doors — the four above plus the transitions query — resolve through one `Engine.resolveWorkflow`: load definitions, substitute the embedded default when the model has none, then `selectWorkflow`. `findWorkflowForState` is deleted, so the wrong resolver no longer exists to be called.

Consequences worth naming, all pinned by tests:

- Selection is per call and uncached, so a payload change can re-bind an entity to a different definition. If its current state is not declared there, the engine no longer falls through: a named transition is rejected `400 WORKFLOW_FAILED`, a loopback settles as a no-op with `STATE_NOT_IN_WORKFLOW`.
- `WORKFLOW_SKIP` / `WORKFLOW_FOUND` are recorded on every manual transition, loopback and scheduled fire, under the driving transaction. Emitting only on change would need a stored previous selection; per-call emission matches the documented "no caching across calls".
- A workflow-level `function` criterion is now dispatched on the scheduler's fire path too, inside its transaction, through the same `txgate.Suspend` discipline the transition-criterion dispatch already uses.

## Defects found by review and fixed here

**Scheduler door.**

- Expiry is decided **before** workflow resolution. Resolution can fail (a `function` selection criterion whose compute member is down), and gating expiry behind it made a past-timeout task unexpirable and unreclaimable — re-dispatched every backoff interval forever. Expiry needs only the durable row and the clock. The reorder also keeps the fire door's audit contract intact: the guards that resolve a task silently now all complete before selection records anything.
- The fire door matched a transition by **name only**, while the arm side arms only transitions that carry a `Schedule` and are neither manual nor disabled. A task outliving the definition that armed it could therefore drive a **manual** transition — running its processors and moving the entity with no client asking. Reachable through the ordinary API. `findFireableTransitionInState` now applies the exact complement of the arm-side filter.
- Discarding an obsolete task is audited (`SCHEDULED_TRANSITION_CANCEL`) rather than only debug-logged; a scheduled transition is often a time-based control, and a vanished timer must be attributable. Two sibling guards swallowed their `Delete` error and then committed, which can leave a row live for endless re-dispatch; both now check it.

**Error classification and sanitization.**

- `GET /entity/{entityId}/transitions` and its platform-api alias classify through `classifyWorkflowError`, like the write doors. "No compute member for the criterion's tag" was an opaque **500** on a read and a retryable **503** on a write — and the read's status flipped with `CYODA_CLUSTER_ENABLED`, since only the cluster dispatcher pre-classifies that sentinel.
- Workflow-store failures during resolution, and criterion-typing model-load failures, are minted as sanitized 5xx instead of reaching a 400 body verbatim with raw store text. `ErrCriterionTypingInfra` joins the existing infra sentinels; the cause chain is preserved for logs.
- A store outage on the transitions read reported `404 ENTITY_NOT_FOUND` — a wrong-but-available answer. Only a genuine `ErrNotFound` is a 404.

**Sibling defects in `GetAvailableTransitionsForEntity`,** found while wiring the query door onto the shared path:

- It wrote `WORKFLOW_SKIP` / `WORKFLOW_FOUND` keyed to an empty transaction ID on a pure read — its own comment said "no-op audit approach since we're just querying", but it passed the real store — and discarded the store-resolution error, so an audit-store failure would have nil-dereferenced. It now records into a `discardedAuditStore`.
- It swallowed criterion-**evaluation** errors and answered with the default workflow's transitions: a wrong-but-available result (`.claude/rules/correctness-over-availability.md`). It now fails closed. A criterion that merely does not *match* still resolves to the default, which is selection working as documented.

## Behaviour worth knowing about, deliberately left alone

**An obsolete scheduled task is reaped when it next comes due, not at the write that orphans it.** A state may declare several scheduled transitions, so an entity has one task row per armed transition out of its current state (`ScheduledTask` keyed by a hash of tenant + entity + sourceState + transition, so re-arming upserts in place). `ReconcileForEntity` deletes rows whose `SourceState` the entity has *left*; a row naming the state it is still in therefore survives a re-bind to another definition. The fire door then re-resolves, refuses (`findFireableTransitionInState`), deletes the row and records `SCHEDULED_TRANSITION_CANCEL`.

Reviewed and accepted: it self-heals, this kind of workflow flip is rare, and the cost is one wasted scan. Documented as the actual behaviour in `cyoda help workflows`, the CHANGELOG and the cloud-parity doc.

**`StateMachineAuditStore.Record` is transactional on postgres but writes straight through on memory and sqlite,** so audit events on a rolled-back path persist on two backends and vanish on the third. Pre-existing and general — filed separately as #470.

## Coverage

Every new test verified RED against the code it drives and GREEN after.

| Scenario | unit | HTTP e2e | parity | gRPC |
|---|---|---|---|---|
| Manual transition runs the criterion-selected workflow | ✓ | ✓ | ✓ | ✓ |
| Loopback cascades the criterion-selected workflow | ✓ | ✓ | ✓ | — |
| Scheduled fire runs the criterion-selected workflow | ✓ | — | — | — |
| State absent from the selected workflow → 400 | ✓ | ✓ | — | — |
| Loopback state absent there → `STATE_NOT_IN_WORKFLOW` | ✓ | — | — | — |
| `WORKFLOW_SKIP` / `WORKFLOW_FOUND` per door | ✓ | ✓ | — | — |
| Transitions query answers for the selected workflow | ✓ | ✓ | — | — |
| Transitions query records no audit events | ✓ | ✓ | — | — |
| Unevaluable criterion fails closed on every door | ✓ | ✓ | — | ✓ |
| Expiry survives an unresolvable workflow | ✓ | — | — | — |
| Unresolvable workflow before expiry → task retained | ✓ | — | — | — |
| Scheduler never fires a manual transition | ✓ | — | — | — |
| Obsolete-task discard audited | ✓ | — | — | — |
| Silent guards record no selection events | ✓ | — | — | — |
| Guard-path `Delete` failure surfaced, not committed | ✓ | — | — | — |
| Store outage → sanitized 5xx, not 400/404 | ✓ | — | — | — |
| `ErrNoMatchingMember` → retryable 503 | ✓ | — | — | — |

Fixtures use two workflows that share state names and differ only by `criterion`, with per-workflow target states, so the observed end state alone identifies which definition ran. Criteria are inline predicates — no compute node required. Parity scenario `WorkflowSelectionAfterCreation` passes on memory / sqlite / postgres; it will surface on the commercial backend at its next dependency update.

**Multi-node:** no distinct property to pin. `CachingStoreFactory.WorkflowStore` delegates without caching, so definitions cannot go stale per node, and the peer-dispatched fire runs the same `FireScheduledTransition` on the owner node.

## Docs (Gate 4)

- `cyoda help workflows` — selection applies on every door; the re-binding consequences; the audit trail; and that a selection criterion over a caller-writable field lets one request choose which definition's guards apply to itself, so where definitions differ in what they permit the selection field is a security control.
- `cyoda help crud`, `errors/WORKFLOW_FAILED`, `errors/TRANSITION_NOT_FOUND`, `errors.md`, and the OpenAPI operation — the transitions reads now carry `400 WORKFLOW_FAILED` and `503 NO_COMPUTE_MEMBER_FOR_TAG`. `TRANSITION_NOT_FOUND` was documented as `404` in four places; the code returns `400`.
- `docs/cloud-parity/scheduled-transitions.md` §6 — the fire door's audit set, which drops stay silent, expiry's precedence, and the lazy cancellation.
- `CHANGELOG.md` — two Fixed entries. The reported `409` was the reporter's application stack; cyoda-go returns `400 TRANSITION_NOT_FOUND`.

No env vars, new error codes, SPI pin or chart version changed, so no `README` / `COMPATIBILITY.md` / `errors/<CODE>.md` additions are due.

## Verification

`go test ./...` (root, incl. `internal/e2e` and the full parity suite) green; `plugins/memory|sqlite|postgres` green; `go vet ./...` clean; `make race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcbMZuZc3cbxZTevKpeL7w
