### PR TITLE
fix(search): keep empty groups out of the SQL pushdown so the kernel applies the group identities

### DIFF
--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 229 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 230 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -136,6 +136,11 @@ var allTests = []NamedTest{
 	{"SearchMetaBlockNotMatchableAsDataPath", RunSearchMetaBlockNotMatchableAsDataPath},
 	{"SearchStringMetaVocabulary", RunSearchStringMetaVocabulary},
 	{"SearchBetweenArity400", RunSearchBetweenArity400},
+	// Group-identity contract: an explicit empty AND matches everything, an
+	// explicit empty OR matches nothing — standalone and nested. The SQL
+	// planners previously pushed a childless OR as an empty WHERE fragment,
+	// flipping "match nothing" into "match everything".
+	{"SearchEmptyGroupIdentities", RunSearchEmptyGroupIdentities},
 	// Type-directed contract: a scalar comparison on a PURE-container path (a
 	// known structural interior with substructure but no scalar observation)
 	// is rejected with HTTP 400 INVALID_FIELD_PATH uniformly across backends —

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 229
+const wantParityScenarioCount = 230
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/e2e/parity/search_empty_group.go
+++ b/e2e/parity/search_empty_group.go
@@ -1,0 +1,75 @@
+package parity
+
+import (
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// RunSearchEmptyGroupIdentities asserts the group-identity contract for
+// explicit empty group conditions, uniformly across backends: an empty AND is
+// the AND identity (true, matches everything) and an empty OR is the OR
+// identity (false, matches nothing) — both standalone and nested inside a
+// parent group. The SQL backends previously pushed a childless OR down as an
+// empty WHERE fragment, turning "match nothing" into "match everything" (and,
+// nested, into malformed SQL); the kernel is authoritative for these shapes.
+func RunSearchEmptyGroupIdentities(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "parity-search-empty-group"
+	const modelVersion = 1
+	setupSearchModel(t, c, modelName, modelVersion)
+
+	for _, payload := range []string{
+		`{"name":"Alice","amount":100,"status":"active"}`,
+		`{"name":"Bob","amount":50,"status":"active"}`,
+		`{"name":"Carol","amount":200,"status":"inactive"}`,
+	} {
+		if _, err := c.CreateEntity(t, modelName, modelVersion, payload); err != nil {
+			t.Fatalf("CreateEntity %s: %v", payload, err)
+		}
+	}
+
+	cases := []struct {
+		name string
+		cond string
+		want int
+	}{
+		{
+			name: "empty OR matches nothing",
+			cond: `{"type":"group","operator":"OR","conditions":[]}`,
+			want: 0,
+		},
+		{
+			name: "empty AND matches everything",
+			cond: `{"type":"group","operator":"AND","conditions":[]}`,
+			want: 3,
+		},
+		{
+			name: "empty OR nested in AND makes the conjunction false",
+			cond: `{"type":"group","operator":"AND","conditions":[` +
+				`{"type":"simple","jsonPath":"$.status","operatorType":"EQUALS","value":"active"},` +
+				`{"type":"group","operator":"OR","conditions":[]}]}`,
+			want: 0,
+		},
+		{
+			name: "empty AND nested in OR makes the disjunction true",
+			cond: `{"type":"group","operator":"OR","conditions":[` +
+				`{"type":"simple","jsonPath":"$.status","operatorType":"EQUALS","value":"no-such-status"},` +
+				`{"type":"group","operator":"AND","conditions":[]}]}`,
+			want: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		results, err := c.SyncSearch(t, modelName, modelVersion, tc.cond)
+		if err != nil {
+			t.Errorf("%s: SyncSearch: %v", tc.name, err)
+			continue
+		}
+		if len(results) != tc.want {
+			t.Errorf("%s: got %d results, want %d", tc.name, len(results), tc.want)
+		}
+	}
+}

--- a/plugins/postgres/query_planner.go
+++ b/plugins/postgres/query_planner.go
@@ -59,6 +59,13 @@ func leafExact(op spi.FilterOp) bool {
 func allPushedExact(f spi.Filter) bool {
 	switch f.Op {
 	case spi.FilterAnd, spi.FilterOr:
+		// An empty group is never EXACT: exactness is a claim about leaves and
+		// an empty group has none — its identity semantics (empty AND = true,
+		// empty OR = false) are the kernel's to apply. Unreachable by
+		// construction (dissect never pushes an empty group); fails safe.
+		if len(f.Children) == 0 {
+			return false
+		}
 		for _, c := range f.Children {
 			if !allPushedExact(c) {
 				return false
@@ -161,6 +168,14 @@ func dissectAnd(f spi.Filter) (*spi.Filter, *spi.Filter) {
 // dissectOr implements conservative OR dissection: only push if ALL children
 // are fully pushable, otherwise the entire OR is residual.
 func dissectOr(f spi.Filter) (*spi.Filter, *spi.Filter) {
+	// An explicit empty OR is the OR identity (false, matches nothing) — a
+	// shape SQL cannot express: joining zero fragments yields no predicate at
+	// all (i.e. TRUE, matches everything). Route it to the residual so the
+	// kernel applies the identity. Note the asymmetry with the empty AND,
+	// whose identity (true) IS what dissectAnd's (nil, nil) means.
+	if len(f.Children) == 0 {
+		return nil, &f
+	}
 	for _, child := range f.Children {
 		if !isFullyPushable(child) {
 			return nil, &f
@@ -173,6 +188,13 @@ func dissectOr(f spi.Filter) (*spi.Filter, *spi.Filter) {
 func isFullyPushable(f spi.Filter) bool {
 	switch f.Op {
 	case spi.FilterAnd, spi.FilterOr:
+		// Empty groups are identity shapes (empty AND = true, empty OR =
+		// false) that toSQL cannot express — joinChildren over zero children
+		// emits "" standalone and a malformed "()" nested. Never pushable;
+		// the enclosing OR goes residual and the kernel applies the identity.
+		if len(f.Children) == 0 {
+			return false
+		}
 		for _, c := range f.Children {
 			if !isFullyPushable(c) {
 				return false

--- a/plugins/postgres/query_planner.go
+++ b/plugins/postgres/query_planner.go
@@ -169,8 +169,8 @@ func dissectAnd(f spi.Filter) (*spi.Filter, *spi.Filter) {
 // are fully pushable, otherwise the entire OR is residual.
 func dissectOr(f spi.Filter) (*spi.Filter, *spi.Filter) {
 	// An explicit empty OR is the OR identity (false, matches nothing) — a
-	// shape SQL cannot express: joining zero fragments yields no predicate at
-	// all (i.e. TRUE, matches everything). Route it to the residual so the
+	// shape toSQL cannot express: joining zero fragments yields no predicate
+	// at all (i.e. TRUE, matches everything). Route it to the residual so the
 	// kernel applies the identity. Note the asymmetry with the empty AND,
 	// whose identity (true) IS what dissectAnd's (nil, nil) means.
 	if len(f.Children) == 0 {
@@ -281,7 +281,10 @@ func isPushable(op spi.FilterOp) bool {
 }
 
 // toSQL recursively converts a (fully pushable) filter tree to a SQL WHERE
-// fragment and bound arguments. argCounter is a monotonically increasing
+// fragment and bound arguments. The tree must contain no empty groups —
+// joining zero fragments renders "" standalone and a malformed "()" nested;
+// dissect guarantees none reach here (empty groups are identity shapes the
+// kernel owns). argCounter is a monotonically increasing
 // placeholder index used to generate $1, $2, ... — it MUST be shared across
 // the whole tree so each leaf gets a unique placeholder number.
 func toSQL(f spi.Filter, argCounter *int) (string, []any) {

--- a/plugins/postgres/query_planner_empty_group_test.go
+++ b/plugins/postgres/query_planner_empty_group_test.go
@@ -1,0 +1,104 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// The SPI filter contract (spi.MatchFilter): an explicit empty AND is the AND
+// identity (true, matches everything); an explicit empty OR is the OR identity
+// (false, matches nothing). SQL cannot express either shape — joining zero
+// fragments yields no predicate at all (i.e. TRUE) at the top level and a
+// malformed "()" when nested — so the planner must keep empty groups out of
+// the pushed SQL and let the kernel apply the identity.
+
+// An explicit empty OR must fall to the residual so the kernel applies the OR
+// identity (false). Pushing it emits no WHERE clause and no post-filter — a
+// query that must match nothing silently matching everything.
+func TestPlanQuery_EmptyOR(t *testing.T) {
+	f := spi.Filter{Op: spi.FilterOr}
+	plan := planQuery(f)
+	if plan.where != "" {
+		t.Errorf("where should be empty for an empty OR, got %s", plan.where)
+	}
+	if plan.postFilter == nil {
+		t.Fatal("postFilter should be the empty-OR residual (kernel applies the OR identity: match nothing); nil means match-all")
+	}
+	if plan.postFilter.Op != spi.FilterOr {
+		t.Errorf("postFilter.Op = %s, want or", plan.postFilter.Op)
+	}
+}
+
+// An explicit empty AND is the AND identity (true): match-all is correctly
+// expressed as no WHERE clause and no residual. Pins existing behavior.
+func TestPlanQuery_EmptyAND(t *testing.T) {
+	f := spi.Filter{Op: spi.FilterAnd}
+	plan := planQuery(f)
+	if plan.where != "" {
+		t.Errorf("where should be empty for an empty AND, got %s", plan.where)
+	}
+	if plan.postFilter != nil {
+		t.Errorf("postFilter should be nil for an empty AND (identity: match all), got %+v", plan.postFilter)
+	}
+}
+
+// An empty OR nested under AND must not reach the pushed SQL (joinChildren
+// over zero children nests as malformed "()"); it falls to the residual,
+// forcing the full-filter kernel re-check. The IsNull sibling is chosen
+// because it is EXACT — without the fix the plan is certified exact and no
+// re-check happens at all.
+func TestPlanQuery_EmptyORNestedInAND(t *testing.T) {
+	f := spi.Filter{
+		Op: spi.FilterAnd,
+		Children: []spi.Filter{
+			{Op: spi.FilterIsNull, Path: "status", Source: spi.SourceData},
+			{Op: spi.FilterOr},
+		},
+	}
+	plan := planQuery(f)
+	if strings.Contains(plan.where, "()") {
+		t.Errorf("where contains malformed empty group: %s", plan.where)
+	}
+	if plan.postFilter == nil {
+		t.Fatal("postFilter should be the full AND filter (empty-OR child makes the whole conjunction false; only the kernel applies that)")
+	}
+	if plan.postFilter.Op != spi.FilterAnd {
+		t.Errorf("postFilter.Op = %s, want and (full filter)", plan.postFilter.Op)
+	}
+}
+
+// An empty AND nested under OR is the identity true — the whole OR matches
+// everything. SQL cannot express the empty group ("()" is malformed), so the
+// entire OR goes residual (conservative OR dissection) and the kernel
+// evaluates it.
+func TestPlanQuery_EmptyANDNestedInOR(t *testing.T) {
+	f := spi.Filter{
+		Op: spi.FilterOr,
+		Children: []spi.Filter{
+			{Op: spi.FilterIsNull, Path: "status", Source: spi.SourceData},
+			{Op: spi.FilterAnd},
+		},
+	}
+	plan := planQuery(f)
+	if plan.where != "" {
+		t.Errorf("where should be empty (whole OR residual), got %s", plan.where)
+	}
+	if plan.postFilter == nil || plan.postFilter.Op != spi.FilterOr {
+		t.Fatalf("postFilter should be the whole OR residual, got %+v", plan.postFilter)
+	}
+}
+
+// allPushedExact must never certify an empty group as EXACT: exactness of a
+// group is a claim about its leaves, and an empty group has none — its
+// identity semantics are the kernel's to apply, so a vacuous true here would
+// skip the kernel re-check.
+func TestAllPushedExact_EmptyGroupNotExact(t *testing.T) {
+	if allPushedExact(spi.Filter{Op: spi.FilterOr}) {
+		t.Error("allPushedExact(empty OR) = true, want false")
+	}
+	if allPushedExact(spi.Filter{Op: spi.FilterAnd}) {
+		t.Error("allPushedExact(empty AND) = true, want false")
+	}
+}

--- a/plugins/sqlite/query_planner.go
+++ b/plugins/sqlite/query_planner.go
@@ -54,6 +54,13 @@ func leafExact(op spi.FilterOp) bool {
 func allPushedExact(f spi.Filter) bool {
 	switch f.Op {
 	case spi.FilterAnd, spi.FilterOr:
+		// An empty group is never EXACT: exactness is a claim about leaves and
+		// an empty group has none — its identity semantics (empty AND = true,
+		// empty OR = false) are the kernel's to apply. Unreachable by
+		// construction (dissect never pushes an empty group); fails safe.
+		if len(f.Children) == 0 {
+			return false
+		}
 		for _, c := range f.Children {
 			if !allPushedExact(c) {
 				return false
@@ -154,6 +161,14 @@ func dissectAnd(f spi.Filter) (*spi.Filter, *spi.Filter) {
 // dissectOr implements conservative OR dissection: only push if ALL children
 // are fully pushable, otherwise the entire OR is residual.
 func dissectOr(f spi.Filter) (*spi.Filter, *spi.Filter) {
+	// An explicit empty OR is the OR identity (false, matches nothing) — a
+	// shape SQL cannot express: joining zero fragments yields no predicate at
+	// all (i.e. TRUE, matches everything). Route it to the residual so the
+	// kernel applies the identity. Note the asymmetry with the empty AND,
+	// whose identity (true) IS what dissectAnd's (nil, nil) means.
+	if len(f.Children) == 0 {
+		return nil, &f
+	}
 	for _, child := range f.Children {
 		if !isFullyPushable(child) {
 			return nil, &f
@@ -166,6 +181,13 @@ func dissectOr(f spi.Filter) (*spi.Filter, *spi.Filter) {
 func isFullyPushable(f spi.Filter) bool {
 	switch f.Op {
 	case spi.FilterAnd, spi.FilterOr:
+		// Empty groups are identity shapes (empty AND = true, empty OR =
+		// false) that toSQL cannot express — joinChildren over zero children
+		// emits "" standalone and a malformed "()" nested. Never pushable;
+		// the enclosing OR goes residual and the kernel applies the identity.
+		if len(f.Children) == 0 {
+			return false
+		}
 		for _, c := range f.Children {
 			if !isFullyPushable(c) {
 				return false

--- a/plugins/sqlite/query_planner.go
+++ b/plugins/sqlite/query_planner.go
@@ -162,8 +162,8 @@ func dissectAnd(f spi.Filter) (*spi.Filter, *spi.Filter) {
 // are fully pushable, otherwise the entire OR is residual.
 func dissectOr(f spi.Filter) (*spi.Filter, *spi.Filter) {
 	// An explicit empty OR is the OR identity (false, matches nothing) — a
-	// shape SQL cannot express: joining zero fragments yields no predicate at
-	// all (i.e. TRUE, matches everything). Route it to the residual so the
+	// shape toSQL cannot express: joining zero fragments yields no predicate
+	// at all (i.e. TRUE, matches everything). Route it to the residual so the
 	// kernel applies the identity. Note the asymmetry with the empty AND,
 	// whose identity (true) IS what dissectAnd's (nil, nil) means.
 	if len(f.Children) == 0 {
@@ -356,7 +356,10 @@ func operandText(v any) string {
 }
 
 // toSQL recursively converts a (fully pushable) filter tree to a SQL WHERE
-// fragment and bound arguments.
+// fragment and bound arguments. The tree must contain no empty groups —
+// joining zero fragments renders "" standalone and a malformed "()" nested;
+// dissect guarantees none reach here (empty groups are identity shapes the
+// kernel owns).
 func toSQL(f spi.Filter) (string, []any) {
 	switch f.Op {
 	case spi.FilterAnd:

--- a/plugins/sqlite/query_planner_empty_group_test.go
+++ b/plugins/sqlite/query_planner_empty_group_test.go
@@ -1,0 +1,104 @@
+package sqlite
+
+import (
+	"strings"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// The SPI filter contract (spi.MatchFilter): an explicit empty AND is the AND
+// identity (true, matches everything); an explicit empty OR is the OR identity
+// (false, matches nothing). SQL cannot express either shape — joining zero
+// fragments yields no predicate at all (i.e. TRUE) at the top level and a
+// malformed "()" when nested — so the planner must keep empty groups out of
+// the pushed SQL and let the kernel apply the identity.
+
+// An explicit empty OR must fall to the residual so the kernel applies the OR
+// identity (false). Pushing it emits no WHERE clause and no post-filter — a
+// query that must match nothing silently matching everything.
+func TestPlanQuery_EmptyOR(t *testing.T) {
+	f := spi.Filter{Op: spi.FilterOr}
+	plan := planQuery(f)
+	if plan.where != "" {
+		t.Errorf("where should be empty for an empty OR, got %s", plan.where)
+	}
+	if plan.postFilter == nil {
+		t.Fatal("postFilter should be the empty-OR residual (kernel applies the OR identity: match nothing); nil means match-all")
+	}
+	if plan.postFilter.Op != spi.FilterOr {
+		t.Errorf("postFilter.Op = %s, want or", plan.postFilter.Op)
+	}
+}
+
+// An explicit empty AND is the AND identity (true): match-all is correctly
+// expressed as no WHERE clause and no residual. Pins existing behavior.
+func TestPlanQuery_EmptyAND(t *testing.T) {
+	f := spi.Filter{Op: spi.FilterAnd}
+	plan := planQuery(f)
+	if plan.where != "" {
+		t.Errorf("where should be empty for an empty AND, got %s", plan.where)
+	}
+	if plan.postFilter != nil {
+		t.Errorf("postFilter should be nil for an empty AND (identity: match all), got %+v", plan.postFilter)
+	}
+}
+
+// An empty OR nested under AND must not reach the pushed SQL (joinChildren
+// over zero children nests as malformed "()"); it falls to the residual,
+// forcing the full-filter kernel re-check. The IsNull sibling is chosen
+// because it is EXACT — without the fix the plan is certified exact and no
+// re-check happens at all.
+func TestPlanQuery_EmptyORNestedInAND(t *testing.T) {
+	f := spi.Filter{
+		Op: spi.FilterAnd,
+		Children: []spi.Filter{
+			{Op: spi.FilterIsNull, Path: "status", Source: spi.SourceData},
+			{Op: spi.FilterOr},
+		},
+	}
+	plan := planQuery(f)
+	if strings.Contains(plan.where, "()") {
+		t.Errorf("where contains malformed empty group: %s", plan.where)
+	}
+	if plan.postFilter == nil {
+		t.Fatal("postFilter should be the full AND filter (empty-OR child makes the whole conjunction false; only the kernel applies that)")
+	}
+	if plan.postFilter.Op != spi.FilterAnd {
+		t.Errorf("postFilter.Op = %s, want and (full filter)", plan.postFilter.Op)
+	}
+}
+
+// An empty AND nested under OR is the identity true — the whole OR matches
+// everything. SQL cannot express the empty group ("()" is malformed), so the
+// entire OR goes residual (conservative OR dissection) and the kernel
+// evaluates it.
+func TestPlanQuery_EmptyANDNestedInOR(t *testing.T) {
+	f := spi.Filter{
+		Op: spi.FilterOr,
+		Children: []spi.Filter{
+			{Op: spi.FilterIsNull, Path: "status", Source: spi.SourceData},
+			{Op: spi.FilterAnd},
+		},
+	}
+	plan := planQuery(f)
+	if plan.where != "" {
+		t.Errorf("where should be empty (whole OR residual), got %s", plan.where)
+	}
+	if plan.postFilter == nil || plan.postFilter.Op != spi.FilterOr {
+		t.Fatalf("postFilter should be the whole OR residual, got %+v", plan.postFilter)
+	}
+}
+
+// allPushedExact must never certify an empty group as EXACT: exactness of a
+// group is a claim about its leaves, and an empty group has none — its
+// identity semantics are the kernel's to apply, so a vacuous true here would
+// skip the kernel re-check.
+func TestAllPushedExact_EmptyGroupNotExact(t *testing.T) {
+	if allPushedExact(spi.Filter{Op: spi.FilterOr}) {
+		t.Error("allPushedExact(empty OR) = true, want false")
+	}
+	if allPushedExact(spi.Filter{Op: spi.FilterAnd}) {
+		t.Error("allPushedExact(empty AND) = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary

An explicit empty OR (`{"type":"group","operator":"OR","conditions":[]}`) is the OR identity — false, matches nothing — per the SPI filter contract, and that is what the in-memory backend returns. The sqlite and postgres planners instead pushed the childless OR down as an empty WHERE fragment (matching **every entity in the model**, the unsafe direction — reachable from conditional DELETE), and nested empty groups rendered malformed SQL (`()`) that failed the whole query with a 500.

## Fix

Three guards, mirrored verbatim in both SQL planners:

- `dissectOr` routes a childless OR to the residual, where the kernel (`spi.Prepare`/`PreparedFilter.Match`) applies the documented identity.
- `isFullyPushable` rejects empty groups (both operators), so an enclosing OR goes residual instead of rendering `()`.
- `allPushedExact` never certifies an empty group as EXACT — defense-in-depth; unreachable by construction after the first two.

A childless AND keeps its existing behaviour: `dissectAnd`'s `(nil, nil)` is exactly the AND identity (true, match-all), which the search help topic already documents as the way to retrieve all entities. The help docs already state both identities, so this conforms code to the documented contract — no doc changes.

The commercial backend's planner re-checks the original filter via `spi.MatchFilter` at its root post-filter node, so it already honours the identity; the new parity scenario will confirm on its next dependency update.

## Trade-off noted for the record

An empty OR now evaluates through the residual path, which arms the scan budget (`SearchScanLimit`) on the SQL backends. On a model larger than the budget, a query whose answer is statically zero rows returns `ErrScanBudgetExhausted` instead — fail-closed (an error, never a wrong answer), and in the same pre-existing residual-divergence class as #472. The alternative — pushing the identities as exact SQL constants — would enlarge the exact-certified surface the planners deliberately keep tiny (only `IsNull`/`NotNull`), so the residual route is the deliberate choice.

## Testing

- Planner unit tests in both plugins (`query_planner_empty_group_test.go`): empty OR, empty AND, empty OR nested in AND, empty AND nested in OR, and an `allPushedExact` vacuity guard. The nested-in-AND test uses an `IsNull` sibling deliberately — pre-fix, that plan was certified EXACT and skipped the kernel re-check entirely.
- Cross-backend parity scenario `SearchEmptyGroupIdentities` (`e2e/parity/search_empty_group.go`, registered, count bumped): both identities, standalone and nested, return identical results on memory/sqlite/postgres through the full HTTP stack.
- All tests watched failing before the fix (memory passed throughout, confirming it as the reference); `make test-all` green including `internal/e2e` and the DB-backed postgres plugin tests; `go vet` clean on all modules; `make race` clean.

Fixes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLzH3YYHjgyHt2m8LkhQQ