### PR TITLE
fix(cluster): cross-node dispatch failover + secret-rotation and nonce-cap docs

### DIFF
--- a/cmd/cyoda/help/content/cluster.md
+++ b/cmd/cyoda/help/content/cluster.md
@@ -75,7 +75,7 @@ Rotating the secret therefore requires full-cluster downtime: stop all nodes, up
 
 ## DISPATCH REPLAY PROTECTION
 
-Each node keeps an in-memory replay cache of dispatch-envelope nonces: entries live for 60 seconds (twice the 30-second timestamp-skew window) and the cache holds at most 100 000 nonces, per node. The cache is fail-closed: when full, new dispatch envelopes are rejected as replays until entries expire, surfacing to the forwarding node as a retryable failure (which dispatch failover routes around). The ceiling leaves roughly 10× headroom over the maximum sustained cross-node dispatch rate; reaching it in practice indicates a flood, not normal load.
+Each node keeps an in-memory replay cache of dispatch-envelope nonces: entries live for 60 seconds (twice the 30-second timestamp-skew window) and the cache holds at most 100 000 nonces, per node. The cache is fail-closed: when full, new dispatch envelopes are rejected as replays until entries expire, surfacing to the forwarding node as a retryable failure (which dispatch failover routes around). The ceiling admits roughly 1 600 sustained inbound cross-node dispatches per second per node (100 000 nonces per 60-second window) — far above realistic callout rates; reaching it indicates a flood, not normal load.
 
 ## COMPUTE CALLBACK TRANSACTION ROUTING
 

--- a/cmd/cyoda/help/content/cluster.md
+++ b/cmd/cyoda/help/content/cluster.md
@@ -54,7 +54,7 @@ The HTTP and gRPC frontends inspect the token, verify the HMAC, and either handl
 - Token signature mismatch, malformed token, or expired token — `400 Bad Request` (codes `BAD_REQUEST` / `TRANSACTION_EXPIRED`); the client must restart the transaction.
 - Owner node not in the registry, marked dead by gossip, or unreachable from the proxy — `503 Service Unavailable` (code `TRANSACTION_NODE_UNAVAILABLE`); PostgreSQL has already aborted the connection's transaction on the dead node, so the client retries from scratch. Fail-closed semantics, no orphaned transactions.
 
-`CYODA_HMAC_SECRET` is a deployment secret. All nodes in a cluster must share the same value; it is also the root key for peer-to-peer dispatch authentication (HKDF-derived AEAD), so rotating it requires a cluster-wide restart.
+`CYODA_HMAC_SECRET` is a deployment secret. All nodes in a cluster must share the same value; it is also the root key for peer-to-peer dispatch authentication (HKDF-derived AEAD), so rotating it requires a cluster-wide restart — see `SECRET ROTATION`.
 
 ## OPERATIONS
 
@@ -62,6 +62,20 @@ The HTTP and gRPC frontends inspect the token, verify the HMAC, and either handl
 - **Shrinking the cluster.** Send SIGTERM. The node finishes in-flight requests, declares itself dead via gossip, and exits. Outstanding transactions owned by the departing node abort cleanly via PostgreSQL connection close.
 - **Rolling restart.** Restart one node at a time, waiting for `/readyz` to report ready before moving on. Transactions in flight on the restarting node abort; clients retry.
 - **Network partitions.** A node partitioned from peers but still reachable from PostgreSQL continues to serve requests; gossip-level membership is best-effort and does not gate request handling. A node partitioned from PostgreSQL continues to pass `/readyz` (readiness is a static initialization flag plus the panic-recovery health flag, not a live store probe — see `app/app.go ReadinessCheck`); individual requests fail at query time and the client retries. The full partition analysis (5 phases, dispatch and CRUD-callback paths) is in `docs/ARCHITECTURE.md` §4.5.
+
+## CROSS-NODE DISPATCH FAILOVER
+
+When a callout (processor, criterion, or scheduled function) needs a compute tag no local member serves, the node forwards it to a peer advertising the tag. If the forward fails at the transport level (peer unreachable) or the peer reports it no longer has a matching member, the node fails over to the next tag-matching peer, trying each peer at most once. Failures indicating the callout actually ran on the peer (e.g. `DISPATCH_TIMEOUT`) are never retried on another peer. When all peers are exhausted, the last failure surfaces as a retryable `503`.
+
+## SECRET ROTATION
+
+`CYODA_HMAC_SECRET` is the single root secret for three primitives: gossip encryption, inter-node dispatch authentication (HKDF-derived AES-256-GCM), and transaction-routing token signing. There is no versioned-key support, so nodes holding different secrets cannot interoperate: a node started with a mismatched secret fails its gossip join and exits at startup, and dispatch requests between mismatched nodes are rejected with `403`. Failure is loud — never a silent split-brain.
+
+Rotating the secret therefore requires full-cluster downtime: stop all nodes, update the secret everywhere, start the cluster again. A rolling restart across a secret change is not possible. In-flight transactions and routing tokens do not survive the restart; clients retry from scratch.
+
+## DISPATCH REPLAY PROTECTION
+
+Each node keeps an in-memory replay cache of dispatch-envelope nonces: entries live for 60 seconds (twice the 30-second timestamp-skew window) and the cache holds at most 100 000 nonces, per node. The cache is fail-closed: when full, new dispatch envelopes are rejected as replays until entries expire, surfacing to the forwarding node as a retryable failure (which dispatch failover routes around). The ceiling leaves roughly 10× headroom over the maximum sustained cross-node dispatch rate; reaching it in practice indicates a flood, not normal load.
 
 ## COMPUTE CALLBACK TRANSACTION ROUTING
 

