### PR TITLE
fix(postgres): serialize ExtendSchema per (tenant, model) to prevent schema-fold delta loss

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -171,17 +171,7 @@ func New(cfg Config) *App {
 
 	// Wire the schema.Apply replay function into the plugin factory so
 	// ExtendSchema can fold deltas on read. Postgres uses this to fold
-	// the extension log; SQLite/Memory use it to apply in-place. The
-	// interface uses the raw function signature (not any plugin-local
-	// named ApplyFunc type) so a single type-assertion satisfies all
-	// plugins uniformly.
-	// The assertion is soft, so a factory that stops implementing this
-	// exact signature would be skipped silently and every fold-on-read of
-	// pending deltas would fail; applyfunc_wiring_test.go pins the in-tree
-	// factories to it at compile time.
-	type applyFuncSetter interface {
-		SetApplyFunc(fn func(base []byte, delta spi.SchemaDelta) ([]byte, error))
-	}
+	// the extension log; SQLite/Memory use it to apply in-place.
 	if setter, ok := factory.(applyFuncSetter); ok {
 		setter.SetApplyFunc(makeSchemaApply())
 	}
@@ -976,6 +966,17 @@ func validateClusterConfig(c cluster.Config) {
 		slog.Error("CYODA_NODE_ADDR must include scheme (http:// or https://)", "pkg", "cluster", "addr", c.NodeAddr)
 		os.Exit(1)
 	}
+}
+
+// applyFuncSetter is the wiring surface Run soft-asserts on each plugin
+// factory. It uses the raw function signature (not any plugin-local named
+// ApplyFunc type) so a single type-assertion satisfies all plugins
+// uniformly. The assertion is soft: a factory that stops implementing
+// this exact signature would be skipped silently and every fold-on-read
+// of pending deltas would fail — applyfunc_wiring_test.go pins the
+// in-tree factories to this same declaration at compile time.
+type applyFuncSetter interface {
+	SetApplyFunc(fn func(base []byte, delta spi.SchemaDelta) ([]byte, error))
 }
 
 // makeSchemaApply returns the schema-apply replay function the plugin

