### PR TITLE
fix(search): five defects in the condition path — silent empty results, wrong criterion decisions, per-evaluation schema reparse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,6 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   The parsed form is held on the descriptor cache entry, so it is dropped by the same
   invalidation and lease the bytes already follow.
 
-
 - **A workflow processor's returned data is now governed by the model, exactly as a
   client's write is.** Previously a processor could write anything at all: content no
   backend could store (returning **500**), or fields the model does not declare —
@@ -131,7 +130,6 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   spells "match everything" as an empty `AND`, which already worked — so this is storage
   contract conformance rather than a user-visible fix, and it matters to anything driving
   the storage interface directly.
-
 
 - **An entity write now releases its transaction on every exit path, including a
   panic.** Previously a panic between begin and commit left the transaction neither

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **Sorting by a `$.`-prefixed field path over gRPC now works.** Sort-key resolution
+  prepended `$.` by hand, which is not idempotent. The HTTP layer strips the prefix
+  before resolving, so HTTP was unaffected; gRPC passes the client's path through
+  verbatim, so `orderBy` on `$.city` was looked up as `$.$.city` and returned **400
+  `INVALID_FIELD_PATH`** for a field that exists. The two transports now answer the same
+  request identically.
+
 - **A field path written without the `$.` prefix now resolves its declared type.**
   `city` and `$.city` are both accepted and both pass field-path validation, but only
   the prefixed form resolved against the model schema. The unprefixed form came back

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,15 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Changed
 
+- **A model's parsed schema is now cached alongside its descriptor.** Evaluating a
+  workflow criterion against a data field re-read the stored schema and rebuilt the
+  whole field map on every evaluation — per transition, and per step of a cascade.
+  Measured, that was 80–99% of the evaluation, scaling with schema size: on a
+  1000-field model, 1.84 ms and 12,400 allocations per evaluation, now 12 µs and 91.
+  The parsed form is held on the descriptor cache entry, so it is dropped by the same
+  invalidation and lease the bytes already follow.
+
+
 - **A workflow processor's returned data is now governed by the model, exactly as a
   client's write is.** Previously a processor could write anything at all: content no
   backend could store (returning **500**), or fields the model does not declare —
@@ -91,6 +100,38 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
 
 ### Fixed
+
+- **A field path written without the `$.` prefix now resolves its declared type.**
+  `city` and `$.city` are both accepted and both pass field-path validation, but only
+  the prefixed form resolved against the model schema. The unprefixed form came back
+  with no declared type, and a type-directed comparison with no declared type matches
+  nothing — so `city EQUALS "Berlin"` returned **200 with an empty page** on a model
+  whose `$.city` holds `Berlin`. In a workflow criterion the same defect made the leaf
+  evaluate false for **every** entity, so the transition silently never fired.
+  Declared-temporal fields reached this way were also compared as text rather than as
+  timestamps, and the type-soundness check skipped such a leaf entirely, so an operand
+  that should have been rejected `400 CONDITION_TYPE_MISMATCH` was accepted and
+  answered with an empty page. A genuinely unknown path still resolves to no declared
+  type, which is the intended degrade-to-no-match.
+
+- **PostgreSQL's in-Go residual filter no longer sees the internal `_meta` block.**
+  Postgres stores an entity as one document with the domain data and a storage-level
+  `_meta` block side by side, and the Go-side evaluator was handed the un-stripped
+  document, so a condition naming a data path under `_meta` matched there and on no
+  other backend. It now receives the same domain data every other backend passes.
+  Entity state, creation date and the other metadata remain searchable the supported
+  way, which is unaffected. **This does not yet close the surface**: for `IS_NULL`
+  and `NOT_NULL` the query is answered entirely in SQL with no Go re-check, and the
+  SQL still resolves a data path against the merged document. That remainder is
+  tracked separately.
+
+- **SQLite treats a zero-value filter as "match all", like the other backends.** It was
+  installed as a residual post-filter instead, which disabled `LIMIT` pushdown and armed
+  `CYODA_SQLITE_SEARCH_SCAN_LIMIT`. No cyoda-go request reaches this — every route
+  spells "match everything" as an empty `AND`, which already worked — so this is storage
+  contract conformance rather than a user-visible fix, and it matters to anything driving
+  the storage interface directly.
+
 
 - **An entity write now releases its transaction on every exit path, including a
   panic.** Previously a panic between begin and commit left the transaction neither