--- a/cmd/cyoda/help/content/config/cluster.md
+++ b/cmd/cyoda/help/content/config/cluster.md
@@ -22,7 +22,7 @@ config.cluster — multi-node clustering, gossip, and cross-node dispatch env va
 - `CYODA_GOSSIP_ADDR` (string, default: `:7946`) — gossip protocol listen address; format `[host]:port` — parsed via `net.SplitHostPort`; invalid format causes startup failure.
 - `CYODA_GOSSIP_STABILITY_WINDOW` (duration, default: `2s`) — gossip stability window.
 - `CYODA_SEED_NODES` (string, default: empty) — comma-separated list of seed node addresses (e.g., `node1.example.com:7946,node2.example.com:7946`); empty means single-node or seed-discovery handled externally.
-- `CYODA_HMAC_SECRET` (string, default: unset) — hex-encoded HMAC secret for inter-node dispatch authentication; required when `CYODA_CLUSTER_ENABLED=true`. Supports `_FILE` suffix.
+- `CYODA_HMAC_SECRET` (string, default: unset) — hex-encoded HMAC secret for inter-node dispatch authentication; required when `CYODA_CLUSTER_ENABLED=true`. Supports `_FILE` suffix. Single root secret for gossip encryption, dispatch AEAD, and tx-token signing; no versioned-key rotation — changing it requires a full-cluster stop/start (see the `cluster` help topic, `SECRET ROTATION`).
 - `CYODA_PROXY_TIMEOUT` (duration, default: `30s`) — request proxy timeout.
 - `CYODA_DISPATCH_WAIT_TIMEOUT` (duration, default: `5s`) — how long the dispatcher polls gossip for a compute member with matching tags.
 - `CYODA_DISPATCH_FORWARD_TIMEOUT` (duration, default: `30s`) — HTTP timeout for the cross-node forwarding call.