--- a/app/app.go
+++ b/app/app.go
@@ -175,6 +175,10 @@ func New(cfg Config) *App {
 	// interface uses the raw function signature (not any plugin-local
 	// named ApplyFunc type) so a single type-assertion satisfies all
 	// plugins uniformly.
+	// The assertion is soft, so a factory that stops implementing this
+	// exact signature would be skipped silently and every fold-on-read of
+	// pending deltas would fail; applyfunc_wiring_test.go pins the in-tree
+	// factories to it at compile time.
 	type applyFuncSetter interface {
 		SetApplyFunc(fn func(base []byte, delta spi.SchemaDelta) ([]byte, error))
 	}

--- a/app/applyfunc_wiring_test.go
+++ b/app/applyfunc_wiring_test.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+
+	memoryplugin "github.com/cyoda-platform/cyoda-go/plugins/memory"
+	pgplugin "github.com/cyoda-platform/cyoda-go/plugins/postgres"
+	sqliteplugin "github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
+
+// Run wires the schema-apply replay function into the storage factory
+// through a soft type-assertion (see the applyFuncSetter interface in
+// app.go): a factory that does not implement SetApplyFunc is silently
+// skipped, and every later fold-on-read of a model with pending schema
+// deltas fails. These compile-time assertions pin all in-tree plugin
+// factories to the exact signature app.go asserts on, so a signature
+// drift surfaces here as a build failure instead of at runtime as an
+// unfoldable model.
+type wiredApplyFuncSetter interface {
+	SetApplyFunc(fn func(base []byte, delta spi.SchemaDelta) ([]byte, error))
+}
+
+var (
+	_ wiredApplyFuncSetter = (*memoryplugin.StoreFactory)(nil)
+	_ wiredApplyFuncSetter = (*pgplugin.StoreFactory)(nil)
+	_ wiredApplyFuncSetter = (*sqliteplugin.StoreFactory)(nil)
+)

--- a/app/applyfunc_wiring_test.go
+++ b/app/applyfunc_wiring_test.go
@@ -1,27 +1,20 @@
 package app
 
 import (
-	spi "github.com/cyoda-platform/cyoda-go-spi"
-
 	memoryplugin "github.com/cyoda-platform/cyoda-go/plugins/memory"
 	pgplugin "github.com/cyoda-platform/cyoda-go/plugins/postgres"
 	sqliteplugin "github.com/cyoda-platform/cyoda-go/plugins/sqlite"
 )
 
 // Run wires the schema-apply replay function into the storage factory
-// through a soft type-assertion (see the applyFuncSetter interface in
-// app.go): a factory that does not implement SetApplyFunc is silently
-// skipped, and every later fold-on-read of a model with pending schema
-// deltas fails. These compile-time assertions pin all in-tree plugin
-// factories to the exact signature app.go asserts on, so a signature
-// drift surfaces here as a build failure instead of at runtime as an
-// unfoldable model.
-type wiredApplyFuncSetter interface {
-	SetApplyFunc(fn func(base []byte, delta spi.SchemaDelta) ([]byte, error))
-}
-
+// through a soft type-assertion on applyFuncSetter (app.go): a factory
+// that does not implement SetApplyFunc is silently skipped, and every
+// later fold-on-read of a model with pending schema deltas fails. These
+// compile-time assertions pin all in-tree plugin factories to the SAME
+// declaration Run asserts on, so a drift on either side surfaces here
+// as a build failure instead of at runtime as an unfoldable model.
 var (
-	_ wiredApplyFuncSetter = (*memoryplugin.StoreFactory)(nil)
-	_ wiredApplyFuncSetter = (*pgplugin.StoreFactory)(nil)
-	_ wiredApplyFuncSetter = (*sqliteplugin.StoreFactory)(nil)
+	_ applyFuncSetter = (*memoryplugin.StoreFactory)(nil)
+	_ applyFuncSetter = (*pgplugin.StoreFactory)(nil)
+	_ applyFuncSetter = (*sqliteplugin.StoreFactory)(nil)
 )

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -115,11 +115,19 @@ transactional contract itself. The spec living in
 `docs/superpowers/specs/2026-04-20-model-schema-extensions-design.md`
 states this as five invariants:
 
-1. **Non-interference.** A schema extension triggered inside an
-   entity transaction must not cause that transaction (or any
-   concurrent entity transaction) to fail with a conflict. In
-   practice this means schema extensions don't write the same row
-   that entity data writes touch.
+1. **Non-interference for non-extending writes.** An entity write
+   whose data already fits the folded schema (a nil delta — the
+   steady state) touches no model row and cannot conflict with any
+   concurrent writer over schema state. Writes that genuinely
+   extend the same model are the exception: they serialise per
+   `(tenant, model)` via a write-claim on the `models` row, so a
+   concurrent extender under `REPEATABLE READ` fails with a
+   retryable conflict (first committer wins, as for entity rows).
+   The serialisation is required by the limit of invariant 3:
+   delta appends commute, but the periodic savepoint fold does
+   not — a fold running in a snapshot that cannot yet see a
+   concurrent lower-seq delta would exclude that delta from every
+   future fold, silently and permanently.
 2. **Commit-bound visibility.** A schema extension is visible to
    subsequent readers only after the enclosing entity transaction
    commits. Rolled-back entity transactions leave no trace of their

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -113,7 +113,9 @@ occasional schema extensions (when a model has a non-empty
 `ChangeLevel`), the boundary between the two is part of the
 transactional contract itself. The spec living in
 `docs/superpowers/specs/2026-04-20-model-schema-extensions-design.md`
-states this as five invariants:
+introduced this as five invariants; the current form below amends
+invariant 1 (the original promised absolute non-interference, which the
+savepoint fold cannot honour — see invariant 1's closing sentence):
 
 1. **Non-interference for non-extending writes.** An entity write
    whose data already fits the folded schema (a nil delta — the

--- a/internal/domain/entity/handler.go
+++ b/internal/domain/entity/handler.go
@@ -108,9 +108,11 @@ func (h *Handler) commitOwned(ctx context.Context, txID string, owned bool) erro
 // changeLevel is set, it computes an additive schema delta via schema.Diff
 // and appends it to the model's extension log via ModelStore.ExtendSchema.
 // That call participates in the ambient entity transaction, so visibility
-// is commit-bound and concurrent entity writes on the same model do not
-// contend on a single "models" row — the hot-row regression that
-// ModelStore.Save would otherwise produce under REPEATABLE READ.
+// is commit-bound. Writes whose data already fits the schema (nil delta —
+// the steady state) touch no "models" row and cannot contend; writes that
+// genuinely extend the same model serialise per (tenant, model) inside the
+// plugin, and a concurrent extender surfaces a retryable conflict rather
+// than folding a savepoint over a delta it cannot yet see.
 // Returns an error on validation or extension failure.
 // ValidateWithRefresh runs strict schema validation with a bounded
 // refresh-on-stale safety net. One refresh attempt, only on unknown-

--- a/internal/domain/entity/handler_extend_conflict_test.go
+++ b/internal/domain/entity/handler_extend_conflict_test.go
@@ -1,0 +1,42 @@
+package entity
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/ingest"
+)
+
+// TestClassifyValidateOrExtendErr_ExtendConflict_Is409Retryable — a
+// concurrent ExtendSchema on the same model now surfaces spi.ErrConflict
+// (the postgres plugin serialises schema writers per (tenant, model) and
+// rejects the loser, first committer wins). ValidateOrExtend wraps store
+// failures in ErrInternalSchema, whose branch routes through
+// common.Internal — which must keep recognising the conflict through
+// both wraps and answer a retryable 409, not a 500: the loser's write
+// succeeds on retry against a fresh snapshot.
+func TestClassifyValidateOrExtendErr_ExtendConflict_Is409Retryable(t *testing.T) {
+	// Same double-wrap shape ValidateOrExtend produces around a plugin
+	// conflict error.
+	underlying := fmt.Errorf("%w: failed to extend schema: %w",
+		ingest.ErrInternalSchema,
+		fmt.Errorf("serialize schema writers for E/1: %w", spi.ErrConflict))
+
+	appErr := classifyValidateOrExtendErr(underlying)
+	if appErr == nil {
+		t.Fatal("classifyValidateOrExtendErr returned nil")
+	}
+	if appErr.Status != http.StatusConflict {
+		t.Errorf("status = %d, want %d", appErr.Status, http.StatusConflict)
+	}
+	if appErr.Code != common.ErrCodeConflict {
+		t.Errorf("code = %q, want %q", appErr.Code, common.ErrCodeConflict)
+	}
+	if !appErr.Retryable {
+		t.Error("conflict from a concurrent schema extend must be retryable")
+	}
+}

--- a/plugins/postgres/classified_querier_internal_test.go
+++ b/plugins/postgres/classified_querier_internal_test.go
@@ -1,0 +1,54 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// errQuerier is a stub whose every method reports the configured error,
+// standing in for a pgx.Tx whose statements fail server-side.
+type errQuerier struct{ err error }
+
+func (q errQuerier) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, q.err
+}
+func (q errQuerier) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, q.err
+}
+func (q errQuerier) QueryRow(context.Context, string, ...any) pgx.Row {
+	return errRow{err: q.err}
+}
+
+type errRow struct{ err error }
+
+func (r errRow) Scan(...any) error { return r.err }
+
+// TestClassifiedQuerier_ClassifiesStatementErrors — ExtendSchema's
+// self-wrap transaction routes its statements through classifiedQuerier
+// so its errors carry the same classification the ambient path gets from
+// ctxQuerier: a serialization abort must surface as spi.ErrConflict, and
+// an idle-in-transaction reclaim must carry the storage-unavailable
+// marker. A raw pgx.Tx would bypass classification entirely and turn
+// retryable outcomes into opaque 500s.
+func TestClassifiedQuerier_ClassifiesStatementErrors(t *testing.T) {
+	ctx := context.Background()
+	conflict := &pgconn.PgError{Code: pgerrcode.SerializationFailure}
+	q := classifiedQuerier{inner: errQuerier{err: conflict}}
+
+	if _, err := q.Exec(ctx, "UPDATE models SET doc = doc"); !errors.Is(err, spi.ErrConflict) {
+		t.Errorf("Exec: 40001 classified as %v, want spi.ErrConflict", err)
+	}
+	if _, err := q.Query(ctx, "SELECT 1"); !errors.Is(err, spi.ErrConflict) {
+		t.Errorf("Query: 40001 classified as %v, want spi.ErrConflict", err)
+	}
+	if err := q.QueryRow(ctx, "SELECT 1").Scan(); !errors.Is(err, spi.ErrConflict) {
+		t.Errorf("QueryRow.Scan: 40001 classified as %v, want spi.ErrConflict", err)
+	}
+}