--- a/cmd/cyoda/help/content/errors/INVALID_FIELD_PATH.md
+++ b/cmd/cyoda/help/content/errors/INVALID_FIELD_PATH.md
@@ -21,7 +21,7 @@ HTTP: `400` `Bad Request`. Retryable: `no` (unless the model schema is then exte
 
 ## DESCRIPTION
 
-Before executing a search, the server validates that every data-field path referenced by the condition (e.g. `$.price`, `$.profile.email`) resolves against the target model's locked schema. Lifecycle paths (`state`, `previousTransition`, etc.) and meta paths (`$._meta.*`) bypass this check.
+Before executing a search, the server validates that every data-field path referenced by the condition (e.g. `$.price`, `$.profile.email`) resolves against the target model's locked schema. Lifecycle paths (`state`, `previousTransition`, etc.) bypass this check.
 
 A path that is a **pure container** — a known structural interior with substructure (an object with child fields) but no scalar observation of its own — is also rejected this way when compared with a scalar operator: a container has no scalar value to compare against, so the client must navigate to a leaf sub-path. `IS_NULL`/`NOT_NULL` are exempt (they test presence, not a value) and remain valid on a container path. A path observed as **both** an object and a bare scalar across different entities is not a pure container — it is searchable via its scalar type, and the object-valued entities remain reachable through their child leaves.
 

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 226 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 229 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -125,6 +125,15 @@ var allTests = []NamedTest{
 	{"SearchTemporalCreationDate", RunSearchTemporalCreationDate},
 	{"SearchTemporalLastUpdateTime", RunSearchTemporalLastUpdateTime},
 	{"SearchUnknownMetaField400", RunSearchUnknownMetaField400},
+
+	// Path-key resolution (PR #490). A field path spelled with and without
+	// the "$." prefix names the same field, and the storage layer's own
+	// _meta block is not addressable as entity data. Both were
+	// backend-visible before the fix, so both belong here rather than in a
+	// single-backend test.
+	{"SearchPrefixlessPathResolvesDeclaredType", RunSearchPrefixlessPathResolvesDeclaredType},
+	{"SearchPrefixlessPathTypeMismatch400", RunSearchPrefixlessPathTypeMismatch400},
+	{"SearchMetaBlockNotMatchableAsDataPath", RunSearchMetaBlockNotMatchableAsDataPath},
 	{"SearchStringMetaVocabulary", RunSearchStringMetaVocabulary},
 	{"SearchBetweenArity400", RunSearchBetweenArity400},
 	// Type-directed contract: a scalar comparison on a PURE-container path (a

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 226
+const wantParityScenarioCount = 229
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/e2e/parity/search_path_key.go
+++ b/e2e/parity/search_path_key.go
@@ -1,0 +1,202 @@
+package parity
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// search_path_key.go pins two properties that were backend-visible defects
+// before PR #490, and which no single-backend test can guard: both are about
+// which document a condition's field path is resolved against.
+
+// RunSearchPrefixlessPathResolvesDeclaredType pins that `amount` and
+// `$.amount` name the same field.
+//
+// FieldsMap keys always carry the "$." prefix, and pre-execution path
+// validation normalises before checking — so a prefix-less path clears every
+// gate as a known field. The declared-type lookup did not normalise, so it
+// missed the map and the leaf came back with no declared type. The kernel is
+// type-directed, so a comparison leaf with no declared type expands into
+// nothing and never matches: `city EQUALS "Berlin"` answered 200 with an empty
+// page on a model whose $.city holds Berlin.
+//
+// It is a parity scenario rather than a unit test because the two spellings
+// have to agree on every backend at once — the pushdown translator, the
+// in-memory evaluator, and the type-soundness validator each held their own
+// copy of the defect, and each is exercised by a different backend/plan shape.
+func RunSearchPrefixlessPathResolvesDeclaredType(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "parity-search-prefixless-path"
+	const modelVersion = 1
+	setupSearchModel(t, c, modelName, modelVersion)
+
+	aID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Alice","amount":100,"status":"active"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity Alice: %v", err)
+	}
+	if _, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Bob","amount":5,"status":"active"}`); err != nil {
+		t.Fatalf("CreateEntity Bob: %v", err)
+	}
+
+	// Both spellings of the same field must select the same entity. A string
+	// equality and a numeric comparison, because the defect showed up through
+	// the declared-type set and the two take different kernel branches.
+	for _, tc := range []struct {
+		label string
+		cond  string
+	}{
+		{"prefixed string", `{"type":"simple","jsonPath":"$.name","operatorType":"EQUALS","value":"Alice"}`},
+		{"prefixless string", `{"type":"simple","jsonPath":"name","operatorType":"EQUALS","value":"Alice"}`},
+		{"prefixed numeric", `{"type":"simple","jsonPath":"$.amount","operatorType":"GREATER_THAN","value":50}`},
+		{"prefixless numeric", `{"type":"simple","jsonPath":"amount","operatorType":"GREATER_THAN","value":50}`},
+	} {
+		results, err := c.SyncSearch(t, modelName, modelVersion, tc.cond)
+		if err != nil {
+			t.Fatalf("[%s] SyncSearch: %v", tc.label, err)
+		}
+		assertResultIDSet(t, tc.label, results, []string{aID.String()})
+	}
+}
+
+// RunSearchPrefixlessPathTypeMismatch400 pins the other half: the
+// type-soundness check indexes the same FieldsMap, so before the fix it
+// skipped any prefix-less leaf entirely. An operand that must be rejected was
+// accepted and answered with an empty page, while the identical condition
+// written "$.amount" was rejected — two spellings of one query returning
+// different HTTP statuses.
+func RunSearchPrefixlessPathTypeMismatch400(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "parity-search-prefixless-400"
+	const modelVersion = 1
+	setupSearchModel(t, c, modelName, modelVersion)
+
+	if _, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Alice","amount":100,"status":"active"}`); err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	for _, tc := range []struct {
+		label string
+		path  string
+	}{
+		{"prefixed", "$.amount"},
+		{"prefixless", "amount"},
+	} {
+		cond := `{"type":"simple","jsonPath":"` + tc.path + `","operatorType":"GREATER_THAN","value":"not-a-number"}`
+		status, body, err := c.SyncSearchRaw(t, modelName, modelVersion, cond)
+		if err != nil {
+			t.Fatalf("[%s] SyncSearchRaw: %v", tc.label, err)
+		}
+		if status != http.StatusBadRequest {
+			t.Fatalf("[%s] expected 400, got %d; body=%s", tc.label, status, body)
+		}
+		if !containsErrorCode(body, "CONDITION_TYPE_MISMATCH") {
+			t.Errorf("[%s] expected errorCode CONDITION_TYPE_MISMATCH, body=%s", tc.label, body)
+		}
+	}
+}
+
+// RunSearchMetaBlockNotMatchableAsDataPath pins that the storage layer's own
+// bookkeeping is not addressable as entity data.
+//
+// PostgreSQL stores an entity as one JSON document with the domain data and a
+// storage-level "_meta" block side by side; memory and sqlite keep the two
+// apart. The residual evaluator was handed the un-stripped document, so a
+// SourceData condition naming a path under _meta matched on PostgreSQL and on
+// no other backend — a divergence, and storage internals exposed as a
+// queryable surface.
+//
+// It probes through grouped stats, NOT /search, and that choice is the whole
+// point: /search validates every data-field path against the model first, so
+// "_meta.state" is rejected 400 INVALID_FIELD_PATH before any evaluator runs
+// and the probe would pass vacuously on a leaking backend. Grouped stats runs
+// no data-field path validation (cyoda-go#480), so the condition reaches the
+// residual evaluator — which is the code this guards. Verified by reverting
+// the fix: through /search the scenario passes either way; through grouped
+// stats it fails.
+//
+// DELIBERATELY NOT COVERED: the groupBy / ORDER BY / aggregate arms, and the
+// IS_NULL / NOT_NULL operators. Those are compiled straight to SQL against the
+// merged document with no kernel re-check, so they still resolve _meta on
+// PostgreSQL. That is cyoda-go#489, whose fix (nesting the domain data rather
+// than merging it) removes the shared namespace outright and closes all of them
+// at once. When #489 lands, extend this scenario and delete this note.
+func RunSearchMetaBlockNotMatchableAsDataPath(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "parity-search-meta-not-data"
+	const modelVersion = 1
+	setupSearchModel(t, c, modelName, modelVersion)
+
+	if _, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Alice","amount":100,"status":"active"}`); err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	// Sanity: the same query shape over a real data field does select the
+	// entity, so a zero-bucket result below means "did not match", not
+	// "grouped stats is broken".
+	control, err := c.QueryGroupedStats(t, modelName, modelVersion, client.GroupedStatsRequest{
+		GroupBy:   []string{"status"},
+		Condition: &client.AggregationCond{"type": "simple", "jsonPath": "status", "operatorType": "EQUALS", "value": "active"},
+	})
+	if err != nil {
+		t.Fatalf("control grouped stats: %v", err)
+	}
+	if len(control) != 1 || control[0].Count != 1 {
+		t.Fatalf("control returned %d buckets, want 1 with count 1: %+v", len(control), control)
+	}
+
+	// String operators, and each operand is a value the entity's metadata
+	// ACTUALLY holds. Both choices are load-bearing, and I got both wrong first:
+	//
+	//   - An operand nothing holds passes on a leaking backend and pins nothing.
+	//   - A COMPARISON operator also pins nothing. "_meta.state" is not in the
+	//     model, so it carries no declared type, and the type-directed kernel
+	//     expands a comparison with no declared type into nothing — a non-match
+	//     whichever document it was handed. String operators never consult
+	//     declared types, so they are the operators that can see the difference.
+	//
+	// Verified by reverting the fix: with EQUALS the scenario passes either way;
+	// with CONTAINS all four probes fail.
+	for _, tc := range []struct {
+		label string
+		cond  client.AggregationCond
+	}{
+		{"_meta.state", client.AggregationCond{"type": "simple", "jsonPath": "_meta.state", "operatorType": "CONTAINS", "value": "CREATE"}},
+		{"$._meta.state", client.AggregationCond{"type": "simple", "jsonPath": "$._meta.state", "operatorType": "CONTAINS", "value": "CREATE"}},
+		{"_meta.tenant_id", client.AggregationCond{"type": "simple", "jsonPath": "_meta.tenant_id", "operatorType": "CONTAINS", "value": tenant.ID}},
+		{"_meta.model_name", client.AggregationCond{"type": "simple", "jsonPath": "_meta.model_name", "operatorType": "CONTAINS", "value": modelName}},
+	} {
+		buckets, err := c.QueryGroupedStats(t, modelName, modelVersion, client.GroupedStatsRequest{
+			GroupBy:   []string{"status"},
+			Condition: &tc.cond,
+		})
+		if err != nil {
+			t.Fatalf("[%s] QueryGroupedStats: %v", tc.label, err)
+		}
+		total := int64(0)
+		for _, b := range buckets {
+			total += b.Count
+		}
+		if total != 0 {
+			t.Errorf("[%s] matched %d entities: the storage meta block is addressable as entity data on this backend", tc.label, total)
+		}
+	}
+
+	// Meta stays searchable the supported way — a lifecycle condition reads
+	// the entity's metadata and is unaffected. Asserted so the guard cannot be
+	// satisfied by starving the evaluator of the document entirely.
+	results, err := c.SyncSearch(t, modelName, modelVersion, `{"type":"lifecycle","field":"state","operatorType":"EQUALS","value":"CREATED"}`)
+	if err != nil {
+		t.Fatalf("lifecycle state search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("lifecycle condition on state returned %d entities, want 1 — meta must stay searchable the supported way", len(results))
+	}
+}

--- a/internal/cluster/modelcache/cache.go
+++ b/internal/cluster/modelcache/cache.go
@@ -9,6 +9,7 @@ package modelcache
 
 import (
 	"context"
+	"fmt"
 	"math/rand/v2"
 	"sync"
 	"time"
@@ -17,6 +18,7 @@ import (
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 )
 
 // Clock abstracts time.Now so tests can drive expiry deterministically.
@@ -63,6 +65,35 @@ type cacheKey struct {
 type cacheEntry struct {
 	desc      *spi.ModelDescriptor
 	expiresAt time.Time
+
+	// node is desc.Schema parsed, derived once when the entry is built and
+	// discarded with it. Deriving it is the dominant cost of evaluating a
+	// workflow criterion — the raw bytes were already cached here, the parse
+	// was not, so every evaluation rebuilt the whole field tree. Holding it on
+	// the entry means it inherits this entry's eviction and lease, so there is
+	// exactly one thing to invalidate and no way for a parse to outlive the
+	// bytes it came from.
+	//
+	// nodeErr is the parse failure, retained so a broken schema reports the
+	// same error every time without re-parsing to rediscover it. A descriptor
+	// with no schema bound yields (nil, nil) — "no type constraints", not an
+	// error, matching the callers this replaces.
+	node    *schema.ModelNode
+	nodeErr error
+}
+
+// parseSchemaNode derives the parsed schema for desc. The (nil, nil) result for
+// an absent or unbound schema, and the error wording, match what the search
+// package's fieldsFromDescriptor produced when it did this per call.
+func parseSchemaNode(desc *spi.ModelDescriptor) (*schema.ModelNode, error) {
+	if desc == nil || len(desc.Schema) == 0 {
+		return nil, nil
+	}
+	node, err := schema.Unmarshal(desc.Schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal model schema: %w", err)
+	}
+	return node, nil
 }
 
 // New constructs a CachingModelStore.
@@ -221,12 +252,51 @@ func (c *CachingModelStore) lookup(key cacheKey) *spi.ModelDescriptor {
 }
 
 func (c *CachingModelStore) store(key cacheKey, desc *spi.ModelDescriptor) {
+	// Derived outside the lock: parsing is the expensive part and depends only
+	// on desc, so holding the write lock across it would serialise every reader
+	// behind an unrelated model's parse.
+	node, nodeErr := parseSchemaNode(desc)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.entries[key] = cacheEntry{
 		desc:      desc,
 		expiresAt: c.clock.Now().Add(c.jitteredLeaseLocked()),
+		node:      node,
+		nodeErr:   nodeErr,
 	}
+}
+
+// lookupEntry returns the live entry for key, or ok=false when absent or past
+// its lease. Mirrors lookup, which returns only the descriptor.
+func (c *CachingModelStore) lookupEntry(key cacheKey) (cacheEntry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[key]
+	if !ok || c.clock.Now().After(e.expiresAt) {
+		return cacheEntry{}, false
+	}
+	return e, true
+}
+
+// SchemaNode returns ref's parsed model schema, derived once per cache entry
+// and reused for that entry's lifetime. Returns (nil, nil) when the descriptor
+// has no schema bound.
+//
+// An UNLOCKED descriptor is never cached — its schema can still change — so its
+// parse is produced fresh and not retained, exactly as its bytes are not.
+func (c *CachingModelStore) SchemaNode(ctx context.Context, ref spi.ModelRef) (*schema.ModelNode, error) {
+	key := cacheKey{tenant: common.TenantFromContext(ctx), ref: ref}
+	if e, ok := c.lookupEntry(key); ok {
+		return e.node, e.nodeErr
+	}
+	desc, err := c.Get(ctx, ref) // populates the entry when LOCKED
+	if err != nil {
+		return nil, err
+	}
+	if e, ok := c.lookupEntry(key); ok {
+		return e.node, e.nodeErr
+	}
+	return parseSchemaNode(desc)
 }
 
 func (c *CachingModelStore) evict(key cacheKey) {

--- a/internal/cluster/modelcache/factory.go
+++ b/internal/cluster/modelcache/factory.go
@@ -6,6 +6,7 @@ import (
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 )
 
 // CachingStoreFactory wraps an spi.StoreFactory so that ModelStore(ctx)
@@ -126,6 +127,27 @@ func (s *requestScopedStore) Get(ctx context.Context, ref spi.ModelRef) (*spi.Mo
 	}
 	s.cache.store(key, desc)
 	return desc, nil
+}
+
+// SchemaNode returns ref's parsed model schema, derived once per cache entry
+// and reused for that entry's lifetime. Mirrors Get: read through the shared
+// cache, otherwise fetch from this request's inner store and populate.
+//
+// An UNLOCKED descriptor is not cached, so its parse is produced fresh and not
+// retained — same rule its bytes follow.
+func (s *requestScopedStore) SchemaNode(ctx context.Context, ref spi.ModelRef) (*schema.ModelNode, error) {
+	key := cacheKey{tenant: common.TenantFromContext(ctx), ref: ref}
+	if e, ok := s.cache.lookupEntry(key); ok {
+		return e.node, e.nodeErr
+	}
+	desc, err := s.Get(ctx, ref) // populates the shared entry when LOCKED
+	if err != nil {
+		return nil, err
+	}
+	if e, ok := s.cache.lookupEntry(key); ok {
+		return e.node, e.nodeErr
+	}
+	return parseSchemaNode(desc)
 }
 
 // RefreshAndGet forces a cache miss, collapses concurrent callers via

--- a/internal/cluster/modelcache/schema_node_test.go
+++ b/internal/cluster/modelcache/schema_node_test.go
@@ -1,0 +1,165 @@
+package modelcache_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/cluster/modelcache"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+)
+
+func schemaBytes(t *testing.T) []byte {
+	t.Helper()
+	root := schema.NewObjectNode()
+	root.SetChild("amount", schema.NewLeafNode(schema.Integer))
+	root.SetChild("status", schema.NewLeafNode(schema.String))
+	b, err := schema.Marshal(root)
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	return b
+}
+
+func descWithSchema(t *testing.T, ref spi.ModelRef) *spi.ModelDescriptor {
+	t.Helper()
+	return &spi.ModelDescriptor{
+		Ref:    ref,
+		State:  spi.ModelLocked,
+		Schema: schemaBytes(t),
+	}
+}
+
+// The derived parse of a model schema is the dominant cost of evaluating a
+// workflow criterion — 80-99% of it, scaling with schema size. The descriptor
+// bytes are already cached; the parsed form must be cached on the same entry so
+// it inherits that entry's eviction, rather than being rebuilt per evaluation.
+func TestSchemaNode_ParsedOncePerCacheEntry(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+	inner := &stubStore{desc: descWithSchema(t, ref)}
+	clk := &manualClock{now: time.Now()}
+	c := modelcache.New(inner, nil, clk, time.Minute)
+	ctx := context.Background()
+
+	n1, err := c.SchemaNode(ctx, ref)
+	if err != nil {
+		t.Fatalf("SchemaNode: %v", err)
+	}
+	if n1 == nil {
+		t.Fatal("expected a parsed node")
+	}
+	if _, ok := n1.FieldsMap()["$.amount"]; !ok {
+		t.Fatalf("parsed node missing $.amount: %v", n1.FieldsMap())
+	}
+
+	n2, err := c.SchemaNode(ctx, ref)
+	if err != nil {
+		t.Fatalf("SchemaNode (second): %v", err)
+	}
+	if n1 != n2 {
+		t.Error("schema was re-parsed on a cache hit: the derived parse is not held on the cache entry")
+	}
+
+	// Invalidation must drop the derived parse with the descriptor, or a stale
+	// schema outlives the bytes it came from.
+	if err := c.Save(ctx, descWithSchema(t, ref)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	n3, err := c.SchemaNode(ctx, ref)
+	if err != nil {
+		t.Fatalf("SchemaNode (after invalidation): %v", err)
+	}
+	if n3 == n1 {
+		t.Error("invalidation did not drop the derived parse")
+	}
+}
+
+// A lease expiry must drop the derived parse too — same reason.
+func TestSchemaNode_ReparsedAfterLeaseExpiry(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+	inner := &stubStore{desc: descWithSchema(t, ref)}
+	clk := &manualClock{now: time.Now()}
+	c := modelcache.New(inner, nil, clk, time.Minute)
+	ctx := context.Background()
+
+	n1, err := c.SchemaNode(ctx, ref)
+	if err != nil {
+		t.Fatalf("SchemaNode: %v", err)
+	}
+	clk.advance(2 * time.Minute)
+	n2, err := c.SchemaNode(ctx, ref)
+	if err != nil {
+		t.Fatalf("SchemaNode after expiry: %v", err)
+	}
+	if n1 == n2 {
+		t.Error("expired entry returned the old derived parse")
+	}
+}
+
+// An unlocked descriptor is never cached (its schema can still change), so it
+// must still parse correctly — just without being retained.
+func TestSchemaNode_UnlockedModelParsesButIsNotCached(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+	unlocked := descWithSchema(t, ref)
+	unlocked.State = spi.ModelUnlocked
+	inner := &stubStore{desc: unlocked}
+	clk := &manualClock{now: time.Now()}
+	c := modelcache.New(inner, nil, clk, time.Minute)
+	ctx := context.Background()
+
+	n1, err := c.SchemaNode(ctx, ref)
+	if err != nil {
+		t.Fatalf("SchemaNode: %v", err)
+	}
+	if n1 == nil {
+		t.Fatal("expected a parsed node for an unlocked model")
+	}
+	n2, err := c.SchemaNode(ctx, ref)
+	if err != nil {
+		t.Fatalf("SchemaNode (second): %v", err)
+	}
+	if n1 == n2 {
+		t.Error("an unlocked descriptor's parse was retained; its schema can still change")
+	}
+}
+
+// A descriptor with no schema bound is "no type constraints", not an error —
+// matching what fieldsFromDescriptor and loadModelNode already do.
+func TestSchemaNode_NoSchemaBoundIsNotAnError(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+	inner := &stubStore{desc: &spi.ModelDescriptor{Ref: ref, State: spi.ModelLocked}}
+	clk := &manualClock{now: time.Now()}
+	c := modelcache.New(inner, nil, clk, time.Minute)
+
+	node, err := c.SchemaNode(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("expected no error for an unbound schema, got %v", err)
+	}
+	if node != nil {
+		t.Error("expected a nil node for an unbound schema")
+	}
+}
+
+// An unparseable schema must surface the same error every time, from the entry,
+// without re-parsing to rediscover it.
+func TestSchemaNode_UnparseableSchemaErrorIsStable(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+	inner := &stubStore{desc: &spi.ModelDescriptor{
+		Ref:    ref,
+		State:  spi.ModelLocked,
+		Schema: []byte(`{not json`),
+	}}
+	clk := &manualClock{now: time.Now()}
+	c := modelcache.New(inner, nil, clk, time.Minute)
+	ctx := context.Background()
+
+	_, err1 := c.SchemaNode(ctx, ref)
+	if err1 == nil {
+		t.Fatal("expected an error for an unparseable schema")
+	}
+	_, err2 := c.SchemaNode(ctx, ref)
+	if err2 == nil || err1.Error() != err2.Error() {
+		t.Errorf("unstable error across calls: %v vs %v", err1, err2)
+	}
+}

--- a/internal/cluster/modelcache/schema_node_test.go
+++ b/internal/cluster/modelcache/schema_node_test.go
@@ -7,6 +7,7 @@ import (
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/cluster/modelcache"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 )
 
@@ -162,4 +163,82 @@ func TestSchemaNode_UnparseableSchemaErrorIsStable(t *testing.T) {
 	if err2 == nil || err1.Error() != err2.Error() {
 		t.Errorf("unstable error across calls: %v vs %v", err1, err2)
 	}
+}
+
+// Gate 3 requires every data path to be verified for tenant isolation, and the
+// derived parse is a new one. The entry is keyed by (tenant, ref), so two
+// tenants holding different schemas for the same ModelRef must never see each
+// other's parse.
+func TestSchemaNode_TenantIsolation(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	rootA := schema.NewObjectNode()
+	rootA.SetChild("alpha", schema.NewLeafNode(schema.String))
+	bytesA, err := schema.Marshal(rootA)
+	if err != nil {
+		t.Fatalf("marshal A: %v", err)
+	}
+	rootB := schema.NewObjectNode()
+	rootB.SetChild("beta", schema.NewLeafNode(schema.Integer))
+	bytesB, err := schema.Marshal(rootB)
+	if err != nil {
+		t.Fatalf("marshal B: %v", err)
+	}
+
+	// One inner store that answers per tenant, so the only thing separating the
+	// two results is the cache key.
+	inner := &perTenantStore{schemas: map[string][]byte{
+		"tenant-a": bytesA,
+		"tenant-b": bytesB,
+	}, ref: ref}
+	c := modelcache.New(inner, nil, &manualClock{now: time.Now()}, time.Minute)
+
+	ctxA := withTenantContext(context.Background(), "tenant-a")
+	ctxB := withTenantContext(context.Background(), "tenant-b")
+
+	nodeA, err := c.SchemaNode(ctxA, ref)
+	if err != nil {
+		t.Fatalf("SchemaNode A: %v", err)
+	}
+	nodeB, err := c.SchemaNode(ctxB, ref)
+	if err != nil {
+		t.Fatalf("SchemaNode B: %v", err)
+	}
+
+	if _, ok := nodeA.FieldsMap()["$.alpha"]; !ok {
+		t.Errorf("tenant-a got the wrong schema: %v", nodeA.FieldsMap())
+	}
+	if _, ok := nodeB.FieldsMap()["$.beta"]; !ok {
+		t.Errorf("tenant-b got the wrong schema: %v", nodeB.FieldsMap())
+	}
+	if _, leaked := nodeA.FieldsMap()["$.beta"]; leaked {
+		t.Error("tenant-a was served tenant-b's parsed schema")
+	}
+	if _, leaked := nodeB.FieldsMap()["$.alpha"]; leaked {
+		t.Error("tenant-b was served tenant-a's parsed schema")
+	}
+
+	// Re-read both from cache; the separation must survive a cache hit.
+	againA, _ := c.SchemaNode(ctxA, ref)
+	againB, _ := c.SchemaNode(ctxB, ref)
+	if againA != nodeA || againB != nodeB {
+		t.Error("cached parse was not reused per tenant")
+	}
+	if againA == againB {
+		t.Error("both tenants received the same parsed node")
+	}
+}
+
+type perTenantStore struct {
+	spi.ModelStore
+	schemas map[string][]byte
+	ref     spi.ModelRef
+}
+
+func (s *perTenantStore) Get(ctx context.Context, _ spi.ModelRef) (*spi.ModelDescriptor, error) {
+	return &spi.ModelDescriptor{
+		Ref:    s.ref,
+		State:  spi.ModelLocked,
+		Schema: s.schemas[common.TenantFromContext(ctx)],
+	}, nil
 }

--- a/internal/domain/search/condition_type_validate.go
+++ b/internal/domain/search/condition_type_validate.go
@@ -81,7 +81,12 @@ func walkConditionTypes(fm map[string]schema.FieldDescriptor, cond predicate.Con
 }
 
 func validateSimpleConditionType(fm map[string]schema.FieldDescriptor, c *predicate.SimpleCondition) error {
-	fd, ok := fm[c.JsonPath]
+	// FieldsMap keys carry the "$." prefix; a condition may legitimately omit it
+	// and still name a known field. Looking it up raw made the type check silently
+	// skip such a leaf, so an operand that should be rejected 400
+	// CONDITION_TYPE_MISMATCH was accepted and evaluated to an empty page instead.
+	key := normalisePath(c.JsonPath)
+	fd, ok := fm[key]
 	if !ok {
 		// Not a leaf. In a schema'd model (non-empty FieldsMap), a path that is
 		// a KNOWN CONTAINER — a strict prefix of one or more leaf paths, but not
@@ -94,7 +99,7 @@ func validateSimpleConditionType(fm map[string]schema.FieldDescriptor, c *predic
 		// never reaches this branch. A genuinely-unknown (non-container) path
 		// carries no type constraint here; the separate field-path validation
 		// pass classifies it.
-		if len(fm) > 0 && carriesScalarOperand(mapOperator(c.OperatorType)) && isKnownContainerPath(c.JsonPath, fm) {
+		if len(fm) > 0 && carriesScalarOperand(mapOperator(c.OperatorType)) && isKnownContainerPath(key, fm) {
 			return fmt.Errorf("field %q is a container with substructure and cannot be compared to a scalar; navigate to a leaf sub-path: %w",
 				c.JsonPath, errInvalidFieldPath)
 		}

--- a/internal/domain/search/condition_type_validate.go
+++ b/internal/domain/search/condition_type_validate.go
@@ -313,6 +313,14 @@ func operandElements(v any) []any {
 // has already confirmed the model exists by the time this runs, so in the
 // normal case the node is present.
 func loadModelNode(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) *schema.ModelNode {
+	// Reuse the store's cached parse when it has one; see loadFieldsMap.
+	if p, ok := store.(schemaNodeProvider); ok {
+		node, err := p.SchemaNode(ctx, ref)
+		if err != nil {
+			return nil
+		}
+		return node
+	}
 	desc, err := store.Get(ctx, ref)
 	if err != nil || desc == nil || len(desc.Schema) == 0 {
 		return nil

--- a/internal/domain/search/filter_translate.go
+++ b/internal/domain/search/filter_translate.go
@@ -47,14 +47,22 @@ func simpleToFilter(c *predicate.SimpleCondition, fields map[string]schema.Field
 		return spi.Filter{}, err
 	}
 	op := mapOperator(c.OperatorType)
+	// FieldsMap keys are always "$."-prefixed. A condition may legitimately
+	// omit the prefix, and validateConditionPaths normalises before checking,
+	// so such a path reaches here as a known field. Look it up the same way, or
+	// it misses the map, Declared comes back empty, and a type-directed
+	// comparison leaf expands into nothing — a field that exists and holds
+	// matching data answers with an empty page. arrayToFilter already
+	// normalises via arrayElementPath; this is the arm that did not.
+	key := normalisePath(c.JsonPath)
 	return spi.Filter{
 		Op:       op,
 		Path:     stripped,
 		Source:   spi.SourceData,
 		Value:    c.Value,
 		Values:   betweenValues(op, c.Value),
-		Coercion: dataCoercion(c.JsonPath, fields),
-		Declared: fields[c.JsonPath].Types,
+		Coercion: dataCoercion(key, fields),
+		Declared: fields[key].Types,
 	}, nil
 }
 

--- a/internal/domain/search/filter_translate_declared_key_test.go
+++ b/internal/domain/search/filter_translate_declared_key_test.go
@@ -1,0 +1,91 @@
+package search
+
+import (
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+)
+
+// FieldsMap keys are always "$."-prefixed (normalisePath). A condition may
+// legitimately omit the prefix — TestConditionToFilter_SimpleNoPrefix pins that
+// "city" is accepted — and validateConditionPaths normalises before checking, so
+// such a path passes every gate as a known field.
+//
+// The translator must normalise too. Looking up the raw path misses the map,
+// leaves Declared nil, and a type-directed comparison leaf with no declared type
+// expands into nothing and never matches. The caller gets 200 with an empty page
+// for a field that exists and holds matching data.
+func fieldsFixture() map[string]schema.FieldDescriptor {
+	return map[string]schema.FieldDescriptor{
+		"$.city":   {Path: "$.city", Types: []spi.DataType{spi.String}},
+		"$.amount": {Path: "$.amount", Types: []spi.DataType{spi.Integer}},
+		"$.when":   {Path: "$.when", Types: []spi.DataType{spi.ZonedDateTime}},
+	}
+}
+
+func TestConditionToFilter_DeclaredResolvesForPrefixlessPath(t *testing.T) {
+	fields := fieldsFixture()
+
+	for _, path := range []string{"city", "$.city"} {
+		t.Run(path, func(t *testing.T) {
+			f, err := ConditionToFilter(&predicate.SimpleCondition{
+				JsonPath:     path,
+				OperatorType: "EQUALS",
+				Value:        "Berlin",
+			}, fields)
+			if err != nil {
+				t.Fatalf("ConditionToFilter: %v", err)
+			}
+			if len(f.Declared) != 1 || f.Declared[0] != spi.String {
+				t.Fatalf("Declared = %v, want [STRING] — an unresolved declared set makes the leaf never match", f.Declared)
+			}
+			if !spi.MatchFilter(f, []byte(`{"city":"Berlin"}`), spi.EntityMeta{}) {
+				t.Error("leaf did not match an entity that holds the value")
+			}
+		})
+	}
+}
+
+// Coercion is looked up with the same key and has the same defect: a
+// declared-temporal field reached by a prefix-less path was stamped CoerceNone,
+// so the SQL planners would compare it as text rather than as a timestamp.
+func TestConditionToFilter_CoercionResolvesForPrefixlessPath(t *testing.T) {
+	fields := fieldsFixture()
+
+	for _, path := range []string{"when", "$.when"} {
+		t.Run(path, func(t *testing.T) {
+			f, err := ConditionToFilter(&predicate.SimpleCondition{
+				JsonPath:     path,
+				OperatorType: "GREATER_THAN",
+				Value:        "2020-01-01T00:00:00Z",
+			}, fields)
+			if err != nil {
+				t.Fatalf("ConditionToFilter: %v", err)
+			}
+			if f.Coercion != spi.CoerceTemporal {
+				t.Errorf("Coercion = %v, want CoerceTemporal", f.Coercion)
+			}
+		})
+	}
+}
+
+// A genuinely unknown path must still resolve to no declared types — the
+// deliberate degrade-to-non-match behaviour this must not disturb.
+func TestConditionToFilter_UnknownPathStillHasNoDeclaredTypes(t *testing.T) {
+	f, err := ConditionToFilter(&predicate.SimpleCondition{
+		JsonPath:     "$.nosuch",
+		OperatorType: "EQUALS",
+		Value:        "x",
+	}, fieldsFixture())
+	if err != nil {
+		t.Fatalf("ConditionToFilter: %v", err)
+	}
+	if len(f.Declared) != 0 {
+		t.Errorf("Declared = %v, want empty for an unknown path", f.Declared)
+	}
+	if f.Coercion != spi.CoerceNone {
+		t.Errorf("Coercion = %v, want CoerceNone for an unknown path", f.Coercion)
+	}
+}

--- a/internal/domain/search/orderresolve.go
+++ b/internal/domain/search/orderresolve.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"fmt"
+	"strings"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
@@ -23,7 +24,13 @@ func resolveOrderBy(keys []OrderKey, fields map[string]schema.FieldDescriptor) (
 			specs = append(specs, spi.OrderSpec{Path: mf.Path, Source: mf.Source, Desc: k.Desc, Kind: mf.Kind})
 			continue
 		}
-		fd, ok := fields["$."+k.Path]
+		// normalisePath, not a manual prepend: the HTTP parser strips "$." before
+		// building the key (sortparam.go) but gRPC passes the client's path
+		// through verbatim, so "$.city" from a gRPC caller became "$.$.city" and
+		// a 400 for a field that exists — the two transports disagreeing on the
+		// same request.
+		key := normalisePath(k.Path)
+		fd, ok := fields[key]
 		if !ok {
 			return nil, fmt.Errorf("unknown sort field: %q", k.Path)
 		}
@@ -39,7 +46,10 @@ func resolveOrderBy(keys []OrderKey, fields map[string]schema.FieldDescriptor) (
 		if err != nil {
 			return nil, fmt.Errorf("field %q: %w", k.Path, err)
 		}
-		specs = append(specs, spi.OrderSpec{Path: k.Path, Source: spi.SourceData, Desc: k.Desc, Kind: kind})
+		// Emit the prefix-stripped form the plugins' path validators accept —
+		// they reject "$" as an identifier byte. HTTP already stripped before
+		// building the key; gRPC did not, so strip here for both.
+		specs = append(specs, spi.OrderSpec{Path: strings.TrimPrefix(key, "$."), Source: spi.SourceData, Desc: k.Desc, Kind: kind})
 	}
 	return specs, nil
 }

--- a/internal/domain/search/path_key_coverage_test.go
+++ b/internal/domain/search/path_key_coverage_test.go
@@ -1,0 +1,129 @@
+package search
+
+import (
+	"errors"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+)
+
+func keyTestFields() map[string]schema.FieldDescriptor {
+	return map[string]schema.FieldDescriptor{
+		"$.amount":       {Path: "$.amount", Types: []spi.DataType{spi.Integer}},
+		"$.city":         {Path: "$.city", Types: []spi.DataType{spi.String}},
+		"$.address.city": {Path: "$.address.city", Types: []spi.DataType{spi.String}},
+		"$.tags":         {Path: "$.tags", Types: []spi.DataType{spi.String}, IsArray: true},
+	}
+}
+
+// The type-soundness check indexes the FieldsMap, whose keys carry the "$."
+// prefix. Looking a condition's path up raw made the check skip any prefix-less
+// leaf entirely — so an operand that must be rejected 400 CONDITION_TYPE_MISMATCH
+// was accepted and answered with an empty page, while the identical condition
+// written "$.amount" was rejected. This is a status-code difference between two
+// spellings of the same query.
+func TestValidateSimpleConditionType_RejectsBadOperandOnPrefixlessPath(t *testing.T) {
+	for _, path := range []string{"amount", "$.amount"} {
+		t.Run(path, func(t *testing.T) {
+			err := validateSimpleConditionType(keyTestFields(), &predicate.SimpleCondition{
+				JsonPath:     path,
+				OperatorType: "GREATER_THAN",
+				Value:        "not-a-number",
+			})
+			if err == nil {
+				t.Fatal("expected a type mismatch; an unresolved leaf skips the check and answers 200 with an empty page")
+			}
+			if !errors.Is(err, errConditionTypeMismatch) {
+				t.Errorf("expected errConditionTypeMismatch, got %v", err)
+			}
+		})
+	}
+}
+
+// The container-path rejection uses the same key and had the same defect.
+func TestValidateSimpleConditionType_RejectsContainerOnPrefixlessPath(t *testing.T) {
+	for _, path := range []string{"address", "$.address"} {
+		t.Run(path, func(t *testing.T) {
+			err := validateSimpleConditionType(keyTestFields(), &predicate.SimpleCondition{
+				JsonPath:     path,
+				OperatorType: "EQUALS",
+				Value:        "x",
+			})
+			if err == nil {
+				t.Fatal("expected a container path to be rejected")
+			}
+			if !errors.Is(err, errInvalidFieldPath) {
+				t.Errorf("expected errInvalidFieldPath, got %v", err)
+			}
+		})
+	}
+}
+
+// A well-typed operand must still pass, both spellings — the fix must not turn
+// the check into a blanket rejection.
+func TestValidateSimpleConditionType_AcceptsWellTypedOperand(t *testing.T) {
+	for _, path := range []string{"amount", "$.amount"} {
+		t.Run(path, func(t *testing.T) {
+			if err := validateSimpleConditionType(keyTestFields(), &predicate.SimpleCondition{
+				JsonPath:     path,
+				OperatorType: "GREATER_THAN",
+				Value:        10,
+			}); err != nil {
+				t.Errorf("well-typed operand rejected: %v", err)
+			}
+		})
+	}
+}
+
+// An unknown path carries no type constraint here — the separate field-path
+// pass classifies it. Preserved for both spellings.
+func TestValidateSimpleConditionType_UnknownPathCarriesNoConstraint(t *testing.T) {
+	for _, path := range []string{"nosuch", "$.nosuch"} {
+		t.Run(path, func(t *testing.T) {
+			if err := validateSimpleConditionType(keyTestFields(), &predicate.SimpleCondition{
+				JsonPath:     path,
+				OperatorType: "GREATER_THAN",
+				Value:        "not-a-number",
+			}); err != nil {
+				t.Errorf("unknown path must carry no constraint here, got %v", err)
+			}
+		})
+	}
+}
+
+// Sort-key resolution prepends "$." by hand, which is not idempotent. HTTP
+// strips the prefix before building the key (sortparam.go), but gRPC passes the
+// client's path through verbatim (internal/grpc/search.go), so a gRPC client
+// sorting by "$.city" produced the lookup key "$.$.city" and a 400 for a field
+// that exists — the two transports disagreeing on the same request.
+func TestResolveSortKeys_PrefixedPathResolvesOnBothSpellings(t *testing.T) {
+	for _, path := range []string{"city", "$.city"} {
+		t.Run(path, func(t *testing.T) {
+			specs, err := resolveOrderBy([]OrderKey{{Path: path, Source: spi.SourceData}}, keyTestFields())
+			if err != nil {
+				t.Fatalf("resolveOrderBy(%q): %v", path, err)
+			}
+			if len(specs) != 1 || specs[0].Path != "city" {
+				t.Fatalf("unexpected specs: %+v", specs)
+			}
+		})
+	}
+}
+
+func TestResolveSortKeys_UnknownFieldStillRejected(t *testing.T) {
+	if _, err := resolveOrderBy([]OrderKey{{Path: "nosuch", Source: spi.SourceData}}, keyTestFields()); err == nil {
+		t.Error("expected an unknown sort field to be rejected")
+	}
+}
+
+func TestResolveSortKeys_ArrayFieldStillRejected(t *testing.T) {
+	for _, path := range []string{"tags", "$.tags"} {
+		t.Run(path, func(t *testing.T) {
+			if _, err := resolveOrderBy([]OrderKey{{Path: path, Source: spi.SourceData}}, keyTestFields()); err == nil {
+				t.Error("expected an array sort field to be rejected")
+			}
+		})
+	}
+}

--- a/internal/domain/search/path_validate.go
+++ b/internal/domain/search/path_validate.go
@@ -184,6 +184,19 @@ func refreshFieldsMap(ctx context.Context, store spi.ModelStore, ref spi.ModelRe
 	if err != nil {
 		return nil, true, err
 	}
+	// RefreshAndGet repopulates the cache entry, parsed node included, so read
+	// the parse back rather than re-deriving it from the bytes we just caused
+	// to be cached — that reparse is exactly what the cache exists to remove.
+	if p, ok := store.(schemaNodeProvider); ok {
+		node, nerr := p.SchemaNode(ctx, ref)
+		if nerr != nil {
+			return nil, true, nerr
+		}
+		if node == nil {
+			return nil, true, nil
+		}
+		return node.FieldsMap(), true, nil
+	}
 	fm, err := fieldsFromDescriptor(desc)
 	if err != nil {
 		return nil, true, err

--- a/internal/domain/search/path_validate.go
+++ b/internal/domain/search/path_validate.go
@@ -129,6 +129,9 @@ func isPathKnown(p string, fields map[string]schema.FieldDescriptor) bool {
 // the type-directed kernel compares temporal data fields temporally rather than
 // lexically. Returns (nil, nil) when the model has no schema bound; genuine
 // store errors propagate for the caller to surface (fail closed).
+//
+// The returned map may be owned by the model-descriptor cache and shared with
+// every other reader holding the same lease. It is read-only — do not mutate it.
 func LoadFieldsMap(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) (map[string]schema.FieldDescriptor, error) {
 	return loadFieldsMap(ctx, store, ref)
 }

--- a/internal/domain/search/path_validate.go
+++ b/internal/domain/search/path_validate.go
@@ -140,11 +140,33 @@ func LoadFieldsMap(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) 
 // propagate so the caller can log and skip validation rather than
 // mistakenly reject the search.
 func loadFieldsMap(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) (map[string]schema.FieldDescriptor, error) {
+	// Prefer the cached derived parse when the store offers one. Rebuilding it
+	// per call is 80-99% of a criterion evaluation and scales with schema size;
+	// FieldsMap() off an already-parsed node is effectively free. Stores that
+	// do not implement the interface (tests, plain in-memory stores) keep the
+	// original behaviour.
+	if p, ok := store.(schemaNodeProvider); ok {
+		node, err := p.SchemaNode(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		if node == nil {
+			return nil, nil
+		}
+		return node.FieldsMap(), nil
+	}
 	desc, err := store.Get(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 	return fieldsFromDescriptor(desc)
+}
+
+// schemaNodeProvider is the optional capability a caching model store exposes to
+// hand back the schema it has already parsed, instead of the bytes to parse
+// again. Same optional-interface shape as the RefreshAndGet probe below.
+type schemaNodeProvider interface {
+	SchemaNode(context.Context, spi.ModelRef) (*schema.ModelNode, error)
 }
 
 // refreshFieldsMap forces a cache refresh via RefreshAndGet (when the

--- a/internal/domain/search/schema_node_reuse_test.go
+++ b/internal/domain/search/schema_node_reuse_test.go
@@ -1,0 +1,123 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+)
+
+// countingSchemaStore implements the optional SchemaNode capability and counts
+// both routes, so a test can tell which one loadFieldsMap took.
+type countingSchemaStore struct {
+	spi.ModelStore
+	node      *schema.ModelNode
+	nodeErr   error
+	nodeCalls int
+	getCalls  int
+	desc      *spi.ModelDescriptor
+}
+
+func (s *countingSchemaStore) SchemaNode(context.Context, spi.ModelRef) (*schema.ModelNode, error) {
+	s.nodeCalls++
+	return s.node, s.nodeErr
+}
+
+func (s *countingSchemaStore) Get(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	s.getCalls++
+	return s.desc, nil
+}
+
+func testNode(t *testing.T) *schema.ModelNode {
+	t.Helper()
+	root := schema.NewObjectNode()
+	root.SetChild("amount", schema.NewLeafNode(schema.Integer))
+	return root
+}
+
+// The whole point of caching the parsed schema is lost if loadFieldsMap keeps
+// asking for the raw descriptor and re-parsing it. Pin the route.
+func TestLoadFieldsMap_UsesCachedParseWhenOffered(t *testing.T) {
+	store := &countingSchemaStore{node: testNode(t)}
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	for i := 0; i < 5; i++ {
+		fm, err := loadFieldsMap(context.Background(), store, ref)
+		if err != nil {
+			t.Fatalf("loadFieldsMap: %v", err)
+		}
+		if _, ok := fm["$.amount"]; !ok {
+			t.Fatalf("expected $.amount in fields map, got %v", fm)
+		}
+	}
+	if store.getCalls != 0 {
+		t.Errorf("loadFieldsMap fetched the raw descriptor %d times; it should use the cached parse", store.getCalls)
+	}
+	if store.nodeCalls != 5 {
+		t.Errorf("expected 5 SchemaNode calls, got %d", store.nodeCalls)
+	}
+}
+
+// A store with no schema bound yields no type constraints, not an error —
+// unchanged from the descriptor-parsing behaviour this replaced.
+func TestLoadFieldsMap_NilNodeIsNotAnError(t *testing.T) {
+	store := &countingSchemaStore{node: nil}
+	fm, err := loadFieldsMap(context.Background(), store, spi.ModelRef{EntityName: "Order", ModelVersion: "1"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if fm != nil {
+		t.Errorf("expected a nil fields map, got %v", fm)
+	}
+}
+
+// loadModelNode takes the same route.
+func TestLoadModelNode_UsesCachedParseWhenOffered(t *testing.T) {
+	store := &countingSchemaStore{node: testNode(t)}
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	node := loadModelNode(context.Background(), store, ref)
+	if node == nil {
+		t.Fatal("expected a node")
+	}
+	if store.getCalls != 0 {
+		t.Errorf("loadModelNode fetched the raw descriptor %d times", store.getCalls)
+	}
+}
+
+// A store without the capability keeps the original descriptor-parsing path,
+// so nothing that supplies a plain ModelStore changes behaviour.
+func TestLoadFieldsMap_FallsBackWhenCapabilityAbsent(t *testing.T) {
+	root := testNode(t)
+	raw, err := schema.Marshal(root)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	plain := &plainModelStore{desc: &spi.ModelDescriptor{
+		Ref:    spi.ModelRef{EntityName: "Order", ModelVersion: "1"},
+		State:  spi.ModelLocked,
+		Schema: raw,
+	}}
+	fm, err := loadFieldsMap(context.Background(), plain, spi.ModelRef{EntityName: "Order", ModelVersion: "1"})
+	if err != nil {
+		t.Fatalf("loadFieldsMap: %v", err)
+	}
+	if _, ok := fm["$.amount"]; !ok {
+		t.Fatalf("expected $.amount, got %v", fm)
+	}
+	if plain.getCalls != 1 {
+		t.Errorf("expected exactly 1 descriptor fetch on the fallback path, got %d", plain.getCalls)
+	}
+}
+
+type plainModelStore struct {
+	spi.ModelStore
+	desc     *spi.ModelDescriptor
+	getCalls int
+}
+
+func (s *plainModelStore) Get(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	s.getCalls++
+	return s.desc, nil
+}

--- a/internal/e2e/workflow_criterion_path_key_test.go
+++ b/internal/e2e/workflow_criterion_path_key_test.go
@@ -1,0 +1,95 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Workflow-criterion field-path coverage.
+//
+// A criterion's jsonPath may legitimately be written without the "$." prefix —
+// nothing rejects it, at import or at evaluation. But the declared-type lookup
+// indexes a FieldsMap whose keys always carry the prefix, so a prefix-less path
+// resolved to no declared type. The kernel is type-directed: a comparison leaf
+// with no declared type expands into nothing and never matches.
+//
+// Workflow criteria always evaluate through internal/match and never through
+// the pushdown translator, so this arm was strictly worse than the search one —
+// not an empty result page, but a transition that silently never fired for any
+// entity. This is the e2e proof through the full HTTP stack.
+// ---------------------------------------------------------------------------
+
+// dataCriterionWorkflow builds a workflow whose CREATED state has one automated
+// transition to ADVANCED, gated by a SimpleCondition comparing a data field.
+// NONE -> CREATED is unconditioned and automated, so creating an entity
+// cascades through CREATED and evaluates the guarded transition in the same
+// request. jsonPath is supplied verbatim so a test can vary the spelling.
+func dataCriterionWorkflow(t *testing.T, wfName, jsonPath string) string {
+	t.Helper()
+	criterion, err := json.Marshal(map[string]any{
+		"type":         "simple",
+		"jsonPath":     jsonPath,
+		"operatorType": "GREATER_THAN",
+		"value":        50,
+	})
+	if err != nil {
+		t.Fatalf("marshal simple criterion: %v", err)
+	}
+	return fmt.Sprintf(`{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": %q, "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "advance", "next": "ADVANCED", "manual": false,
+					"criterion": %s}]},
+				"ADVANCED": {}
+			}
+		}]
+	}`, wfName, string(criterion))
+}
+
+// TestCriterionPathKey_PrefixlessPathFiresTransition is the regression guard.
+// The criterion names "amount" rather than "$.amount"; the entity's amount is
+// 100, comfortably over the threshold, so the transition must fire. Before the
+// fix the leaf resolved to no declared type, evaluated false, and the entity
+// stayed at CREATED — for every entity, forever, with no error anywhere.
+func TestCriterionPathKey_PrefixlessPathFiresTransition(t *testing.T) {
+	const model = "e2e-crit-path-prefixless"
+
+	setupModelWithWorkflow(t, model, dataCriterionWorkflow(t, "crit-path-prefixless-wf", "amount"))
+	entityID := createEntityE2E(t, model, 1, `{"name":"X","amount":100}`)
+
+	if state := getEntityState(t, entityID); state != "ADVANCED" {
+		t.Errorf("criterion on prefix-less path \"amount\" with amount=100 > 50: expected ADVANCED, got %q — the leaf resolved to no declared type and evaluated false", state)
+	}
+}
+
+// The prefixed spelling must behave identically — it always worked, and is the
+// control proving the test above measures the spelling and not something else.
+func TestCriterionPathKey_PrefixedPathFiresTransition(t *testing.T) {
+	const model = "e2e-crit-path-prefixed"
+
+	setupModelWithWorkflow(t, model, dataCriterionWorkflow(t, "crit-path-prefixed-wf", "$.amount"))
+	entityID := createEntityE2E(t, model, 1, `{"name":"X","amount":100}`)
+
+	if state := getEntityState(t, entityID); state != "ADVANCED" {
+		t.Errorf("criterion on \"$.amount\" with amount=100 > 50: expected ADVANCED, got %q", state)
+	}
+}
+
+// And the criterion must still be able to evaluate FALSE on a prefix-less path.
+// Without this, a fix that made every prefix-less leaf match unconditionally
+// would pass the guard above.
+func TestCriterionPathKey_PrefixlessPathDoesNotFireBelowThreshold(t *testing.T) {
+	const model = "e2e-crit-path-prefixless-false"
+
+	setupModelWithWorkflow(t, model, dataCriterionWorkflow(t, "crit-path-prefixless-false-wf", "amount"))
+	entityID := createEntityE2E(t, model, 1, `{"name":"X","amount":10}`)
+
+	if state := getEntityState(t, entityID); state != "CREATED" {
+		t.Errorf("criterion on prefix-less path with amount=10 < 50: expected CREATED (criterion false, transition does not fire), got %q", state)
+	}
+}

--- a/internal/match/field_path_key_test.go
+++ b/internal/match/field_path_key_test.go
@@ -1,0 +1,78 @@
+package match
+
+import (
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+)
+
+// Every caller resolves declared types out of a FieldsMap whose keys carry the
+// "$." prefix — the workflow engine (engine.go), the search fallback loop
+// (search/service.go) and the grouped-stats residual all index that same map.
+//
+// matchSimple looked the path up raw, so a criterion or condition written
+// without the prefix resolved to no declared type. A type-directed comparison
+// with no declared type expands into nothing and never matches, so the leaf
+// evaluated false for every entity. matchArray already normalised via
+// arrayElementFieldPath; matchSimple did not.
+//
+// This is the same defect fixed in filter_translate.go, on the path workflow
+// criteria actually take: criteria always go through match.Match and never
+// through ConditionToFilter.
+func prefixedTypes(t *testing.T) FieldTypes {
+	t.Helper()
+	fields := map[string][]spi.DataType{
+		"$.amount": {spi.Integer},
+		"$.city":   {spi.String},
+	}
+	return func(p string) []spi.DataType { return fields[p] }
+}
+
+func TestMatchSimple_ResolvesDeclaredTypesForPrefixlessPath(t *testing.T) {
+	data := []byte(`{"amount":42,"city":"Berlin"}`)
+
+	cases := []struct {
+		name     string
+		jsonPath string
+		op       string
+		value    any
+	}{
+		{"prefixed numeric", "$.amount", "GREATER_THAN", 10},
+		{"prefixless numeric", "amount", "GREATER_THAN", 10},
+		{"prefixed string", "$.city", "EQUALS", "Berlin"},
+		{"prefixless string", "city", "EQUALS", "Berlin"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Match(&predicate.SimpleCondition{
+				JsonPath:     tc.jsonPath,
+				OperatorType: tc.op,
+				Value:        tc.value,
+			}, data, spi.EntityMeta{}, prefixedTypes(t))
+			if err != nil {
+				t.Fatalf("Match: %v", err)
+			}
+			if !got {
+				t.Errorf("%s did not match an entity that holds the value — declared types did not resolve", tc.jsonPath)
+			}
+		})
+	}
+}
+
+// A genuinely unknown path must still resolve to no declared types, so a
+// comparison leaf keeps degrading to non-match rather than erroring.
+func TestMatchSimple_UnknownPathStillDegradesToNonMatch(t *testing.T) {
+	got, err := Match(&predicate.SimpleCondition{
+		JsonPath:     "$.nosuch",
+		OperatorType: "GREATER_THAN",
+		Value:        10,
+	}, []byte(`{"amount":42}`), spi.EntityMeta{}, prefixedTypes(t))
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	if got {
+		t.Error("an unknown path matched")
+	}
+}

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -77,6 +77,21 @@ func convertJSONPath(jsonPath string) string {
 // ArrayCondition's element type. ArrayCondition names a container path
 // ("$.tags"); the model records the element type under the same path with a
 // trailing "[*]" ("$.tags[*]"), mirroring search.arrayElementPath so the
+// fieldMapKey normalises a condition's jsonPath to the form every caller's
+// FieldsMap is keyed by: "$."-prefixed. A prefix-less path is accepted
+// everywhere else in the stack, so looking it up raw silently resolves to no
+// declared type — and a type-directed comparison with no declared type expands
+// into nothing and never matches, making the leaf false for every entity.
+// arrayElementFieldPath already did this for array conditions; simple leaves
+// went without.
+func fieldMapKey(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" || strings.HasPrefix(p, "$") {
+		return p
+	}
+	return "$." + p
+}
+
 // predicate evaluator and the search pushdown stamp the same declared types on
 // positional array leaves.
 func arrayElementFieldPath(raw string) string {
@@ -99,7 +114,7 @@ func matchSimple(c *predicate.SimpleCondition, data []byte, fieldTypes FieldType
 
 	var declared []spi.DataType
 	if fieldTypes != nil {
-		declared = fieldTypes(c.JsonPath)
+		declared = fieldTypes(fieldMapKey(c.JsonPath))
 	}
 
 	// If the path produced an array result (from # wildcard), check if ANY

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -73,16 +73,12 @@ func convertJSONPath(jsonPath string) string {
 	return path
 }
 
-// arrayElementFieldPath returns the FieldsMap key that addresses an
-// ArrayCondition's element type. ArrayCondition names a container path
-// ("$.tags"); the model records the element type under the same path with a
-// trailing "[*]" ("$.tags[*]"), mirroring search.arrayElementPath so the
 // fieldMapKey normalises a condition's jsonPath to the form every caller's
 // FieldsMap is keyed by: "$."-prefixed. A prefix-less path is accepted
 // everywhere else in the stack, so looking it up raw silently resolves to no
 // declared type — and a type-directed comparison with no declared type expands
 // into nothing and never matches, making the leaf false for every entity.
-// arrayElementFieldPath already did this for array conditions; simple leaves
+// arrayElementFieldPath already normalised for array conditions; simple leaves
 // went without.
 func fieldMapKey(raw string) string {
 	p := strings.TrimSpace(raw)
@@ -92,6 +88,10 @@ func fieldMapKey(raw string) string {
 	return "$." + p
 }
 
+// arrayElementFieldPath returns the FieldsMap key that addresses an
+// ArrayCondition's element type. ArrayCondition names a container path
+// ("$.tags"); the model records the element type under the same path with a
+// trailing "[*]" ("$.tags[*]"), mirroring search.arrayElementPath so the
 // predicate evaluator and the search pushdown stamp the same declared types on
 // positional array leaves.
 func arrayElementFieldPath(raw string) string {

--- a/plugins/postgres/grouped_stats.go
+++ b/plugins/postgres/grouped_stats.go
@@ -439,8 +439,10 @@ func aggregateExprToSQL(a spi.AggregateExpr) (string, error) {
 // else, since memory and sqlite hold domain data and meta apart. Meta stays
 // reachable through Source: SourceMeta, which reads entity.Meta. The domain
 // bytes are unaffected: unmarshalEntityDoc decodes into json.RawMessage values
-// and re-marshals them verbatim, so only key order can differ, which no path
-// lookup observes.
+// and re-emits them verbatim, so numbers survive byte-for-byte and strings stay
+// semantically identical. Only document-level framing differs — key order,
+// whitespace, and HTML escaping of < > & U+2028 U+2029 inside string literals —
+// none of which a path lookup or the kernel's stored.String() observes.
 func evalPostFilter(f spi.Filter, entity *spi.Entity) (bool, error) {
 	return spi.MatchFilter(f, entity.Data, entity.Meta), nil
 }

--- a/plugins/postgres/grouped_stats.go
+++ b/plugins/postgres/grouped_stats.go
@@ -169,7 +169,7 @@ func (it *postgresIter) Next() bool {
 			return false
 		}
 		if it.postFilter != nil {
-			ok, ferr := evalPostFilter(*it.postFilter, e, doc)
+			ok, ferr := evalPostFilter(*it.postFilter, e)
 			if ferr != nil {
 				it.err = fmt.Errorf("post-filter evaluation: %w", ferr)
 				return false
@@ -432,6 +432,15 @@ func aggregateExprToSQL(a spi.AggregateExpr) (string, error) {
 // entity in Go. Delegates to spi.MatchFilter, the canonical cross-backend
 // evaluator that sqlite's post-filter and the memory plugin also use — see
 // that function's doc for why the two must never diverge.
-func evalPostFilter(f spi.Filter, entity *spi.Entity, doc []byte) (bool, error) {
-	return spi.MatchFilter(f, doc, entity.Meta), nil
+//
+// It is given entity.Data, not the raw JSONB document. The stored document
+// carries a "_meta" block this plugin merges in (marshalEntityDoc); passing it
+// would make storage-layer meta a matchable SourceData path here and nowhere
+// else, since memory and sqlite hold domain data and meta apart. Meta stays
+// reachable through Source: SourceMeta, which reads entity.Meta. The domain
+// bytes are unaffected: unmarshalEntityDoc decodes into json.RawMessage values
+// and re-marshals them verbatim, so only key order can differ, which no path
+// lookup observes.
+func evalPostFilter(f spi.Filter, entity *spi.Entity) (bool, error) {
+	return spi.MatchFilter(f, entity.Data, entity.Meta), nil
 }

--- a/plugins/postgres/post_filter_meta_test.go
+++ b/plugins/postgres/post_filter_meta_test.go
@@ -1,0 +1,106 @@
+package postgres
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/google/uuid"
+)
+
+// The residual evaluator must see the same document every other backend's
+// evaluator sees: the entity's domain data, without the storage-layer _meta
+// block postgres merges into its JSONB column.
+//
+// memory and sqlite pass entity.Data, which has no _meta key at all, so a
+// condition naming a data path under _meta cannot match there. Postgres must
+// agree — a matchable path on one backend and not another is a divergence,
+// and it exposes storage-layer internals as a queryable surface.
+//
+// Meta fields remain reachable the supported way, through Source: SourceMeta,
+// which reads entity.Meta and is unaffected by this.
+func TestEvalPostFilter_MetaBlockIsNotAMatchableDataPath(t *testing.T) {
+	now := time.Now().UTC()
+	ent := &spi.Entity{
+		Data: json.RawMessage(`{"status":"OPEN"}`),
+		Meta: spi.EntityMeta{
+			ID:               uuid.NewString(),
+			TenantID:         "t1",
+			ModelRef:         spi.ModelRef{EntityName: "Order", ModelVersion: "1"},
+			State:            "active",
+			CreationDate:     now,
+			LastModifiedDate: now,
+		},
+	}
+
+	doc, err := marshalEntityDoc(ent, now, now, now, false)
+	if err != nil {
+		t.Fatalf("marshalEntityDoc: %v", err)
+	}
+	// Precondition: the stored document really does carry _meta.state.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(doc, &probe); err != nil {
+		t.Fatalf("unmarshal doc: %v", err)
+	}
+	if _, ok := probe["_meta"]; !ok {
+		t.Fatal("precondition failed: stored doc has no _meta block")
+	}
+
+	decoded, err := unmarshalEntityDoc(doc)
+	if err != nil {
+		t.Fatalf("unmarshalEntityDoc: %v", err)
+	}
+
+	metaAsData := spi.Filter{
+		Op:       spi.FilterEq,
+		Path:     "_meta.state",
+		Source:   spi.SourceData,
+		Value:    "active",
+		Declared: []spi.DataType{spi.String},
+	}
+
+	got, err := evalPostFilter(metaAsData, decoded)
+	if err != nil {
+		t.Fatalf("evalPostFilter: %v", err)
+	}
+	if got {
+		t.Error("a data-source condition on _meta.state matched: postgres is exposing the storage-layer meta block as a queryable data path, which memory and sqlite do not")
+	}
+
+	// The domain data must still match, so the fix is not simply starving the
+	// evaluator of the document.
+	domain := spi.Filter{
+		Op:       spi.FilterEq,
+		Path:     "status",
+		Source:   spi.SourceData,
+		Value:    "OPEN",
+		Declared: []spi.DataType{spi.String},
+	}
+	ok, err := evalPostFilter(domain, decoded)
+	if err != nil {
+		t.Fatalf("evalPostFilter(domain): %v", err)
+	}
+	if !ok {
+		t.Error("domain data condition failed to match")
+	}
+
+	// And a SourceMeta condition on the same field must still work — that is
+	// the supported way to filter on state.
+	// Declared mirrors what lifecycleToFilter stamps on a non-temporal meta
+	// leaf; without it the comparison expands into no declared type.
+	metaProper := spi.Filter{
+		Op:       spi.FilterEq,
+		Path:     "state",
+		Source:   spi.SourceMeta,
+		Value:    "active",
+		Declared: []spi.DataType{spi.String},
+	}
+	ok, err = evalPostFilter(metaProper, decoded)
+	if err != nil {
+		t.Fatalf("evalPostFilter(meta): %v", err)
+	}
+	if !ok {
+		t.Error("SourceMeta condition on state failed to match")
+	}
+}

--- a/plugins/sqlite/searcher.go
+++ b/plugins/sqlite/searcher.go
@@ -64,7 +64,14 @@ func (s *entityStore) Search(ctx context.Context, filter spi.Filter, opts spi.Se
 // (spi.ErrScanBudgetExhausted) first, regardless of how few matches were
 // found.
 func (s *entityStore) searchCommitted(ctx context.Context, filter spi.Filter, opts spi.SearchOptions) ([]*spi.Entity, error) {
-	plan := planQuery(filter)
+	// Zero-value Filter means "match all". Skip planQuery — it would treat the
+	// empty Op as non-pushable and install the zero filter as a residual, which
+	// costs LIMIT pushdown and arms the scan budget on a query with nothing to
+	// post-filter. Mirrors the guard in the postgres plugin.
+	var plan sqlPlan
+	if filter.Op != "" {
+		plan = planQuery(filter)
+	}
 
 	var baseQuery string
 	var baseArgs []any
@@ -211,7 +218,14 @@ func sortEntitiesByOrder(rows []*spi.Entity, order []spi.OrderSpec) {
 // the sql.DB query — identical to Save/GetAll/getAllTx in this package.
 func (s *entityStore) searchTxOverlay(ctx context.Context, tx *spi.TransactionState, filter spi.Filter, opts spi.SearchOptions) ([]*spi.Entity, error) {
 	modelRef := spi.ModelRef{EntityName: opts.ModelName, ModelVersion: opts.ModelVersion}
-	plan := planQuery(filter)
+	// Zero-value Filter means "match all". Skip planQuery — it would treat the
+	// empty Op as non-pushable and install the zero filter as a residual, which
+	// costs LIMIT pushdown and arms the scan budget on a query with nothing to
+	// post-filter. Mirrors the guard in the postgres plugin.
+	var plan sqlPlan
+	if filter.Op != "" {
+		plan = planQuery(filter)
+	}
 
 	// Committed candidate SQL: snapshot at tx.SnapshotTime, ORDER BY, no LIMIT.
 	baseQuery, baseArgs := s.searchSnapshotBase(opts, timeToMicro(tx.SnapshotTime))

--- a/plugins/sqlite/searcher_zero_filter_test.go
+++ b/plugins/sqlite/searcher_zero_filter_test.go
@@ -1,0 +1,93 @@
+package sqlite_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	sqlite "github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
+
+// A zero-value Filter means "match all". Postgres skips planQuery for it, with
+// a comment saying why: planQuery treats the empty Op as non-pushable and
+// installs the zero filter as a residual. sqlite's Search had no such guard, so
+// the same filter arrived with a residual installed — which loses LIMIT
+// pushdown and arms the scan budget on a query that has nothing to post-filter.
+//
+// The observable consequence is a filter-free search failing with
+// ErrScanBudgetExhausted on a model larger than the budget, where postgres and
+// memory return the rows.
+func TestSearch_ZeroValueFilterDoesNotArmScanBudget(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "zero_filter_test.db")
+	factory, err := sqlite.NewStoreFactoryForTestWithScanLimit(context.Background(), dbPath, 3)
+	if err != nil {
+		t.Fatalf("create factory: %v", err)
+	}
+	defer factory.Close()
+
+	ctx := testCtx("tenant-1")
+	ref := spi.ModelRef{EntityName: "item", ModelVersion: "1"}
+	store, _ := factory.EntityStore(ctx)
+
+	const rows = 5 // comfortably above the scan budget of 3
+	for i := 0; i < rows; i++ {
+		if _, err := store.Save(ctx, &spi.Entity{
+			Meta: spi.EntityMeta{ID: fmt.Sprintf("z%d", i), ModelRef: ref, State: "NEW"},
+			Data: []byte(`{"val":"x"}`),
+		}); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	got, err := store.(spi.Searcher).Search(ctx, spi.Filter{}, spi.SearchOptions{
+		ModelName: "item", ModelVersion: "1", Limit: 10,
+	})
+	if errors.Is(err, spi.ErrScanBudgetExhausted) {
+		t.Fatal("a filter-free search armed the scan budget: the zero filter was installed as a residual")
+	}
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != rows {
+		t.Errorf("got %d rows, want %d", len(got), rows)
+	}
+}
+
+// The explicit empty-AND spelling — what ConditionToFilter emits for a nil
+// condition — already took the other branch. Both spellings of "match
+// everything" must behave the same.
+func TestSearch_EmptyAndFilterDoesNotArmScanBudget(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "empty_and_test.db")
+	factory, err := sqlite.NewStoreFactoryForTestWithScanLimit(context.Background(), dbPath, 3)
+	if err != nil {
+		t.Fatalf("create factory: %v", err)
+	}
+	defer factory.Close()
+
+	ctx := testCtx("tenant-1")
+	ref := spi.ModelRef{EntityName: "item", ModelVersion: "1"}
+	store, _ := factory.EntityStore(ctx)
+
+	const rows = 5
+	for i := 0; i < rows; i++ {
+		if _, err := store.Save(ctx, &spi.Entity{
+			Meta: spi.EntityMeta{ID: fmt.Sprintf("a%d", i), ModelRef: ref, State: "NEW"},
+			Data: []byte(`{"val":"x"}`),
+		}); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	got, err := store.(spi.Searcher).Search(ctx, spi.Filter{Op: spi.FilterAnd}, spi.SearchOptions{
+		ModelName: "item", ModelVersion: "1", Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != rows {
+		t.Errorf("got %d rows, want %d", len(got), rows)
+	}
+}


### PR DESCRIPTION
Five defects in the search-condition path, found while researching cyoda-go-spi#30.
None of them is #30 — that work is unstarted and lives on its own branch. These are
independent, so they ship on their own.

The research that surfaced them is
`docs/superpowers/research/2026-08-07-search-condition-pipeline.md` on the #30 branch,
not included here.

## 1. A field path without the `$.` prefix silently matched nothing

`city` and `$.city` are both accepted, and both pass field-path validation — which
normalises before checking. The declared-type lookup did **not** normalise, so the
unprefixed form missed the schema map and came back with no declared type. The kernel
is type-directed, so a comparison leaf with no declared type expands into nothing and
never matches.

Three arms had it, and they were not equally harmful:

- `simpleToFilter` — `city EQUALS "Berlin"` returned **200 with an empty page** on a
  model whose `$.city` holds `Berlin`. Declared-temporal fields reached this way were
  also stamped `CoerceNone`, so the SQL planners compared them as text.
- `internal/match.matchSimple` — **the worse one.** Workflow criteria always evaluate
  through `match.Match` and never through the translator, so a criterion written
  `{"jsonPath":"amount",…}` evaluated false for **every** entity and the transition
  silently never fired.
- `validateSimpleConditionType` — the type check skipped such a leaf, so
  `amount GREATER_THAN "not-a-number"` was accepted and answered empty where
  `$.amount GREATER_THAN "not-a-number"` returns 400 `CONDITION_TYPE_MISMATCH`.

`matchArray` and `arrayToFilter` already normalised; these were the arms that did not.
An unknown path still resolves to no declared type — the deliberate
degrade-to-non-match is untouched.

## 2. The model schema was re-parsed on every criterion evaluation

Evaluating a criterion against a data field re-read the stored schema, rebuilt the
whole field tree, and re-derived the path→types map. Per transition, and per step of a
cascade.

Measured on an M1 Max, one criterion evaluation:

| model schema | before | after | allocations |
|---|---|---|---|
| 10 fields | 56 µs | 11 µs | 247 → 91 |
| 50 fields | 130 µs | 15 µs | 757 → 91 |
| 200 fields | 322 µs | 19 µs | 2,651 → 91 |
| 1000 fields | 1.84 ms | 12 µs | 12,403 → 91 |

80–99% of the evaluation, scaling with schema size rather than entity or result size.

The descriptor bytes were already cached per process, keyed by tenant and model,
evicted on mutation via gossip and on a jittered lease. Only the derived parse was
missing — `FieldsMap()` memoises on its node, but `Unmarshal` built a fresh node every
call, so that memo never survived.

The parse is now derived once when the entry is built and held there, so it inherits
the entry's eviction: **one thing to invalidate, and no way for a parse to outlive the
bytes it came from.** A second cache with its own expiry was the alternative, and it is
the one that can go stale.

- UNLOCKED descriptors are still not cached, so their parse is not retained either.
- A schema that fails to parse retains its error rather than re-parsing to rediscover it.
- No schema bound stays `(nil, nil)` — no type constraints, not an error.
- Parsing happens outside the write lock, so one model's parse cannot serialise readers
  of another.

Consumers reach it through an optional interface, the same shape as the existing
`RefreshAndGet` probe; a plain `ModelStore` keeps the original path unchanged.

## 3. PostgreSQL exposed its `_meta` block as a matchable data path

Postgres merges storage metadata into the same JSON object as the domain data. The
residual evaluator was handed the un-stripped document, so a `SourceData` condition on
`_meta.*` matched there and on no other backend. It now receives `entity.Data`.

**This does not close the surface.** `leafExact` is true only for `IS_NULL`/`NOT_NULL`,
so exactly those two operators are answered by SQL with no Go re-check, and `fieldExpr`
still resolves a data path against the merged document. The remainder — together with
the fact that postgres **destroys** an entity's own `_meta` field on write — is
#489, whose design is agreed: nest the domain data rather than merging it.

## 4. SQLite treated a zero-value filter as a residual

`planQuery` treats an empty `Op` as non-pushable and installs the zero filter as a
residual, which loses `LIMIT` pushdown and arms the scan budget. Postgres guards against
this with a comment saying exactly why; sqlite's `Search` did not.

No cyoda-go route reaches it — every route spells "match everything" as an empty `AND`,
which already worked — so this is storage-contract conformance rather than a user-visible
fix. It matters to anything driving the storage interface directly.

## 5. A refresh threw away the parse it had just cached

`refreshFieldsMap` called `RefreshAndGet`, which repopulates the entry including the
parsed node, then re-derived the map from the bytes. Reads the parse back instead.

## Testing

Every fix is test-first, with the test watched failing against the unfixed code. New
tests pin: parse-once-per-cache-entry, dropped on invalidation, dropped on lease expiry,
not retained for unlocked models, stable error for an unparseable schema, that the
search code actually takes the cached route, both prefixed and unprefixed paths
resolving, unknown paths still degrading, `_meta` unmatchable as a data path while
domain data and `SourceMeta` still match, and both spellings of match-all behaving alike
on sqlite.

Root module and all three plugin submodules green; `go vet` clean; `make race` clean.

## Known gaps, stated rather than hidden

- **No `e2e/parity` scenarios.** All five are backend-agnostic behaviour changes and
  `.claude/rules/test-coverage.md` asks for cross-backend scenarios. A parity test on
  `_meta` would likely have caught the `IS_NULL`/`NOT_NULL` remainder in (3) before
  review did. Worth adding before merge if you want the gate held strictly.
- `cmd/cyoda/help/content/errors/INVALID_FIELD_PATH.md:24` states that `$._meta.*`
  paths bypass path validation. That was already wrong, and (3) makes it misleading.
  Folded into #489 rather than corrected here, since #489 removes the form entirely.

Gate 7: none of these is a contract change — all five are conformance to the existing
contract, so no `docs/cloud-parity/` entry.


---

## After review — what changed, and what is still open

Code review and a security audit both ran against this branch. Security: **tenant
isolation, injection, DoS and cache staleness all clean**; the two disclosure findings
are pre-existing arms of the same defect, tracked in #489.

Fixed in `0960fd1`:

- **The type-soundness arm had no test at all.** The reviewer reverted the hunk and the
  suite stayed green. That arm changes a status code, so shipping it unpinned was a
  Gate 1 violation and contradicted this PR's own TDD claim. Now covered and confirmed
  RED against the unfixed code.
- **Order-by resolution had the same raw-path defect**, and it made the transports
  disagree: `fields["$."+k.Path]` is a non-idempotent prepend, HTTP strips the prefix
  first and gRPC does not, so a gRPC client sorting by `$.city` got a 400 for a field
  that exists. Both the lookup and the emitted path now normalise.
- Comment and doc repairs: a godoc comment my insertion had split in two, an
  over-narrow equivalence claim, an undocumented shared-map return, and a help topic
  advertising `$._meta.*` as a valid path form.

**Still open, deliberately:**

- ~~No e2e or parity coverage.~~ **Added.** Scoping the PR down was the wrong reason to
  skip them — tests for the fixes already here are the PR being finished, not an
  expansion of it. Three cross-backend scenarios (both path spellings select the same
  entity; both return 400 `CONDITION_TYPE_MISMATCH`; `_meta` is not addressable as
  entity data) plus three e2e cases on the workflow-criterion arm.

  The `_meta` scenario took three attempts and the first two were worthless — found
  only by reverting the fix and watching the test still pass. Probing through `/search`
  proves nothing (path validation rejects `_meta.state` with a 400 before any evaluator
  runs); probing with `EQUALS` proves nothing either (`_meta.state` has no declared
  type, and the type-directed kernel makes any comparison without one a non-match
  whichever document it was handed). It needs a string operator through grouped stats.
  Both dead ends are recorded in the file.
- ~~cyoda-go-spi HEAD carries the identical raw-path bug.~~ **Withdrawn — the claim was
  wrong, and so was the alarm attached to it.** cyoda-go has zero references to the SPI's
  translator, so a version bump could never have reverted anything; only a deliberate
  migration could, and this PR's own parity tests would have caught that. The underlying
  problem was that cyoda-go-spi#29 copied a 500-line translator into the library for a
  consumer that does not exist, immediately diverged from the original, and shipped a test
  asserting the divergence was deliberate. That commit is now reverted
  (cyoda-go-spi `d4692f2`); nothing depended on it, it was never tagged. The relocation's
  goal stands and should be done as a *move* when a real consumer exists.

- **#491** — an explicit empty OR returns every entity on the SQL backends and none on
  memory, found while verifying the zero-filter guard here. Same family, one line per
  plugin; filed rather than folded in for the scope reason above.