--- a/internal/cluster/dispatch/cluster_dispatcher.go
+++ b/internal/cluster/dispatch/cluster_dispatcher.go
@@ -71,14 +71,7 @@ func NewClusterDispatcher(
 func (d *ClusterDispatcher) DispatchProcessor(ctx context.Context, entity *spi.Entity, processor spi.ProcessorDefinition, workflowName string, transitionName string, txID string) (*spi.Entity, error) {
 	// Mint the owner token once before the local-vs-forward split so that
 	// a callback landing on a peer node routes back to this (owner) node.
-	tok := ""
-	if txID != "" && d.signer != nil {
-		if t, err := d.signer.Issue(d.selfNodeID, txID, time.Now().Add(d.tokenTTL)); err == nil {
-			tok = t
-		} else {
-			slog.Error("failed to mint tx-token", "pkg", "dispatch", "err", err)
-		}
-	}
+	tok := d.mintTxToken(txID)
 	ctx = internalgrpc.WithTxToken(ctx, tok)
 
 	// Try local first.
@@ -99,25 +92,15 @@ func (d *ClusterDispatcher) DispatchProcessor(ctx context.Context, entity *spi.E
 
 	req := d.buildProcessorRequest(entity, processor, workflowName, transitionName, txID, uc, tags, tok)
 
-	peer, err := d.findPeerWithPolling(ctx, tenantID, tags)
+	resp, peerID, err := d.forwardWithFailover(ctx, tenantID, tags, "processor", req)
 	if err != nil {
 		return nil, err
-	}
-
-	slog.Debug("forwarding processor to peer",
-		"pkg", "dispatch", "peer", peer.NodeID, "addr", peer.Addr, "tags", tags)
-
-	resp, err := d.forwarder.ForwardCallout(ctx, peer.Addr, req)
-	if err != nil {
-		slog.Error("forward callout to peer failed", "pkg", "dispatch", "kind", "processor", "peer", peer.NodeID, "err", err)
-		return nil, common.Operational(http.StatusServiceUnavailable, common.ErrCodeDispatchForwardFailed,
-			forwardFailedClientMessage).AsRetryable()
 	}
 	if !resp.Success {
 		if resp.ErrorCode != "" {
 			return nil, remintPeerError(*resp)
 		}
-		slog.Warn("peer processor dispatch failed", "pkg", "dispatch", "peer", peer.NodeID, "error", resp.Error)
+		slog.Warn("peer processor dispatch failed", "pkg", "dispatch", "peer", peerID, "error", resp.Error)
 		return nil, fmt.Errorf("peer dispatch failed")
 	}
 	for _, w := range resp.Warnings {
@@ -136,14 +119,7 @@ func (d *ClusterDispatcher) DispatchProcessor(ctx context.Context, entity *spi.E
 func (d *ClusterDispatcher) DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (bool, string, error) {
 	// Mint the owner token once before the local-vs-forward split so that
 	// a callback landing on a peer node routes back to this (owner) node.
-	tok := ""
-	if txID != "" && d.signer != nil {
-		if t, err := d.signer.Issue(d.selfNodeID, txID, time.Now().Add(d.tokenTTL)); err == nil {
-			tok = t
-		} else {
-			slog.Error("failed to mint tx-token", "pkg", "dispatch", "err", err)
-		}
-	}
+	tok := d.mintTxToken(txID)
 	ctx = internalgrpc.WithTxToken(ctx, tok)
 
 	// Try local first.
@@ -164,25 +140,15 @@ func (d *ClusterDispatcher) DispatchCriteria(ctx context.Context, entity *spi.En
 
 	req := d.buildCriteriaRequest(entity, criterion, target, workflowName, transitionName, processorName, txID, uc, tags, tok)
 
-	peer, err := d.findPeerWithPolling(ctx, tenantID, tags)
+	resp, peerID, err := d.forwardWithFailover(ctx, tenantID, tags, "criteria", req)
 	if err != nil {
 		return false, "", err
-	}
-
-	slog.Debug("forwarding criteria to peer",
-		"pkg", "dispatch", "peer", peer.NodeID, "addr", peer.Addr, "tags", tags)
-
-	resp, err := d.forwarder.ForwardCallout(ctx, peer.Addr, req)
-	if err != nil {
-		slog.Error("forward callout to peer failed", "pkg", "dispatch", "kind", "criteria", "peer", peer.NodeID, "err", err)
-		return false, "", common.Operational(http.StatusServiceUnavailable, common.ErrCodeDispatchForwardFailed,
-			forwardFailedClientMessage).AsRetryable()
 	}
 	if !resp.Success {
 		if resp.ErrorCode != "" {
 			return false, "", remintPeerError(*resp)
 		}
-		slog.Warn("peer criteria dispatch failed", "pkg", "dispatch", "peer", peer.NodeID, "error", resp.Error)
+		slog.Warn("peer criteria dispatch failed", "pkg", "dispatch", "peer", peerID, "error", resp.Error)
 		return false, "", fmt.Errorf("peer dispatch failed")
 	}
 	for _, w := range resp.Warnings {
@@ -198,14 +164,7 @@ func (d *ClusterDispatcher) DispatchCriteria(ctx context.Context, entity *spi.En
 func (d *ClusterDispatcher) DispatchFunction(ctx context.Context, entity *spi.Entity, fn spi.ScheduleFunction, workflowName string, transitionName string, txID string) (contract.FunctionResult, error) {
 	// Mint the owner token once before the local-vs-forward split so that
 	// a callback landing on a peer node routes back to this (owner) node.
-	tok := ""
-	if txID != "" && d.signer != nil {
-		if t, err := d.signer.Issue(d.selfNodeID, txID, time.Now().Add(d.tokenTTL)); err == nil {
-			tok = t
-		} else {
-			slog.Error("failed to mint tx-token", "pkg", "dispatch", "err", err)
-		}
-	}
+	tok := d.mintTxToken(txID)
 	ctx = internalgrpc.WithTxToken(ctx, tok)
 
 	// Try local first.
@@ -226,25 +185,15 @@ func (d *ClusterDispatcher) DispatchFunction(ctx context.Context, entity *spi.En
 
 	req := d.buildFunctionRequest(entity, fn, workflowName, transitionName, txID, uc, tags, tok)
 
-	peer, err := d.findPeerWithPolling(ctx, tenantID, tags)
+	resp, peerID, err := d.forwardWithFailover(ctx, tenantID, tags, "function", req)
 	if err != nil {
 		return contract.FunctionResult{}, err
-	}
-
-	slog.Debug("forwarding function to peer",
-		"pkg", "dispatch", "peer", peer.NodeID, "addr", peer.Addr, "tags", tags)
-
-	resp, err := d.forwarder.ForwardCallout(ctx, peer.Addr, req)
-	if err != nil {
-		slog.Error("forward callout to peer failed", "pkg", "dispatch", "kind", "function", "peer", peer.NodeID, "err", err)
-		return contract.FunctionResult{}, common.Operational(http.StatusServiceUnavailable, common.ErrCodeDispatchForwardFailed,
-			forwardFailedClientMessage).AsRetryable()
 	}
 	if !resp.Success {
 		if resp.ErrorCode != "" {
 			return contract.FunctionResult{}, remintPeerError(*resp)
 		}
-		slog.Warn("peer function dispatch failed", "pkg", "dispatch", "peer", peer.NodeID, "error", resp.Error)
+		slog.Warn("peer function dispatch failed", "pkg", "dispatch", "peer", peerID, "error", resp.Error)
 		return contract.FunctionResult{}, fmt.Errorf("peer dispatch failed")
 	}
 	for _, w := range resp.Warnings {
@@ -254,16 +203,92 @@ func (d *ClusterDispatcher) DispatchFunction(ctx context.Context, entity *spi.En
 	return contract.FunctionResult{Kind: resp.ResultKind, Value: resp.Result}, nil
 }
 
+// mintTxToken issues the signed tx-routing token for txID, or "" when there
+// is no transaction or no signer. Mint failure is logged, not fatal: the
+// dispatch proceeds without cross-node callback routing.
+func (d *ClusterDispatcher) mintTxToken(txID string) string {
+	if txID == "" || d.signer == nil {
+		return ""
+	}
+	t, err := d.signer.Issue(d.selfNodeID, txID, time.Now().Add(d.tokenTTL))
+	if err != nil {
+		slog.Error("failed to mint tx-token", "pkg", "dispatch", "err", err)
+		return ""
+	}
+	return t
+}
+
+// forwardWithFailover forwards req to a tag-matching peer, failing over to
+// the next tag-matching peer when the attempt provably did not dispatch the
+// callout: a transport-level forward error (peer unreachable/degraded), or a
+// peer answering NO_COMPUTE_MEMBER_FOR_TAG (it lost its matching calculation
+// member between gossip advertisement and forward — nothing executed). Any
+// other peer-classified failure means the callout was actually dispatched;
+// re-executing it on another peer is not the dispatcher's call, so the
+// response is returned unchanged for the caller to remint.
+//
+// Note on the transport-error case: the request may have reached the peer
+// before the connection died, so a failover retry can re-execute the callout.
+// That does not weaken existing semantics — this failure class already
+// surfaces as retryable (DISPATCH_FORWARD_FAILED), telling the client to
+// re-drive the whole dispatch; the failover hop automates that same retry.
+//
+// Each peer is tried at most once. When all tag-matching peers are exhausted,
+// the LAST failure surfaces with the same taxonomy the single-attempt path
+// produced. Returns the responding peer's NodeID alongside the response for
+// caller-side logging.
+func (d *ClusterDispatcher) forwardWithFailover(ctx context.Context, tenantID, tags, kind string, req DispatchCalloutRequest) (*DispatchCalloutResponse, string, error) {
+	tried := make(map[string]bool)
+	peer, err := d.findPeerWithPolling(ctx, tenantID, tags, tried)
+	if err != nil {
+		return nil, "", err
+	}
+
+	for {
+		slog.Debug("forwarding callout to peer",
+			"pkg", "dispatch", "kind", kind, "peer", peer.NodeID, "addr", peer.Addr, "tags", tags)
+
+		resp, fwdErr := d.forwarder.ForwardCallout(ctx, peer.Addr, req)
+		if fwdErr == nil && (resp.Success || resp.ErrorCode != common.ErrCodeNoComputeMemberForTag) {
+			return resp, peer.NodeID, nil
+		}
+
+		tried[peer.NodeID] = true
+		if fwdErr != nil {
+			slog.Error("forward callout to peer failed", "pkg", "dispatch", "kind", kind, "peer", peer.NodeID, "err", fwdErr)
+		} else {
+			slog.Warn("peer lost matching calculation member, trying next peer",
+				"pkg", "dispatch", "kind", kind, "peer", peer.NodeID, "tags", tags)
+		}
+
+		if ctx.Err() != nil {
+			return nil, "", ctx.Err()
+		}
+
+		next, found := d.findPeer(ctx, tenantID, tags, tried)
+		if !found {
+			// All tag-matching peers tried — surface the last failure.
+			if fwdErr != nil {
+				return nil, "", common.Operational(http.StatusServiceUnavailable, common.ErrCodeDispatchForwardFailed,
+					forwardFailedClientMessage).AsRetryable()
+			}
+			return resp, peer.NodeID, nil
+		}
+		peer = next
+	}
+}
+
 // findPeerWithPolling polls the gossip registry for a peer with matching tags,
-// retrying every gossipPollInterval up to waitTimeout.
-func (d *ClusterDispatcher) findPeerWithPolling(ctx context.Context, tenantID string, tags string) (contract.NodeInfo, error) {
+// retrying every gossipPollInterval up to waitTimeout. Peers in exclude are
+// skipped.
+func (d *ClusterDispatcher) findPeerWithPolling(ctx context.Context, tenantID string, tags string, exclude map[string]bool) (contract.NodeInfo, error) {
 	deadline := time.After(d.waitTimeout)
 	ticker := time.NewTicker(gossipPollInterval)
 	defer ticker.Stop()
 
 	// Try immediately first, then poll.
 	for {
-		peer, found := d.findPeer(ctx, tenantID, tags)
+		peer, found := d.findPeer(ctx, tenantID, tags, exclude)
 		if found {
 			return peer, nil
 		}
@@ -280,9 +305,9 @@ func (d *ClusterDispatcher) findPeerWithPolling(ctx context.Context, tenantID st
 	}
 }
 
-// findPeer queries the registry and returns a peer (not self, alive) whose tags
-// for the given tenant overlap with the required tags.
-func (d *ClusterDispatcher) findPeer(ctx context.Context, tenantID string, tags string) (contract.NodeInfo, bool) {
+// findPeer queries the registry and returns a peer (not self, alive, not in
+// exclude) whose tags for the given tenant overlap with the required tags.
+func (d *ClusterDispatcher) findPeer(ctx context.Context, tenantID string, tags string, exclude map[string]bool) (contract.NodeInfo, bool) {
 	nodes, err := d.registry.List(ctx)
 	if err != nil {
 		slog.Debug("failed to list cluster nodes", "pkg", "dispatch", "err", err)
@@ -295,6 +320,9 @@ func (d *ClusterDispatcher) findPeer(ctx context.Context, tenantID string, tags 
 			continue
 		}
 		if !n.Alive {
+			continue
+		}
+		if exclude[n.NodeID] {
 			continue
 		}
 		if common.TagsOverlap(n.Tags[tenantID], tags) {

--- a/internal/cluster/dispatch/cluster_dispatcher.go
+++ b/internal/cluster/dispatch/cluster_dispatcher.go
@@ -220,7 +220,9 @@ func (d *ClusterDispatcher) mintTxToken(txID string) string {
 
 // forwardWithFailover forwards req to a tag-matching peer, failing over to
 // the next tag-matching peer when the attempt provably did not dispatch the
-// callout: a transport-level forward error (peer unreachable/degraded), or a
+// callout: a transport-level forward error (peer unreachable/degraded — this
+// class also covers peer HTTP-status rejections such as a 403 auth/replay
+// refusal, which the forwarder folds into the forward error), or a
 // peer answering NO_COMPUTE_MEMBER_FOR_TAG (it lost its matching calculation
 // member between gossip advertisement and forward — nothing executed). Any
 // other peer-classified failure means the callout was actually dispatched;
@@ -261,13 +263,15 @@ func (d *ClusterDispatcher) forwardWithFailover(ctx context.Context, tenantID, t
 				"pkg", "dispatch", "kind", kind, "peer", peer.NodeID, "tags", tags)
 		}
 
-		if ctx.Err() != nil {
-			return nil, "", ctx.Err()
+		// A dead context ends the failover exactly like peer exhaustion: the
+		// last failure surfaces with its usual taxonomy (retryable 503) — not
+		// a bare ctx error, which classifyWorkflowError would collapse into a
+		// non-retryable 400 WORKFLOW_FAILED.
+		next, found := contract.NodeInfo{}, false
+		if ctx.Err() == nil {
+			next, found = d.findPeer(ctx, tenantID, tags, tried)
 		}
-
-		next, found := d.findPeer(ctx, tenantID, tags, tried)
 		if !found {
-			// All tag-matching peers tried — surface the last failure.
 			if fwdErr != nil {
 				return nil, "", common.Operational(http.StatusServiceUnavailable, common.ErrCodeDispatchForwardFailed,
 					forwardFailedClientMessage).AsRetryable()

--- a/internal/cluster/dispatch/cluster_dispatcher_failover_test.go
+++ b/internal/cluster/dispatch/cluster_dispatcher_failover_test.go
@@ -262,6 +262,52 @@ func TestClusterDispatcher_FailoverExhaustion(t *testing.T) {
 	})
 }
 
+// cancellingForwarder cancels the request context and then fails at the
+// transport level, simulating the caller's deadline expiring mid-forward.
+type cancellingForwarder struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (f *cancellingForwarder) ForwardCallout(_ context.Context, _ string, _ DispatchCalloutRequest) (*DispatchCalloutResponse, error) {
+	f.calls++
+	f.cancel()
+	return nil, errors.New("context canceled")
+}
+
+// TestClusterDispatcher_CtxCancelledMidForwardKeepsTaxonomy: a context that
+// dies DURING the forward attempt must surface the same retryable 503
+// DISPATCH_FORWARD_FAILED the single-attempt path always produced — not a
+// bare ctx error that classifyWorkflowError collapses into a non-retryable
+// 400 WORKFLOW_FAILED. The dispatcher must also stop failing over: no
+// further peers are attempted on a dead context.
+func TestClusterDispatcher_CtxCancelledMidForwardKeepsTaxonomy(t *testing.T) {
+	local := &stubDispatcher{noMember: true}
+	ctx, cancel := context.WithCancel(testContext())
+	defer cancel()
+
+	fwd := &cancellingForwarder{cancel: cancel}
+	d := NewClusterDispatcher(local, twoPeerRegistry("http://bad", "http://good"), "self-node", firstSelector{}, fwd, 1*time.Second, nil, 0)
+
+	_, err := d.DispatchProcessor(ctx, testEntity(), testProcessor(), "wf", "tr", "tx1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+	}
+	if appErr.Code != common.ErrCodeDispatchForwardFailed {
+		t.Fatalf("expected code %s, got %s", common.ErrCodeDispatchForwardFailed, appErr.Code)
+	}
+	if appErr.Status != http.StatusServiceUnavailable || !appErr.Retryable {
+		t.Fatalf("expected retryable 503, got status=%d retryable=%v", appErr.Status, appErr.Retryable)
+	}
+	if fwd.calls != 1 {
+		t.Fatalf("expected no failover on a dead context, got %d attempts", fwd.calls)
+	}
+}
+
 // TestClusterDispatcher_FailoverOverWire is the acceptance-criterion test:
 // one degraded peer (listener closed — connection refused) and one healthy
 // peer both advertise the tag; cross-node dispatch succeeds via failover

--- a/internal/cluster/dispatch/cluster_dispatcher_failover_test.go
+++ b/internal/cluster/dispatch/cluster_dispatcher_failover_test.go
@@ -1,0 +1,301 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/contract"
+)
+
+// firstSelector always picks the first candidate, making peer selection
+// deterministic: with the dispatcher excluding already-tried peers from the
+// candidate list, registry order dictates the failover order.
+type firstSelector struct{}
+
+func (firstSelector) Select(candidates []contract.NodeInfo) (contract.NodeInfo, error) {
+	if len(candidates) == 0 {
+		return contract.NodeInfo{}, errors.New("no candidates")
+	}
+	return candidates[0], nil
+}
+
+// scriptedForwarder is a DispatchForwarder test double with per-address
+// scripted outcomes and a call log, so failover tests can degrade one peer
+// and assert exactly which peers were attempted, in which order.
+type scriptedForwarder struct {
+	byAddr map[string]struct {
+		resp *DispatchCalloutResponse
+		err  error
+	}
+	calls []string
+}
+
+func newScriptedForwarder() *scriptedForwarder {
+	return &scriptedForwarder{byAddr: map[string]struct {
+		resp *DispatchCalloutResponse
+		err  error
+	}{}}
+}
+
+func (f *scriptedForwarder) script(addr string, resp *DispatchCalloutResponse, err error) {
+	f.byAddr[addr] = struct {
+		resp *DispatchCalloutResponse
+		err  error
+	}{resp, err}
+}
+
+func (f *scriptedForwarder) ForwardCallout(_ context.Context, addr string, _ DispatchCalloutRequest) (*DispatchCalloutResponse, error) {
+	f.calls = append(f.calls, addr)
+	s, ok := f.byAddr[addr]
+	if !ok {
+		return nil, fmt.Errorf("scriptedForwarder: no script for addr %q", addr)
+	}
+	return s.resp, s.err
+}
+
+// twoPeerRegistry returns a registry advertising the "python" tag for
+// tenant-1 on two peers, listed bad-first so firstSelector tries the
+// degraded peer before the healthy one.
+func twoPeerRegistry(badAddr, goodAddr string) *stubNodeRegistry {
+	return &stubNodeRegistry{
+		nodes: []contract.NodeInfo{
+			{NodeID: "peer-bad", Addr: badAddr, Alive: true, Tags: map[string][]string{"tenant-1": {"python"}}},
+			{NodeID: "peer-good", Addr: goodAddr, Alive: true, Tags: map[string][]string{"tenant-1": {"python"}}},
+		},
+	}
+}
+
+func noMemberResponse() *DispatchCalloutResponse {
+	return &DispatchCalloutResponse{
+		Success:        false,
+		Error:          "dispatch processor failed",
+		ErrorCode:      common.ErrCodeNoComputeMemberForTag,
+		ErrorStatus:    http.StatusServiceUnavailable,
+		ErrorRetryable: true,
+	}
+}
+
+// TestClusterDispatcher_FailoverOnTransportError: the selected peer is
+// unreachable at the transport level; the dispatcher must retry the other
+// healthy tag-matching peer instead of surfacing DISPATCH_FORWARD_FAILED.
+func TestClusterDispatcher_FailoverOnTransportError(t *testing.T) {
+	local := &stubDispatcher{noMember: true}
+
+	newDispatcher := func(fwd DispatchForwarder) *ClusterDispatcher {
+		return NewClusterDispatcher(local, twoPeerRegistry("http://bad", "http://good"), "self-node", firstSelector{}, fwd, 1*time.Second, nil, 0)
+	}
+
+	t.Run("processor", func(t *testing.T) {
+		fwd := newScriptedForwarder()
+		fwd.script("http://bad", nil, errors.New("connection refused"))
+		fwd.script("http://good", &DispatchCalloutResponse{Success: true, EntityData: []byte(`{"key":"peer-processed"}`)}, nil)
+		d := newDispatcher(fwd)
+
+		result, err := d.DispatchProcessor(testContext(), testEntity(), testProcessor(), "wf", "tr", "tx1")
+		if err != nil {
+			t.Fatalf("expected failover success, got %v", err)
+		}
+		if string(result.Data) != `{"key":"peer-processed"}` {
+			t.Fatalf("expected peer-processed data, got %s", string(result.Data))
+		}
+		if len(fwd.calls) != 2 || fwd.calls[0] != "http://bad" || fwd.calls[1] != "http://good" {
+			t.Fatalf("expected [bad, good] attempt order, got %v", fwd.calls)
+		}
+	})
+
+	t.Run("criteria", func(t *testing.T) {
+		fwd := newScriptedForwarder()
+		fwd.script("http://bad", nil, errors.New("connection refused"))
+		matches := true
+		fwd.script("http://good", &DispatchCalloutResponse{Success: true, Matches: &matches, Reason: "peer reason"}, nil)
+		d := newDispatcher(fwd)
+
+		got, reason, err := d.DispatchCriteria(testContext(), testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx1")
+		if err != nil {
+			t.Fatalf("expected failover success, got %v", err)
+		}
+		if !got || reason != "peer reason" {
+			t.Fatalf("expected matches=true with peer reason, got %v %q", got, reason)
+		}
+		if len(fwd.calls) != 2 {
+			t.Fatalf("expected 2 attempts, got %v", fwd.calls)
+		}
+	})
+
+	t.Run("function", func(t *testing.T) {
+		fwd := newScriptedForwarder()
+		fwd.script("http://bad", nil, errors.New("connection refused"))
+		fwd.script("http://good", &DispatchCalloutResponse{Success: true, ResultKind: "Schedule", Result: []byte(`{"fireAfterMs":1000}`)}, nil)
+		d := newDispatcher(fwd)
+
+		result, err := d.DispatchFunction(testContext(), testEntity(), testFunction(), "wf", "tr", "tx1")
+		if err != nil {
+			t.Fatalf("expected failover success, got %v", err)
+		}
+		if result.Kind != "Schedule" {
+			t.Fatalf("expected Kind=Schedule, got %q", result.Kind)
+		}
+		if len(fwd.calls) != 2 {
+			t.Fatalf("expected 2 attempts, got %v", fwd.calls)
+		}
+	})
+}
+
+// TestClusterDispatcher_FailoverOnPeerNoMember: the peer answered but had
+// lost its matching calculation member between gossip advertisement and
+// forward (NO_COMPUTE_MEMBER_FOR_TAG — nothing executed). The dispatcher
+// must try the next tag-matching peer.
+func TestClusterDispatcher_FailoverOnPeerNoMember(t *testing.T) {
+	local := &stubDispatcher{noMember: true}
+	fwd := newScriptedForwarder()
+	fwd.script("http://bad", noMemberResponse(), nil)
+	fwd.script("http://good", &DispatchCalloutResponse{Success: true, EntityData: []byte(`{"key":"peer-processed"}`)}, nil)
+	d := NewClusterDispatcher(local, twoPeerRegistry("http://bad", "http://good"), "self-node", firstSelector{}, fwd, 1*time.Second, nil, 0)
+
+	result, err := d.DispatchProcessor(testContext(), testEntity(), testProcessor(), "wf", "tr", "tx1")
+	if err != nil {
+		t.Fatalf("expected failover success, got %v", err)
+	}
+	if string(result.Data) != `{"key":"peer-processed"}` {
+		t.Fatalf("expected peer-processed data, got %s", string(result.Data))
+	}
+	if len(fwd.calls) != 2 || fwd.calls[0] != "http://bad" || fwd.calls[1] != "http://good" {
+		t.Fatalf("expected [bad, good] attempt order, got %v", fwd.calls)
+	}
+}
+
+// TestClusterDispatcher_NoFailoverOnExecutedCalloutFailure: any peer failure
+// other than NO_COMPUTE_MEMBER_FOR_TAG means the callout was actually
+// dispatched on the peer (e.g. DISPATCH_TIMEOUT — the compute member ran or
+// may have run). The dispatcher must NOT re-execute it on another peer; the
+// peer's classification propagates unchanged.
+func TestClusterDispatcher_NoFailoverOnExecutedCalloutFailure(t *testing.T) {
+	local := &stubDispatcher{noMember: true}
+	fwd := newScriptedForwarder()
+	fwd.script("http://bad", &DispatchCalloutResponse{
+		Success:        false,
+		Error:          "dispatch processor failed",
+		ErrorCode:      common.ErrCodeDispatchTimeout,
+		ErrorStatus:    http.StatusServiceUnavailable,
+		ErrorRetryable: true,
+	}, nil)
+	fwd.script("http://good", &DispatchCalloutResponse{Success: true}, nil)
+	d := NewClusterDispatcher(local, twoPeerRegistry("http://bad", "http://good"), "self-node", firstSelector{}, fwd, 1*time.Second, nil, 0)
+
+	_, err := d.DispatchProcessor(testContext(), testEntity(), testProcessor(), "wf", "tr", "tx1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+	}
+	if appErr.Code != common.ErrCodeDispatchTimeout {
+		t.Fatalf("expected code %s, got %s", common.ErrCodeDispatchTimeout, appErr.Code)
+	}
+	if len(fwd.calls) != 1 || fwd.calls[0] != "http://bad" {
+		t.Fatalf("expected exactly one attempt against the first peer, got %v", fwd.calls)
+	}
+}
+
+// TestClusterDispatcher_FailoverExhaustion: when every tag-matching peer
+// fails, each is tried at most once and the LAST failure surfaces with the
+// same taxonomy the single-attempt path produced.
+func TestClusterDispatcher_FailoverExhaustion(t *testing.T) {
+	local := &stubDispatcher{noMember: true}
+
+	t.Run("all_transport_errors_surface_forward_failed", func(t *testing.T) {
+		fwd := newScriptedForwarder()
+		fwd.script("http://bad", nil, errors.New("connection refused"))
+		fwd.script("http://good", nil, errors.New("connection refused"))
+		d := NewClusterDispatcher(local, twoPeerRegistry("http://bad", "http://good"), "self-node", firstSelector{}, fwd, 1*time.Second, nil, 0)
+
+		_, err := d.DispatchProcessor(testContext(), testEntity(), testProcessor(), "wf", "tr", "tx1")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		var appErr *common.AppError
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+		}
+		if appErr.Code != common.ErrCodeDispatchForwardFailed {
+			t.Fatalf("expected code %s, got %s", common.ErrCodeDispatchForwardFailed, appErr.Code)
+		}
+		if appErr.Status != http.StatusServiceUnavailable || !appErr.Retryable {
+			t.Fatalf("expected retryable 503, got status=%d retryable=%v", appErr.Status, appErr.Retryable)
+		}
+		if len(fwd.calls) != 2 {
+			t.Fatalf("expected each peer tried exactly once, got %v", fwd.calls)
+		}
+	})
+
+	t.Run("all_peers_lost_member_surface_no_compute_member", func(t *testing.T) {
+		fwd := newScriptedForwarder()
+		fwd.script("http://bad", noMemberResponse(), nil)
+		fwd.script("http://good", noMemberResponse(), nil)
+		d := NewClusterDispatcher(local, twoPeerRegistry("http://bad", "http://good"), "self-node", firstSelector{}, fwd, 1*time.Second, nil, 0)
+
+		_, err := d.DispatchProcessor(testContext(), testEntity(), testProcessor(), "wf", "tr", "tx1")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		var appErr *common.AppError
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+		}
+		if appErr.Code != common.ErrCodeNoComputeMemberForTag {
+			t.Fatalf("expected code %s, got %s", common.ErrCodeNoComputeMemberForTag, appErr.Code)
+		}
+		if appErr.Status != http.StatusServiceUnavailable || !appErr.Retryable {
+			t.Fatalf("expected retryable 503, got status=%d retryable=%v", appErr.Status, appErr.Retryable)
+		}
+		if len(fwd.calls) != 2 {
+			t.Fatalf("expected each peer tried exactly once, got %v", fwd.calls)
+		}
+	})
+}
+
+// TestClusterDispatcher_FailoverOverWire is the acceptance-criterion test:
+// one degraded peer (listener closed — connection refused) and one healthy
+// peer both advertise the tag; cross-node dispatch succeeds via failover
+// through the real HTTP + AEAD forward path.
+func TestClusterDispatcher_FailoverOverWire(t *testing.T) {
+	auth, _ := NewAEADPeerAuth(testSecret32, 30*time.Second)
+
+	peerLocal := &stubDispatcher{
+		processorResp: &spi.Entity{
+			Meta: testEntity().Meta,
+			Data: []byte(`{"key":"peer-processed"}`),
+		},
+	}
+	handler := NewDispatchHandler(peerLocal, auth)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	healthy := httptest.NewServer(mux)
+	defer healthy.Close()
+
+	// A server that is immediately closed: its address refuses connections.
+	degraded := httptest.NewServer(http.NotFoundHandler())
+	degradedURL := degraded.URL
+	degraded.Close()
+
+	local := &stubDispatcher{noMember: true}
+	registry := twoPeerRegistry(degradedURL, healthy.URL)
+	forwarder := NewHTTPForwarder(auth, 5*time.Second).AllowLoopbackForTesting()
+	d := NewClusterDispatcher(local, registry, "self-node", firstSelector{}, forwarder, 1*time.Second, nil, 0)
+
+	result, err := d.DispatchProcessor(testContext(), testEntity(), testProcessor(), "wf", "tr", "tx1")
+	if err != nil {
+		t.Fatalf("expected failover success, got %v", err)
+	}
+	if string(result.Data) != `{"key":"peer-processed"}` {
+		t.Fatalf("expected peer-processed data, got %s", string(result.Data))
+	}
+}

--- a/internal/cluster/dispatch/nonce_cache.go
+++ b/internal/cluster/dispatch/nonce_cache.go
@@ -12,9 +12,9 @@ import (
 //
 // Fail-closed on capacity: when the cache is full, checkAndRecord reports
 // *seen* for any new nonce. The caller surfaces this as a replay rejection.
-// At realistic cluster rates (max ~10k dispatch/s) and a 60s TTL, a 100k
-// ceiling leaves a 10x headroom over sustained load; an attacker flood fails
-// closed rather than letting stale entries linger.
+// The 100k ceiling over the 60s TTL window admits ~1,600 sustained inbound
+// dispatches/s per node — far above realistic cross-node callout rates; an
+// attacker flood fails closed rather than letting stale entries linger.
 type nonceCache struct {
 	ttl     time.Duration
 	cap     int


### PR DESCRIPTION
Closes #364 (release-branch merge won't auto-close — close manually at merge time).

## What

- **Cross-node dispatch failover.** A degraded peer no longer fails ~1/N of cross-node callouts. The three dispatch paths (processor / criteria / function) now share `forwardWithFailover`, which retries the next healthy tag-matching peer when the attempt provably did not dispatch the callout: a transport-level forward error, or the peer answering `NO_COMPUTE_MEMBER_FOR_TAG` (stale gossip advertisement — nothing executed). Failures that mean the callout actually ran on the peer (e.g. `DISPATCH_TIMEOUT`, domain errors) propagate unchanged — re-executing them elsewhere is not the dispatcher's call. Each peer is tried at most once; on exhaustion (or a context that dies mid-failover) the last failure surfaces with the same taxonomy as the old single-attempt path.
- **Docs.** The `cluster` help topic gains CROSS-NODE DISPATCH FAILOVER, SECRET ROTATION (single root secret keys gossip encryption, dispatch AEAD, and tx-token signing; no versioned keys; rotation requires full-cluster stop/start; mismatch fails loudly at startup — never silent split-brain), and DISPATCH REPLAY PROTECTION (per-node nonce cache: 60 s window, 100 k cap, fail-closed). The `config.cluster` topic's `CYODA_HMAC_SECRET` entry cross-references SECRET ROTATION.
- The tx-routing token primitive is untouched (superseded item in the issue — it stays and becomes load-bearing via #287/#367). The tx-token minting preamble, previously duplicated across the three dispatch methods, is folded into `mintTxToken` (pure refactor).

## Notes for review

- The issue's acceptance criterion says "≥2 healthy peers"; the tests stage one degraded + one healthy peer with a deterministic degraded-first selector — the strongest form of the scenario — and the exhaustion tests cover the multi-peer exclusion set. Not a narrowing, just the deterministic staging.
- Transport-error failover can re-execute a callout whose request reached the peer before the connection died. This does not weaken existing semantics: that failure class already surfaced as retryable (`DISPATCH_FORWARD_FAILED`), telling the client to re-drive the whole dispatch; the failover hop automates that same retry.
- No gossip-driven multinode e2e scenario was added: the interesting degraded case is "gossip still advertises a dead member", which real gossip actively converges away from — it can't be staged deterministically in the multinode harness. The over-wire test covers the real forward stack (HTTP + AEAD + handler) with a connection-refused peer.
- Fresh-context review ran; both Important findings are fixed in the last commit: ctx-cancellation mid-forward keeps the retryable-503 taxonomy (test-pinned), and the nonce-cap "10× headroom over 10k/s" claim — which didn't survive arithmetic — now states the real number (~1,600 sustained inbound dispatches/s per node) in both the code comment and the help topic.

## Testing

- New tests (written RED-first): failover on transport error (all three callout kinds), failover on peer no-member, no failover on executed-callout failures (exactly-one-attempt pinned), exhaustion taxonomy for both failure classes, ctx-cancel taxonomy, and an over-the-wire acceptance test (real HTTP + AEAD, degraded + healthy peer).
- `go test ./...` (incl. E2E) green; `go vet ./...` clean; `make race` clean; `go test -race ./internal/cluster/dispatch/` green on the final HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLzH3YYHjgyHt2m8LkhQQ