--- a/plugins/postgres/classifying_querier.go
+++ b/plugins/postgres/classifying_querier.go
@@ -23,9 +23,9 @@ import (
 // its bookkeeping with it. Classification belongs here rather than at the call
 // sites, which is why the stores do not re-classify what they get back.
 //
-// It is one of two queriers in this package, not the only one: a store whose
-// statements must not join an ambient transaction takes poolQuerier instead.
-// Both classify identically; they differ only in what they resolve.
+// It is one of two queriers in this package, not the only one: a caller whose
+// statements must not resolve an ambient transaction takes classifiedQuerier
+// instead. Both classify identically; they differ only in what they resolve.
 type ctxQuerier struct {
 	factory *StoreFactory
 }
@@ -93,33 +93,36 @@ func wrapRows(rows pgx.Rows, classify func(error) error) pgx.Rows {
 	return &classifyingRows{Rows: rows, classify: classify}
 }
 
-// poolQuerier is the funnel for a store whose statements must NOT join an
-// ambient transaction: it resolves the pool unconditionally, and classifies with
-// the same plain classification classifyFor applies to a non-transactional
-// statement.
+// classifiedQuerier applies the plain classification funnel — the same
+// one classifyFor uses for a non-transactional statement — to a fixed
+// inner Querier, with no context-based transaction resolution.
 //
-// One store needs this. An async-search job record outlives the request that
-// submitted it — the goroutine that fills it in runs on a context of its own —
-// and the submit path's context can carry a joined transaction, because the
-// TxJoin middleware wraps the whole API mux and the gRPC tx-route interceptor
-// covers the snapshot RPCs. Resolving that transaction would bind the job record
-// to it: invisible to the goroutine that must update it, and gone if the caller
-// rolls back. Pinning to the pool keeps the record independent while still
-// classifying what the pool reports.
-type poolQuerier struct{ pool Querier }
+// Two callers pin an inner querier this way. The async-search job store
+// pins the pool (via StoreFactory.poolQuerier): its job record outlives
+// the request that submitted it — the goroutine that fills it in runs on
+// a context of its own — and the submit path's context can carry a
+// joined transaction, because the TxJoin middleware wraps the whole API
+// mux and the gRPC tx-route interceptor covers the snapshot RPCs.
+// Resolving that transaction would bind the job record to it: invisible
+// to the goroutine that must update it, and gone if the caller rolls
+// back. ExtendSchema's self-wrap pins its own pgx.Tx: the transaction is
+// private by construction, and the funnel is what keeps its errors — a
+// serialization abort on the write-claim, a reclaimed session — carrying
+// the same sentinels the ambient path gets from ctxQuerier.
+type classifiedQuerier struct{ inner Querier }
 
-func (p poolQuerier) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
-	tag, err := p.pool.Exec(ctx, sql, args...)
+func (c classifiedQuerier) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	tag, err := c.inner.Exec(ctx, sql, args...)
 	return tag, classifyError(err)
 }
 
-func (p poolQuerier) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
-	rows, err := p.pool.Query(ctx, sql, args...)
+func (c classifiedQuerier) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	rows, err := c.inner.Query(ctx, sql, args...)
 	return wrapRows(rows, classifyError), classifyError(err)
 }
 
-func (p poolQuerier) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
-	return &classifyingRow{inner: p.pool.QueryRow(ctx, sql, args...), classify: classifyError}
+func (c classifiedQuerier) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	return &classifyingRow{inner: c.inner.QueryRow(ctx, sql, args...), classify: classifyError}
 }
 
 // deadTxError marks a statement issued against a transaction the manager no

--- a/plugins/postgres/model_extensions_concurrency_internal_test.go
+++ b/plugins/postgres/model_extensions_concurrency_internal_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -70,9 +71,14 @@ func TestExtendSchema_OverlappingTx_CommittedDeltaSurvivesSavepointFold(t *testi
 		_ = tm.Rollback(fx.ctx, tx1ID)
 	}
 	if err != nil {
-		// The serialised contract may reject the overlapping writer with a
-		// conflict; the caller's remedy is a retry in a fresh transaction,
-		// which must then succeed.
+		// The serialised contract may reject the overlapping writer, but
+		// only as spi.ErrConflict — that classification is what the kernel
+		// turns into a retryable 409; an unclassified error would surface
+		// as a 500 with no retry guidance. The caller's remedy is a retry
+		// in a fresh transaction, which must then succeed.
+		if !errors.Is(err, spi.ErrConflict) {
+			t.Fatalf("overlapping writer rejected with a non-conflict error: %v", err)
+		}
 		retryID, retryCtx, beginErr := tm.Begin(fx.ctx)
 		if beginErr != nil {
 			t.Fatalf("Begin retry tx: %v", beginErr)
@@ -139,5 +145,33 @@ func TestExtendSchema_ConcurrentSelfWrap_SavepointCrossing_NoLostDelta(t *testin
 		if !bytes.Contains(got.Schema, []byte(token)) {
 			t.Errorf("committed delta %q lost from fold; folded schema = %s", token, got.Schema)
 		}
+	}
+}
+
+// TestExtendSchema_MissingModel_UnwiredApplyFunc_ErrNotFound — the
+// write-claim's zero-row arm. With applyFunc wired, the pre-persist
+// check already reported ErrNotFound for a missing model; with it
+// unwired, ExtendSchema used to append an orphan delta row for a model
+// that does not exist. The claim UPDATE closes that hole: zero rows
+// matched means no model to extend, ErrNotFound, and nothing persisted.
+func TestExtendSchema_MissingModel_UnwiredApplyFunc_ErrNotFound(t *testing.T) {
+	fx := newPGFixture(t)
+	fx.store.applyFunc = nil
+	ref := spi.ModelRef{EntityName: "Ghost", ModelVersion: "1"}
+
+	err := fx.store.ExtendSchema(fx.ctx, ref, spi.SchemaDelta(`"d0"`))
+	if !errors.Is(err, spi.ErrNotFound) {
+		t.Fatalf("ExtendSchema on missing model = %v, want spi.ErrNotFound", err)
+	}
+
+	var count int
+	if err := fx.db.QueryRow(fx.ctx,
+		`SELECT COUNT(*) FROM model_schema_extensions
+		 WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3`,
+		string(fx.tenantID), ref.EntityName, ref.ModelVersion).Scan(&count); err != nil {
+		t.Fatalf("count extension rows: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("missing model accreted %d orphan extension rows, want 0", count)
 	}
 }

--- a/plugins/postgres/model_extensions_concurrency_internal_test.go
+++ b/plugins/postgres/model_extensions_concurrency_internal_test.go
@@ -1,0 +1,143 @@
+package postgres
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// TestExtendSchema_OverlappingTx_CommittedDeltaSurvivesSavepointFold —
+// the schema-fold delta-loss corruption path.
+//
+// Two overlapping REPEATABLE READ transactions extend the same
+// auto-evolving model, and the slower one's delta crosses the savepoint
+// interval. The savepoint fold then runs inside a snapshot taken before
+// the other transaction committed, so without per-(tenant, model) write
+// serialization it folds WITHOUT that committed delta — and because
+// fold-on-read replays only deltas with seq greater than the savepoint's,
+// the missed delta is excluded from every future fold: a committed
+// additive field is silently and permanently lost.
+//
+// Contract under test: ExtendSchema serialises per (tenant, model). The
+// overlapping writer must either fold correctly or fail with a conflict,
+// in which case the caller retries in a fresh transaction (first
+// committer wins, same as entity writes). Either way, once both writers
+// have committed, a fold must contain BOTH fields.
+func TestExtendSchema_OverlappingTx_CommittedDeltaSurvivesSavepointFold(t *testing.T) {
+	const interval = 2
+	fx := newPGFixtureWithInterval(t, interval)
+	fx.store.applyFunc = setUnionApplyFunc
+	fx.factory.InitTransactionManager(newTestUUIDGenerator())
+	tm, err := fx.factory.TransactionManager(fx.ctx)
+	if err != nil {
+		t.Fatalf("TransactionManager: %v", err)
+	}
+
+	ref := spi.ModelRef{EntityName: "E", ModelVersion: "1"}
+	fx.SaveModel(t, ref, []byte{})
+
+	// T1 begins first and pins its REPEATABLE READ snapshot with a read,
+	// so everything T2 commits from here on is invisible to T1.
+	tx1ID, tx1Ctx, err := tm.Begin(fx.ctx)
+	if err != nil {
+		t.Fatalf("Begin T1: %v", err)
+	}
+	if _, err := fx.store.Get(tx1Ctx, ref); err != nil {
+		t.Fatalf("T1 snapshot-pinning Get: %v", err)
+	}
+
+	// T2 adds "fieldB" and commits. One delta < interval: no savepoint.
+	tx2ID, tx2Ctx, err := tm.Begin(fx.ctx)
+	if err != nil {
+		t.Fatalf("Begin T2: %v", err)
+	}
+	if err := fx.store.ExtendSchema(tx2Ctx, ref, spi.SchemaDelta(`"fieldB"`)); err != nil {
+		t.Fatalf("T2 ExtendSchema: %v", err)
+	}
+	if err := tm.Commit(fx.ctx, tx2ID); err != nil {
+		t.Fatalf("T2 Commit: %v", err)
+	}
+
+	// T1 adds "fieldA": its delta crosses the savepoint interval, so the
+	// fold fires inside T1's stale snapshot — which cannot see "fieldB".
+	err = fx.store.ExtendSchema(tx1Ctx, ref, spi.SchemaDelta(`"fieldA"`))
+	if err == nil {
+		err = tm.Commit(fx.ctx, tx1ID)
+	} else {
+		_ = tm.Rollback(fx.ctx, tx1ID)
+	}
+	if err != nil {
+		// The serialised contract may reject the overlapping writer with a
+		// conflict; the caller's remedy is a retry in a fresh transaction,
+		// which must then succeed.
+		retryID, retryCtx, beginErr := tm.Begin(fx.ctx)
+		if beginErr != nil {
+			t.Fatalf("Begin retry tx: %v", beginErr)
+		}
+		if err := fx.store.ExtendSchema(retryCtx, ref, spi.SchemaDelta(`"fieldA"`)); err != nil {
+			_ = tm.Rollback(fx.ctx, retryID)
+			t.Fatalf("retry ExtendSchema: %v", err)
+		}
+		if err := tm.Commit(fx.ctx, retryID); err != nil {
+			t.Fatalf("retry Commit: %v", err)
+		}
+	}
+
+	// Both writers have committed: the fold must contain both fields.
+	got, err := fx.store.Get(fx.ctx, ref)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for _, field := range []string{"fieldA", "fieldB"} {
+		if !bytes.Contains(got.Schema, []byte(field)) {
+			t.Errorf("committed delta %q lost from fold; folded schema = %s", field, got.Schema)
+		}
+	}
+}
+
+// TestExtendSchema_ConcurrentSelfWrap_SavepointCrossing_NoLostDelta —
+// the self-wrap (no ambient transaction) flavour of the same corruption
+// path, driven as a stress test: N concurrent writers each add a distinct
+// token with a savepoint interval small enough that many folds fire
+// mid-storm. Every committed delta must survive into the final fold; a
+// savepoint that folded over a delta it could not yet see loses that
+// token permanently.
+func TestExtendSchema_ConcurrentSelfWrap_SavepointCrossing_NoLostDelta(t *testing.T) {
+	const (
+		n        = 24
+		interval = 3
+	)
+	fx := newPGFixtureWithInterval(t, interval)
+	fx.store.applyFunc = setUnionApplyFunc
+
+	ref := spi.ModelRef{EntityName: "E", ModelVersion: "1"}
+	fx.SaveModel(t, ref, []byte{})
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			delta := spi.SchemaDelta(fmt.Sprintf(`"d%02d"`, i))
+			if err := fx.store.ExtendSchema(fx.ctx, ref, delta); err != nil {
+				t.Errorf("ExtendSchema #%d: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := fx.store.Get(fx.ctx, ref)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		token := fmt.Sprintf("d%02d", i)
+		if !bytes.Contains(got.Schema, []byte(token)) {
+			t.Errorf("committed delta %q lost from fold; folded schema = %s", token, got.Schema)
+		}
+	}
+}

--- a/plugins/postgres/model_extensions_concurrency_internal_test.go
+++ b/plugins/postgres/model_extensions_concurrency_internal_test.go
@@ -2,10 +2,15 @@ package postgres
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
 	"sync"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 )
@@ -173,5 +178,81 @@ func TestExtendSchema_MissingModel_UnwiredApplyFunc_ErrNotFound(t *testing.T) {
 	}
 	if count != 0 {
 		t.Errorf("missing model accreted %d orphan extension rows, want 0", count)
+	}
+}
+
+// TestExtendSchema_SelfWrap_SetsTenantGUCForRLS — the self-wrap
+// transaction must set app.current_tenant like every other transaction
+// this plugin opens (TransactionManager.Begin, the async-search scan),
+// so the tenant-isolation RLS policies on models and
+// model_schema_extensions apply to its statements.
+//
+// The usual fixtures cannot see this: the test role owns the tables (and
+// the container's bootstrap user is superuser), so RLS never applies and
+// a missing set_config is invisible. Production's stated RLS posture is
+// a non-owner application role (rls_test.go), for which ENABLE ROW LEVEL
+// SECURITY applies as-is — so this test runs ExtendSchema through a
+// dedicated non-superuser role. An unset GUC evaluates the policies to
+// NULL and the write-claim UPDATE sees zero rows: fail-closed
+// ErrNotFound instead of an extension.
+func TestExtendSchema_SelfWrap_SetsTenantGUCForRLS(t *testing.T) {
+	fx := newPGFixture(t)
+	fx.store.applyFunc = setUnionApplyFunc
+	ref := spi.ModelRef{EntityName: "E", ModelVersion: "1"}
+	fx.SaveModel(t, ref, []byte{}) // seeded as owner: RLS does not apply
+
+	const probeRole = "cyoda_rls_probe"
+	for _, stmt := range []string{
+		`DROP ROLE IF EXISTS ` + probeRole,
+		`CREATE ROLE ` + probeRole + ` LOGIN PASSWORD 'probe' NOSUPERUSER`,
+		// The fixture recreates schema public (dropSchema), which strips the
+		// default PUBLIC grants — USAGE must be granted explicitly.
+		`GRANT USAGE ON SCHEMA public TO ` + probeRole,
+		`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ` + probeRole,
+		`GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ` + probeRole,
+	} {
+		if _, err := fx.db.Exec(fx.ctx, stmt); err != nil {
+			t.Fatalf("provision probe role: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		// Runs before the fixture's dropSchema cleanup (LIFO), while the
+		// granted objects still exist.
+		_, _ = fx.db.Exec(context.Background(), `DROP OWNED BY `+probeRole)
+		_, _ = fx.db.Exec(context.Background(), `DROP ROLE IF EXISTS `+probeRole)
+	})
+
+	probeURL, err := url.Parse(os.Getenv("CYODA_TEST_DB_URL"))
+	if err != nil {
+		t.Fatalf("parse CYODA_TEST_DB_URL: %v", err)
+	}
+	probeURL.User = url.UserPassword(probeRole, "probe")
+	probePool, err := pgxpool.New(context.Background(), probeURL.String())
+	if err != nil {
+		t.Fatalf("create probe pool: %v", err)
+	}
+	t.Cleanup(probePool.Close)
+
+	factory := NewStoreFactory(probePool)
+	factory.SetApplyFunc(setUnionApplyFunc)
+	ms, err := factory.ModelStore(fx.ctx)
+	if err != nil {
+		t.Fatalf("probe ModelStore: %v", err)
+	}
+
+	if err := ms.ExtendSchema(fx.ctx, ref, spi.SchemaDelta(`"d0"`)); err != nil {
+		t.Fatalf("self-wrap ExtendSchema under RLS (non-owner role): %v", err)
+	}
+
+	// Assert through the owner pool: the delta really landed.
+	var count int
+	if err := fx.db.QueryRow(fx.ctx,
+		`SELECT COUNT(*) FROM model_schema_extensions
+		 WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3 AND kind = 'delta'`,
+		string(fx.tenantID), ref.EntityName, ref.ModelVersion).Scan(&count); err != nil {
+		t.Fatalf("count delta rows: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("delta row count = %d, want 1", count)
 	}
 }

--- a/plugins/postgres/model_extensions_internal_test.go
+++ b/plugins/postgres/model_extensions_internal_test.go
@@ -534,9 +534,10 @@ func TestExtendSchema_UnlockDoesNotWriteSavepoint(t *testing.T) {
 }
 
 // TestExtendSchema_CommutativeAppend_ConvergesUnderConcurrency — B-I7.
-// N goroutines extend the same model concurrently. Postgres has no retry
-// loop (REPEATABLE READ gives no schema-write conflict surface), so all
-// writers are expected to commit. The set-union apply is associative,
+// N goroutines extend the same model concurrently. These are self-wrap
+// writers (no ambient transaction), which serialise by blocking on the
+// per-(tenant, model) write-claim, so all are expected to commit without
+// a conflict or retry. The set-union apply is associative,
 // commutative, and idempotent — so the fold must equal the fold of any
 // serial replay regardless of interleaving. The test also asserts that
 // exactly N delta rows exist: no writer was silently dropped.
@@ -599,8 +600,9 @@ func TestExtendSchema_CommutativeAppend_ConvergesUnderConcurrency(t *testing.T) 
 }
 
 // TestExtendSchema_ContextCancellation_ReturnsCtxErr — §4.2 contract.
-// Postgres's ExtendSchema has no retry loop (REPEATABLE READ presents
-// no schema-write conflict surface) so there is no retry-budget path
+// Postgres's ExtendSchema has no transparent retry loop: a concurrent
+// same-model writer surfaces spi.ErrConflict to the caller (first
+// committer wins), so there is no retry-budget path
 // that could turn a ctx cancellation into ErrRetryExhausted. Assert
 // that the pgx-native cancellation behavior surfaces the context error
 // — the same observable contract every plugin must honour.

--- a/plugins/postgres/model_store.go
+++ b/plugins/postgres/model_store.go
@@ -401,11 +401,24 @@ func (s *modelStore) ExtendSchema(ctx context.Context, ref spi.ModelRef, delta s
 	// Rollback is idempotent in pgx: no-op once Commit has landed.
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	if err := s.extendSchemaBody(ctx, tx, ref, delta); err != nil {
+	// Set the RLS tenant, as every other transaction this plugin opens does
+	// (TransactionManager.Begin, the async-search scan). The owner role
+	// bypasses the policies today, but under the stated non-owner deployment
+	// posture (rls_test.go) an unset GUC filters every row this body needs.
+	if _, err := tx.Exec(ctx,
+		"SELECT set_config('app.current_tenant', $1, true)", string(s.tenantID)); err != nil {
+		return fmt.Errorf("failed to set tenant for ExtendSchema(%s): %w", ref, err)
+	}
+
+	// classifiedQuerier keeps the self-wrap statements on the same error
+	// classification the ambient path gets from ctxQuerier — the write-claim's
+	// conflict sentinel and the ceilings' storage-unavailable marker both
+	// depend on it.
+	if err := s.extendSchemaBody(ctx, classifiedQuerier{inner: tx}, ref, delta); err != nil {
 		return err
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("failed to commit self-wrap tx for ExtendSchema(%s): %w", ref, err)
+		return classifyError(fmt.Errorf("failed to commit self-wrap tx for ExtendSchema(%s): %w", ref, err))
 	}
 	return nil
 }

--- a/plugins/postgres/model_store.go
+++ b/plugins/postgres/model_store.go
@@ -73,6 +73,13 @@ func (s *modelStore) Save(ctx context.Context, desc *spi.ModelDescriptor) error 
 	// here is a fatal assertion; in production it logs a warning and
 	// proceeds, because Save itself is the authoritative schema source
 	// at this moment.
+	//
+	// The assertion is defense-in-depth, not the defense: the kernel's
+	// model state machine (LOCKED/UNLOCKED mutual exclusion and the
+	// MODEL_HAS_ENTITIES zero-entity check, e2e-covered in the root
+	// module) is what keeps writers off this path in production. It is
+	// expected to be unreachable through the public API and stays for
+	// writers that bypass the state machine.
 	tag, err := s.q.Exec(ctx, `
 		DELETE FROM model_schema_extensions
 		WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3`,

--- a/plugins/postgres/model_store.go
+++ b/plugins/postgres/model_store.go
@@ -341,10 +341,15 @@ func unmarshalModelDoc(raw []byte) (*spi.ModelDescriptor, error) {
 // the same transaction so future Gets can start from there rather
 // than replaying the entire log.
 //
-// Under REPEATABLE READ there is no schema-write conflict surface:
-// concurrent writers both succeed, and A.2 I2 (commutativity)
-// guarantees the fold is equivalent regardless of interleaving.
-// No retry wrapper.
+// Writers serialise per (tenant, model) by claiming a write on the
+// models row before anything else — see extendSchemaBody. Delta appends
+// alone would commute, but the savepoint fold does not: folding inside
+// a snapshot that cannot yet see a concurrent writer's lower-seq delta
+// would exclude that delta from every future fold. A concurrent writer
+// in an ambient REPEATABLE READ transaction therefore fails with
+// spi.ErrConflict (first committer wins, as for entity writes) and
+// retries on a fresh snapshot; self-wrapped writers serialise by
+// blocking on the row lock instead. No retry wrapper here.
 //
 // Empty or nil deltas are a no-op.
 func (s *modelStore) ExtendSchema(ctx context.Context, ref spi.ModelRef, delta spi.SchemaDelta) error {
@@ -366,7 +371,12 @@ func (s *modelStore) ExtendSchema(ctx context.Context, ref spi.ModelRef, delta s
 	// acquire, and is cancelled the instant Begin returns so the transaction
 	// handle — which outlives this call — cannot inherit it.
 	acquireCtx, cancelAcquire := s.acquireContext(ctx)
-	tx, err := s.pool.Begin(acquireCtx)
+	// READ COMMITTED is explicit, not inherited from the server default:
+	// extendSchemaBody's write-claim on the models row relies on every
+	// post-claim statement seeing what the previous claim holder committed,
+	// which per-statement snapshots provide and a REPEATABLE READ snapshot
+	// taken before the claim would not.
+	tx, err := s.pool.BeginTx(acquireCtx, pgx.TxOptions{IsoLevel: pgx.ReadCommitted})
 	cancelAcquire() // Begin has returned; the handle must not inherit the deadline
 	if err != nil {
 		// Same classification as every other acquire in this plugin: a saturated
@@ -407,6 +417,28 @@ func (s *modelStore) extendSchemaBody(ctx context.Context, q Querier, ref spi.Mo
 	shadow := *s
 	shadow.q = q
 
+	// Serialise writers per (tenant, model): claim a write on the models
+	// row before any other statement in this body. The claim must be a
+	// real UPDATE — not SELECT ... FOR UPDATE, not an advisory lock —
+	// because under an ambient REPEATABLE READ transaction a blocking-only
+	// lock releases the loser onto its stale snapshot, whose savepoint
+	// fold would exclude the winner's committed delta forever (fold-on-read
+	// replays only deltas newer than the savepoint). The UPDATE makes the
+	// loser fail with 40001 instead (spi.ErrConflict via the classifying
+	// querier), and the caller retries on a fresh snapshot. On the
+	// self-wrap READ COMMITTED path the same claim serialises writers by
+	// blocking, and post-claim statements see the previous holder's commit.
+	tag, err := q.Exec(ctx,
+		`UPDATE models SET doc = doc
+		 WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3`,
+		string(s.tenantID), ref.EntityName, ref.ModelVersion)
+	if err != nil {
+		return fmt.Errorf("serialize schema writers for %s: %w", ref, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("model %s not found: %w", ref, spi.ErrNotFound)
+	}
+
 	// Pre-persist Apply check: reject deltas that applyFunc refuses before
 	// they reach the extension log. Mirrors the memory plugin's
 	// apply-inline behavior (plugins/memory/model_store.go:ExtendSchema)
@@ -434,7 +466,7 @@ func (s *modelStore) extendSchemaBody(ctx context.Context, q Querier, ref spi.Mo
 	}
 
 	var newSeq int64
-	err := q.QueryRow(ctx,
+	err = q.QueryRow(ctx,
 		`INSERT INTO model_schema_extensions
 		    (tenant_id, model_name, model_version, kind, payload, tx_id)
 		 VALUES ($1, $2, $3, 'delta', $4, $5)

--- a/plugins/postgres/model_store.go
+++ b/plugins/postgres/model_store.go
@@ -358,6 +358,10 @@ func unmarshalModelDoc(raw []byte) (*spi.ModelDescriptor, error) {
 // retries on a fresh snapshot; self-wrapped writers serialise by
 // blocking on the row lock instead. No retry wrapper here.
 //
+// A blocked writer waits as long as the claim holder's transaction
+// lives, bounded by the caller's context and the statement_timeout
+// ceiling — not by AcquireTimeout, which covers only the pool acquire.
+//
 // Empty or nil deltas are a no-op.
 func (s *modelStore) ExtendSchema(ctx context.Context, ref spi.ModelRef, delta spi.SchemaDelta) error {
 	if len(delta) == 0 {

--- a/plugins/postgres/store_factory.go
+++ b/plugins/postgres/store_factory.go
@@ -150,10 +150,10 @@ func (f *StoreFactory) querier() Querier {
 
 // poolQuerier returns the pool-pinned Querier — same classification, no
 // transaction resolution. Used by the async-search job store alone; see
-// poolQuerier's godoc for why that record must not join the caller's
-// transaction.
+// classifiedQuerier's godoc for why that record must not join the
+// caller's transaction.
 func (f *StoreFactory) poolQuerier() Querier {
-	return poolQuerier{pool: f.pool}
+	return classifiedQuerier{inner: f.pool}
 }
 
 // classifyFor classifies a statement error against whichever transaction the

--- a/plugins/sqlite/model_extensions_internal_test.go
+++ b/plugins/sqlite/model_extensions_internal_test.go
@@ -747,3 +747,51 @@ func TestSQLite_ExtendSchema_RejectsDeltaThatApplyRefuses(t *testing.T) {
 		t.Errorf("rejected delta persisted: before=%d after=%d", preCount, postCount)
 	}
 }
+
+// TestSQLite_ExtendSchema_ConcurrentSavepointCrossing_NoLostDelta —
+// cross-backend regression for the schema-fold delta-loss corruption
+// path fixed in the postgres plugin (see plugins/postgres
+// TestExtendSchema_ConcurrentSelfWrap_SavepointCrossing_NoLostDelta):
+// a savepoint fold that runs without seeing a concurrent writer's
+// lower-seq delta excludes that delta from every future fold. SQLite's
+// single-writer transaction model makes each ExtendSchema attempt
+// (fold + append in one internal tx, retried wholesale on BUSY)
+// naturally immune; this test locks that property in. N concurrent
+// writers each add a distinct token with a savepoint interval small
+// enough that many folds fire mid-storm; every committed delta must
+// survive into the final fold.
+func TestSQLite_ExtendSchema_ConcurrentSavepointCrossing_NoLostDelta(t *testing.T) {
+	const (
+		n        = 24
+		interval = 3
+	)
+	fx := newSQLiteFixtureWithInterval(t, interval)
+	fx.store.applyFunc = setUnionApplyFunc
+	ref := spi.ModelRef{EntityName: "E", ModelVersion: "1"}
+	fx.SaveModel(t, ref, []byte{})
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			delta := spi.SchemaDelta(fmt.Sprintf(`"d%02d"`, i))
+			if err := fx.store.ExtendSchema(fx.ctx, ref, delta); err != nil {
+				t.Errorf("ExtendSchema #%d: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := fx.store.Get(fx.ctx, ref)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		token := fmt.Sprintf("d%02d", i)
+		if !bytes.Contains(got.Schema, []byte(token)) {
+			t.Errorf("committed delta %q lost from fold; folded schema = %s", token, got.Schema)
+		}
+	}
+}


### PR DESCRIPTION
Closes #360.

## Problem

In auto-evolving schema mode, concurrent `ExtendSchema` writers could fold a savepoint inside a REPEATABLE READ snapshot that did not yet see a concurrent committer's lower-seq delta. Fold-on-read replays only deltas newer than the savepoint, so the missed delta was excluded from every future fold — a committed additive schema field silently and permanently lost. Reproduced deterministically (two-transaction interleave) and statistically (stress test lost 11 of 24 committed deltas).

## Fix

`extendSchemaBody` claims a write on the `models` row (`UPDATE models SET doc = doc WHERE tenant_id/model/version`) before any other statement, serializing writers per (tenant, model):

- **Ambient REPEATABLE READ transaction:** a blocking-only lock (`SELECT … FOR UPDATE`, advisory lock — the issue's first suggestion) is *insufficient*: it releases the loser onto its stale snapshot and the corruption returns. The row UPDATE instead makes the loser fail with 40001 → `spi.ErrConflict` → retryable 409 (`CONFLICT`), the same first-committer-wins contract entity writes have; the caller retries on a fresh snapshot. The classification chain (`ErrInternalSchema` double-wrap → `classifyValidateOrExtendErr` → `common.Internal` conflict routing) is pinned by a new unit test.
- **Self-wrap path (no ambient tx):** now explicitly READ COMMITTED; writers serialise by blocking on the row lock, and post-claim statements see the previous holder's commit — no conflict, no retry. The wait is bounded by the caller's ctx and `statement_timeout`.
- Steady state is unaffected: `schema.Diff` yields a nil delta for data that already fits, and no `models`-row write happens at all.
- Zero-row claim → `ErrNotFound` (previously an orphan delta row could be appended when `applyFunc` was unwired).

## Security-review hardening (self-wrap path, pre-existing gaps now load-bearing)

- Self-wrap tx now sets `app.current_tenant` like every other transaction this plugin opens; regression test drives ExtendSchema through a dedicated non-superuser role so the RLS policies actually apply (the owner/superuser fixtures could never see the gap).
- `poolQuerier` generalised to `classifiedQuerier`; the self-wrap body and commit now classify errors like the ambient path (conflict sentinel, storage-unavailable marker).

## Cross-backend

- **sqlite** shares the fold shape but is structurally immune (single-writer, fold+append in one internal tx retried wholesale) — locked in with the same concurrent savepoint-crossing regression.
- **memory** applies deltas in place under a mutex — no fold path, nothing to regress.

## Secondary findings from the issue

- Dev-only operator-contract guard: comment now names the kernel state machine as the production-live defense (guard behaviour already test-pinned).
- `applyFunc` wiring: package-level `applyFuncSetter` shared by `Run`'s soft assertion and new compile-time pins of all three in-tree factories.
- `docs/CONSISTENCY.md` invariant 1 (non-interference) re-stated: the old wording promised extenders never conflict — the exact claim the corruption hid behind.

## Verification

- TDD throughout: both repro tests confirmed RED on the base (deterministic: `fieldB` lost; stress: 11/24 deltas lost), GREEN after; RLS test confirmed RED (fail-closed `ErrNotFound`) before the `set_config` fix.
- Full root suite incl. `internal/e2e` green; `make test-all` (root + memory/sqlite/postgres) green; `go vet` all modules; `make race` green plus `-race` on the changed packages (`app`, `internal/domain/entity`, `plugins/postgres`).
- Fresh-context code review (verdict: ready with fixes — all applied) and fresh-context security review (PASS WITH NOTES — both notes fixed here) completed.

No new error code, no API-shape change: the retryable 409 `CONFLICT` envelope already exists for concurrent writes — this conforms the schema-extend path to the existing FCW contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLzH3YYHjgyHt2m8LkhQQ