### PR TITLE
fix(auth/oidc): reload preserves and force-warms JWKS key sources; retry recovers boot-race keyless providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,21 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **`POST /api/oauth/oidc/providers/reload` no longer destroys the JWKS key cache
+  it is documented to refresh.** The reload rebuilt the provider list but installed
+  empty key sources and never re-warmed them, so every federated token failed with
+  **401** `unknown kid` until a process restart — including tokens of providers that
+  were healthy before the call. The reload now carries surviving key sources across
+  the rebuild and force-warms every loaded provider (on the receiving node and, in a
+  cluster, on every broadcast peer); a provider whose IdP is unreachable during the
+  refresh keeps serving its previously cached keys.
+
+- **A provider whose IdP was unreachable during the startup JWKS warm-up no longer
+  stays keyless for the life of the process.** The warm-up was one-shot — if cyoda
+  booted ahead of the IdP, every federated token failed with **401** until a restart
+  that won the race. Failed warm-ups are now retried every 30 seconds until the IdP
+  becomes reachable, and the recovery is logged.
+
 - **Resolving a transaction's submit time is now tenant-gated.** `GetSubmitTime`
   was the only transaction-lifecycle method without the tenant check the rest of
   the surface enforces: a caller supplying another tenant's transaction ID —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,8 +222,10 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   **401** `unknown kid` until a process restart — including tokens of providers that
   were healthy before the call. The reload now carries surviving key sources across
   the rebuild and force-warms every loaded provider (on the receiving node and, in a
-  cluster, on every broadcast peer); a provider whose IdP is unreachable during the
-  refresh keeps serving its previously cached keys.
+  cluster, on every broadcast peer); invalidated providers are excluded — their
+  endpoints are explicitly distrusted. A provider whose discovery fetch fails
+  during the refresh keeps its previously cached keys, with freshness still
+  governed by the standard JWKS cache TTL (fail closed).
 
 - **A provider whose IdP was unreachable during the startup JWKS warm-up no longer
   stays keyless for the life of the process.** The warm-up was one-shot — if cyoda

--- a/app/app.go
+++ b/app/app.go
@@ -318,7 +318,13 @@ func New(cfg Config) *App {
 			cfg.IAM.OIDC.RequireHTTPS,
 			cfg.IAM.OIDC.AllowPrivateNetworks,
 		)
-		pendingWarmJWKS = func() { oidcRegistry.WarmJWKSAsync(systemCtx) }
+		// Phase-2 warm-up is one-shot; the retry loop re-attempts any provider
+		// whose IdP was unreachable at that moment (e.g. cyoda boots ahead of
+		// the IdP), so federated auth recovers without a restart.
+		pendingWarmJWKS = func() {
+			oidcRegistry.WarmJWKSAsync(systemCtx)
+			oidcRegistry.StartWarmupRetryLoop(systemCtx)
+		}
 
 		authSvc, err = auth.NewAuthService(auth.AuthConfig{
 			SigningKeyPEM:   cfg.IAM.JWTSigningKey,

--- a/app/app.go
+++ b/app/app.go
@@ -322,7 +322,7 @@ func New(cfg Config) *App {
 		// whose IdP was unreachable at that moment (e.g. cyoda boots ahead of
 		// the IdP), so federated auth recovers without a restart.
 		pendingWarmJWKS = func() {
-			oidcRegistry.WarmJWKSAsync(systemCtx)
+			oidcRegistry.WarmJWKS(systemCtx)
 			oidcRegistry.StartWarmupRetryLoop(systemCtx)
 		}
 

--- a/cmd/cyoda/help/content/auth/oidc.md
+++ b/cmd/cyoda/help/content/auth/oidc.md
@@ -132,7 +132,7 @@ curl -X POST https://cyoda.example.com/api/oauth/oidc/providers/reload \
   -H "Authorization: Bearer ${ADMIN_TOKEN}"
 ```
 
-Forces an immediate JWKS refresh for every active provider on the receiving node. In a multi-node cluster the reload is broadcast. Providers whose IdP is unreachable during the refresh keep serving their previously cached keys.
+Forces an immediate JWKS refresh for every active provider on the receiving node. In a multi-node cluster the reload is broadcast. A provider whose discovery fetch fails during the refresh keeps its previously cached keys (freshness remains subject to the standard JWKS cache TTL).
 
 ### Present an IdP-issued JWT
 

--- a/cmd/cyoda/help/content/auth/oidc.md
+++ b/cmd/cyoda/help/content/auth/oidc.md
@@ -73,7 +73,7 @@ Response (`200 OK`) carries the full provider DTO:
 }
 ```
 
-Registration succeeds even when the IdP's discovery / JWKS endpoints are unreachable — cyoda warms them asynchronously after the response. Tokens issued by an un-warmed provider fail with `401 UNAUTHORIZED` until the next warmup cycle (or an explicit `/reload`). See **DIAGNOSTICS** below for the operator path.
+Registration succeeds even when the IdP's discovery / JWKS endpoints are unreachable — cyoda warms them asynchronously after the response and retries failed warm-ups every 30 seconds until the IdP becomes reachable. Tokens issued by an un-warmed provider fail with `401 UNAUTHORIZED` until a warm-up succeeds (or an explicit `/reload`). See **DIAGNOSTICS** below for the operator path.
 
 Behaviour on `expectedAudiences`:
 
@@ -132,7 +132,7 @@ curl -X POST https://cyoda.example.com/api/oauth/oidc/providers/reload \
   -H "Authorization: Bearer ${ADMIN_TOKEN}"
 ```
 
-Forces an immediate JWKS refresh for every active provider on the receiving node. In a multi-node cluster the reload is broadcast.
+Forces an immediate JWKS refresh for every active provider on the receiving node. In a multi-node cluster the reload is broadcast. Providers whose IdP is unreachable during the refresh keep serving their previously cached keys.
 
 ### Present an IdP-issued JWT
 
@@ -184,7 +184,7 @@ The diagnostic path for every failure mode is **server-side logs**, not the HTTP
 
 Symptom → cause map for the common cases:
 
-- **"I get 401 but my token looks valid":** check `oidc.registry` resolve logs. The most common cause is the provider's JWKS hasn't warmed yet (registration succeeds before discovery completes); force-warm via `/oauth/oidc/providers/reload`.
+- **"I get 401 but my token looks valid":** check `oidc.registry` resolve logs. The most common cause is the provider's JWKS hasn't warmed yet (registration succeeds before discovery completes); force-warm via `/oauth/oidc/providers/reload`, or wait for the automatic warm-up retry (every 30 seconds).
 - **"After re-registering, valid tokens are rejected":** the second-most-common case — two tenants registered the same IdP with overlapping or empty `expectedAudiences`. Internally `ErrAmbiguousProvider` (`internal/auth/oidc/registry.go`) wraps to `ErrUnknownKID`. To resolve, pick disjoint `expectedAudiences` per tenant.
 - **"Tokens reject for the right tenant but the IdP is up":** verify the JWT `iss` claim matches either an explicit `issuers` entry or the discovery document's `issuer` byte-for-byte. Trailing slashes count.
 

--- a/e2e/parity/oidc.go
+++ b/e2e/parity/oidc.go
@@ -3179,3 +3179,83 @@ func RunOidcReactivateAudiencesRoundTrip(t *testing.T, fix BackendFixture) {
 		t.Errorf("rolesClaim after reactivate: got %v, want %q", reactivated.RolesClaim, wantRoles)
 	}
 }
+
+// RunOidcReload_PreservesTokenAcceptance verifies that POST
+// /oauth/oidc/providers/reload against a healthy, warm provider does not
+// break token validation: a fresh token minted after the reload is still
+// accepted. Guards the reload path against reverting to a cache flush.
+func RunOidcReload_PreservesTokenAcceptance(t *testing.T, fix BackendFixture) {
+	admin := fix.NewTenant(t)
+	adminC := client.NewClient(fix.BaseURL(), admin.Token)
+
+	idp := NewParityFixtureIdP(t)
+	if _, err := adminC.RegisterOidcProvider(t, map[string]any{
+		"wellKnownConfigUri": idp.WellKnownURI(),
+	}); err != nil {
+		t.Fatalf("RegisterOidcProvider: %v", err)
+	}
+
+	// Baseline: fresh token accepted.
+	token := idp.MintTenantJWT(t, idp.DefaultKid, admin.ID)
+	probeC := client.NewClient(fix.BaseURL(), token)
+	status, body, err := probeC.ProbeAuthRaw(t)
+	if err != nil {
+		t.Fatalf("baseline ProbeAuthRaw transport: %v", err)
+	}
+	assertProbeStatus(t, http.StatusOK, status, body)
+
+	if err := adminC.ReloadOidcProviders(t); err != nil {
+		t.Fatalf("ReloadOidcProviders: %v", err)
+	}
+
+	// A fresh token minted after the reload must still be accepted.
+	token = idp.MintTenantJWT(t, idp.DefaultKid, admin.ID)
+	probeC = client.NewClient(fix.BaseURL(), token)
+	status, body, err = probeC.ProbeAuthRaw(t)
+	if err != nil {
+		t.Fatalf("post-reload ProbeAuthRaw transport: %v", err)
+	}
+	assertProbeStatus(t, http.StatusOK, status, body)
+}
+
+// RunOidcReload_AfterReactivateKeepsTokenAcceptance runs the full
+// invalidate → reactivate → reload lifecycle and verifies a fresh token is
+// accepted at the end: the reload must not undo the reactivation's re-warm.
+func RunOidcReload_AfterReactivateKeepsTokenAcceptance(t *testing.T, fix BackendFixture) {
+	admin := fix.NewTenant(t)
+	adminC := client.NewClient(fix.BaseURL(), admin.Token)
+
+	idp := NewParityFixtureIdP(t)
+	p, err := adminC.RegisterOidcProvider(t, map[string]any{
+		"wellKnownConfigUri": idp.WellKnownURI(),
+	})
+	if err != nil {
+		t.Fatalf("RegisterOidcProvider: %v", err)
+	}
+
+	token := idp.MintTenantJWT(t, idp.DefaultKid, admin.ID)
+	probeC := client.NewClient(fix.BaseURL(), token)
+	status, body, err := probeC.ProbeAuthRaw(t)
+	if err != nil {
+		t.Fatalf("baseline ProbeAuthRaw transport: %v", err)
+	}
+	assertProbeStatus(t, http.StatusOK, status, body)
+
+	if err := adminC.InvalidateOidcProvider(t, p.ID); err != nil {
+		t.Fatalf("InvalidateOidcProvider: %v", err)
+	}
+	if _, err := adminC.ReactivateOidcProviderWithKeys(t, p.ID, true); err != nil {
+		t.Fatalf("ReactivateOidcProviderWithKeys: %v", err)
+	}
+	if err := adminC.ReloadOidcProviders(t); err != nil {
+		t.Fatalf("ReloadOidcProviders: %v", err)
+	}
+
+	token = idp.MintTenantJWT(t, idp.DefaultKid, admin.ID)
+	probeC = client.NewClient(fix.BaseURL(), token)
+	status, body, err = probeC.ProbeAuthRaw(t)
+	if err != nil {
+		t.Fatalf("post-lifecycle ProbeAuthRaw transport: %v", err)
+	}
+	assertProbeStatus(t, http.StatusOK, status, body)
+}

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 231 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 233 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -220,6 +220,9 @@ var allTests = []NamedTest{
 	{"OidcJWTValidation_DeletePermanent", RunOidcJWTValidation_DeletePermanent},
 	// Issuer-list update affects validation (row 21).
 	{"OidcJWTValidation_IssuerListUpdate", RunOidcJWTValidation_IssuerListUpdate},
+	// Reload endpoint keeps warm key sources in service.
+	{"OidcReload_PreservesTokenAcceptance", RunOidcReload_PreservesTokenAcceptance},
+	{"OidcReload_AfterReactivateKeepsTokenAcceptance", RunOidcReload_AfterReactivateKeepsTokenAcceptance},
 	// Key rotation/revocation (rows 22-26b).
 	{"OidcKeyRotation_NewKidAccepted", RunOidcKeyRotation_NewKidAccepted},
 	{"OidcKeyRotation_OldKidStillAccepted", RunOidcKeyRotation_OldKidStillAccepted},

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 231
+const wantParityScenarioCount = 233
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/internal/auth/oidc/broadcast.go
+++ b/internal/auth/oidc/broadcast.go
@@ -88,7 +88,7 @@ func (r *Registry) handleBroadcast(payload []byte) {
 		}))
 	case "reload_all":
 		r.singleflight.Dispatch("_reload_all", r.safeDispatch(func() {
-			_ = r.ReloadAll(context.Background())
+			_ = r.ReloadAllAndWarm(context.Background())
 		}))
 	default:
 		r.logger.Debug("oidc broadcast: unknown op", "pkg", "oidc", "op", env.Op)

--- a/internal/auth/oidc/registry.go
+++ b/internal/auth/oidc/registry.go
@@ -90,6 +90,12 @@ type Registry struct {
 	// warmupRetryStarted makes StartWarmupRetryLoop's call-once contract
 	// self-enforcing: a second call is a no-op.
 	warmupRetryStarted atomic.Bool
+
+	// reloadWarmMu serializes ReloadAllAndWarm: concurrent force-warm calls
+	// (an admin looping the reload endpoint, or endpoint + broadcast racing)
+	// queue behind one fetch pool instead of multiplying outbound traffic to
+	// every tenant's IdP.
+	reloadWarmMu sync.Mutex
 }
 
 // NewRegistry constructs the registry. broadcast may be nil in tests or
@@ -527,6 +533,8 @@ func (r *Registry) ReloadAll(ctx context.Context) error {
 // disconnecting mid-request cannot leave it half-completed. Each fetch is
 // individually bounded by the discovery/JWKS transport timeouts.
 func (r *Registry) ReloadAllAndWarm(ctx context.Context) error {
+	r.reloadWarmMu.Lock()
+	defer r.reloadWarmMu.Unlock()
 	if err := r.ReloadAll(ctx); err != nil {
 		return err
 	}
@@ -700,10 +708,12 @@ func (r *Registry) reloadOneInternal(ctx context.Context, tenant spi.TenantID, u
 	// E2 fetch-time pin enforcement: when the admin has pinned Issuers, the
 	// discovery doc's issuer field MUST be in that list. An IdP returning a
 	// mismatching issuer is either misconfigured or attacker-controlled; in
-	// either case, refuse to install the source. The provider remains in
-	// Phase-2-pending state — ResolveKey returns ErrUnknownKID until the admin
-	// reconciles. Raw issuer strings are never logged (A1+B1 lessons); only
-	// SHA-256 hashes and counts are emitted.
+	// either case, refuse to install a source AND drop any existing one —
+	// unlike a transient fetch failure, this is an affirmative conflict with
+	// the binding the cached keys were fetched under, so keeping them serving
+	// would fail open. The provider ends keyless — ResolveKey returns
+	// ErrUnknownKID until the admin reconciles. Raw issuer strings are never
+	// logged (A1+B1 lessons); only SHA-256 hashes and counts are emitted.
 	if len(prov.Issuers) > 0 {
 		issMatchesPin := false
 		for _, allowed := range prov.Issuers {
@@ -721,6 +731,13 @@ func (r *Registry) reloadOneInternal(ctx context.Context, tenant spi.TenantID, u
 				"pinned_count", len(prov.Issuers),
 			)
 			r.metrics.IncJWKSFetchError("issuer_pin_mismatch")
+			func() {
+				r.mu.Lock()
+				defer r.mu.Unlock()
+				if byURI, ok := r.sources[tenant]; ok {
+					delete(byURI, uri)
+				}
+			}()
 			return
 		}
 	}

--- a/internal/auth/oidc/registry.go
+++ b/internal/auth/oidc/registry.go
@@ -579,7 +579,7 @@ func (r *Registry) WarmJWKS(ctx context.Context) {
 		go func() {
 			defer wg.Done()
 			for ref := range jobs {
-				r.reloadOne(ctx, ref.tenant, ref.uri)
+				r.warmOneSafely(ctx, ref)
 			}
 		}()
 	}
@@ -610,7 +610,7 @@ func (r *Registry) StartWarmupRetryLoop(ctx context.Context) bool {
 				return
 			case <-ticker.C:
 				for _, ref := range r.coldActiveRefs() {
-					r.reloadOne(ctx, ref.tenant, ref.uri)
+					r.warmOneSafely(ctx, ref)
 					if !r.isCold(ref) {
 						r.logger.Info("oidc: provider JWKS warmed by retry loop",
 							"pkg", "oidc", "tenant", string(ref.tenant),
@@ -621,6 +621,22 @@ func (r *Registry) StartWarmupRetryLoop(ctx context.Context) bool {
 		}
 	}()
 	return true
+}
+
+// warmOneSafely runs reloadOne with a recover layer: the warm pool's worker
+// goroutines and the retry-loop goroutine have no caller to propagate a
+// panic to, so an unrecovered panic there would crash the process. Same
+// contract as safeDispatch on the broadcast path; log-only here — the
+// broadcast panic counter stays broadcast-scoped.
+func (r *Registry) warmOneSafely(ctx context.Context, ref providerRef) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			r.logger.Error("oidc: warm-up panic",
+				"pkg", "oidc", "tenant", string(ref.tenant),
+				"uri_hash", sha256Hex(ref.uri), "panic", rec)
+		}
+	}()
+	r.reloadOne(ctx, ref.tenant, ref.uri)
 }
 
 // coldActiveRefs returns the coordinates of active providers whose key

--- a/internal/auth/oidc/registry.go
+++ b/internal/auth/oidc/registry.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
@@ -85,6 +86,10 @@ type Registry struct {
 	metrics      Metrics
 	logger       *slog.Logger
 	cfg          RegistryConfig
+
+	// warmupRetryStarted makes StartWarmupRetryLoop's call-once contract
+	// self-enforcing: a second call is a no-op.
+	warmupRetryStarted atomic.Bool
 }
 
 // NewRegistry constructs the registry. broadcast may be nil in tests or
@@ -469,9 +474,11 @@ func (r *Registry) EvictKidEntry(kid string, ref providerRef) {
 // Key sources survive the swap: every installed source whose (tenant, uri)
 // coordinate is still present in the fresh store snapshot is carried over,
 // so a reload is never a cache flush — tokens verified by a warm provider
-// keep verifying even if no warm-up follows or the IdP is unreachable.
-// Sources whose provider vanished from the store are dropped, and the
-// kidIndex is rebuilt lazily by the ResolveKey cold path.
+// keep verifying even if no warm-up follows or its discovery fetch fails.
+// Key freshness is still governed by the JWKS cache TTL (stale keys that
+// cannot be re-confirmed stop validating — fail closed). Sources whose
+// provider vanished from the store are dropped, and the kidIndex is rebuilt
+// lazily by the ResolveKey cold path.
 func (r *Registry) ReloadAll(ctx context.Context) error {
 	providers, err := r.store.LoadAll(ctx)
 	if err != nil {
@@ -508,15 +515,22 @@ func (r *Registry) ReloadAll(ctx context.Context) error {
 
 // ReloadAllAndWarm is the force-warm reload used by the reload endpoint and
 // the cluster reload_all broadcast: rebuild from KV, then synchronously
-// re-fetch discovery + JWKS for every loaded provider. Per-provider warm-up
-// failures are non-fatal (WARN-logged by reloadOne); the carried-over source
-// keeps serving in that case. Startup phase 1 (LoadProvidersFromKV) must NOT
-// use this — the listener-bind ordering requires warm-up to stay async there.
+// re-fetch discovery + JWKS for every loaded active provider. A failed
+// discovery fetch is non-fatal (WARN-logged by reloadOne) and leaves the
+// carried-over source in place; a successful one installs a fresh source
+// whose key freshness is governed by the standard JWKS cache TTL, fail-closed.
+// Startup phase 1 (LoadProvidersFromKV) must NOT use this — the listener-bind
+// ordering requires warm-up to stay async there.
+//
+// The warm phase is a cluster-visible operation triggered by an admin call;
+// it runs detached from the caller's cancellation so an HTTP client
+// disconnecting mid-request cannot leave it half-completed. Each fetch is
+// individually bounded by the discovery/JWKS transport timeouts.
 func (r *Registry) ReloadAllAndWarm(ctx context.Context) error {
 	if err := r.ReloadAll(ctx); err != nil {
 		return err
 	}
-	r.WarmJWKSAsync(ctx)
+	r.WarmJWKS(context.WithoutCancel(ctx))
 	return nil
 }
 
@@ -525,16 +539,22 @@ func (r *Registry) LoadProvidersFromKV(ctx context.Context) error {
 	return r.ReloadAll(ctx)
 }
 
-// WarmJWKSAsync is Phase-2 startup warmup. It spawns a bounded worker pool
-// that fetches discovery + JWKS for every loaded provider. Per-provider
-// failures are WARN-logged; the goroutine does not block startup.
-func (r *Registry) WarmJWKSAsync(ctx context.Context) {
+// WarmJWKS fetches discovery + JWKS for every loaded ACTIVE provider through
+// a bounded worker pool and blocks until the pool drains — callers that must
+// not block (the phase-2 startup hook) wrap it in their own goroutine, and
+// ReloadAllAndWarm relies on it being synchronous. Per-provider failures are
+// WARN-logged and skipped. Invalidated providers are never fetched: their
+// endpoints are explicitly distrusted, and reactivation re-warms explicitly.
+func (r *Registry) WarmJWKS(ctx context.Context) {
 	var refs []providerRef
 	func() {
 		r.mu.RLock()
 		defer r.mu.RUnlock()
 		for tenant, byURI := range r.providers {
-			for uri := range byURI {
+			for uri, prov := range byURI {
+				if !prov.Active() {
+					continue
+				}
 				refs = append(refs, providerRef{tenant: tenant, uri: uri})
 			}
 		}
@@ -566,9 +586,13 @@ func (r *Registry) WarmJWKSAsync(ctx context.Context) {
 // WarmupRetryInterval it re-attempts discovery + JWKS warm-up for active
 // providers that have no installed key source (the one-shot startup warm-up
 // or a registration-time warm-up lost the race against an IdP that was not
-// yet reachable). The loop exits when ctx is cancelled. Call once at startup
-// with a process-lifetime context.
-func (r *Registry) StartWarmupRetryLoop(ctx context.Context) {
+// yet reachable). The loop exits when ctx is cancelled. Called once at
+// startup with a process-lifetime context; returns false (and starts
+// nothing) if the loop is already running.
+func (r *Registry) StartWarmupRetryLoop(ctx context.Context) bool {
+	if !r.warmupRetryStarted.CompareAndSwap(false, true) {
+		return false
+	}
 	go func() {
 		ticker := time.NewTicker(r.cfg.WarmupRetryInterval)
 		defer ticker.Stop()
@@ -588,6 +612,7 @@ func (r *Registry) StartWarmupRetryLoop(ctx context.Context) {
 			}
 		}
 	}()
+	return true
 }
 
 // coldActiveRefs returns the coordinates of active providers whose key

--- a/internal/auth/oidc/registry.go
+++ b/internal/auth/oidc/registry.go
@@ -61,6 +61,12 @@ type RegistryConfig struct {
 	// SocketTimeout is applied as the ResponseHeaderTimeout on the JWKS-fetch
 	// transport. Zero or negative values default to 5 s.
 	SocketTimeout time.Duration
+
+	// WarmupRetryInterval is the tick interval of StartWarmupRetryLoop, which
+	// re-attempts the JWKS warm-up of active providers that have no installed
+	// key source (e.g. the IdP was unreachable at startup or registration).
+	// Zero or negative values default to 30 s.
+	WarmupRetryInterval time.Duration
 }
 
 // Registry is the per-process OIDC provider cache. It implements the read
@@ -103,6 +109,9 @@ func NewRegistry(
 	}
 	if cfg.SocketTimeout <= 0 {
 		cfg.SocketTimeout = 5 * time.Second
+	}
+	if cfg.WarmupRetryInterval <= 0 {
+		cfg.WarmupRetryInterval = 30 * time.Second
 	}
 	r := &Registry{
 		providers:    map[spi.TenantID]map[string]*OidcProvider{},
@@ -551,6 +560,63 @@ func (r *Registry) WarmJWKSAsync(ctx context.Context) {
 	}
 	close(jobs)
 	wg.Wait()
+}
+
+// StartWarmupRetryLoop spawns the warm-up retry goroutine: every
+// WarmupRetryInterval it re-attempts discovery + JWKS warm-up for active
+// providers that have no installed key source (the one-shot startup warm-up
+// or a registration-time warm-up lost the race against an IdP that was not
+// yet reachable). The loop exits when ctx is cancelled. Call once at startup
+// with a process-lifetime context.
+func (r *Registry) StartWarmupRetryLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(r.cfg.WarmupRetryInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				for _, ref := range r.coldActiveRefs() {
+					r.reloadOne(ctx, ref.tenant, ref.uri)
+					if !r.isCold(ref) {
+						r.logger.Info("oidc: provider JWKS warmed by retry loop",
+							"pkg", "oidc", "tenant", string(ref.tenant),
+							"uri_hash", sha256Hex(ref.uri))
+					}
+				}
+			}
+		}
+	}()
+}
+
+// coldActiveRefs returns the coordinates of active providers whose key
+// source is missing or whose discovery doc never arrived — the set the
+// warm-up retry loop re-attempts.
+func (r *Registry) coldActiveRefs() []providerRef {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var refs []providerRef
+	for tenant, byURI := range r.providers {
+		for uri, prov := range byURI {
+			if !prov.Active() {
+				continue
+			}
+			src := r.sources[tenant][uri]
+			if src == nil || src.discoveryDoc == nil {
+				refs = append(refs, providerRef{tenant: tenant, uri: uri})
+			}
+		}
+	}
+	return refs
+}
+
+// isCold reports whether ref still lacks an installed source.
+func (r *Registry) isCold(ref providerRef) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	src := r.sources[ref.tenant][ref.uri]
+	return src == nil || src.discoveryDoc == nil
 }
 
 // reloadOne fetches discovery + JWKS for one (tenant, uri) provider and

--- a/internal/auth/oidc/registry.go
+++ b/internal/auth/oidc/registry.go
@@ -456,6 +456,13 @@ func (r *Registry) EvictKidEntry(kid string, ref providerRef) {
 // ReloadAll rebuilds the in-memory provider map from KV (D18). The new maps
 // are built off-lock; the swap takes the write lock so no partial-rebuild
 // state is ever visible to concurrent readers.
+//
+// Key sources survive the swap: every installed source whose (tenant, uri)
+// coordinate is still present in the fresh store snapshot is carried over,
+// so a reload is never a cache flush — tokens verified by a warm provider
+// keep verifying even if no warm-up follows or the IdP is unreachable.
+// Sources whose provider vanished from the store are dropped, and the
+// kidIndex is rebuilt lazily by the ResolveKey cold path.
 func (r *Registry) ReloadAll(ctx context.Context) error {
 	providers, err := r.store.LoadAll(ctx)
 	if err != nil {
@@ -472,15 +479,35 @@ func (r *Registry) ReloadAll(ctx context.Context) error {
 			newSrc[tenant] = map[string]*providerSource{}
 		}
 		newProv[tenant][p.WellKnownConfigURI] = p
-		// Sources are populated by Phase-2 warmup / individual reloadOne calls.
 	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	for tenant, byURI := range r.sources {
+		for uri, src := range byURI {
+			if _, still := newProv[tenant][uri]; still {
+				newSrc[tenant][uri] = src
+			}
+		}
+	}
 	r.providers = newProv
 	r.sources = newSrc
 	r.kidIndex = map[string][]providerRef{}
 	r.metrics.SetRegistryProviders(len(providers))
+	return nil
+}
+
+// ReloadAllAndWarm is the force-warm reload used by the reload endpoint and
+// the cluster reload_all broadcast: rebuild from KV, then synchronously
+// re-fetch discovery + JWKS for every loaded provider. Per-provider warm-up
+// failures are non-fatal (WARN-logged by reloadOne); the carried-over source
+// keeps serving in that case. Startup phase 1 (LoadProvidersFromKV) must NOT
+// use this — the listener-bind ordering requires warm-up to stay async there.
+func (r *Registry) ReloadAllAndWarm(ctx context.Context) error {
+	if err := r.ReloadAll(ctx); err != nil {
+		return err
+	}
+	r.WarmJWKSAsync(ctx)
 	return nil
 }
 

--- a/internal/auth/oidc/reload_warmup_test.go
+++ b/internal/auth/oidc/reload_warmup_test.go
@@ -23,14 +23,19 @@ import (
 // flakyDiscovery is a mutable, concurrency-safe Discovery fake: err can be
 // flipped at runtime to simulate an IdP that is down and later comes up.
 type flakyDiscovery struct {
-	mu   sync.Mutex
-	docs map[string]*DiscoveryDoc
-	err  error
+	mu      sync.Mutex
+	docs    map[string]*DiscoveryDoc
+	err     error
+	fetches map[string]int
 }
 
 func (f *flakyDiscovery) Fetch(_ context.Context, uri string) (*DiscoveryDoc, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.fetches == nil {
+		f.fetches = map[string]int{}
+	}
+	f.fetches[uri]++
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -47,6 +52,12 @@ func (f *flakyDiscovery) set(err error, docs map[string]*DiscoveryDoc) {
 	if docs != nil {
 		f.docs = docs
 	}
+}
+
+func (f *flakyDiscovery) fetchCount(uri string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.fetches[uri]
 }
 
 // plantProvider persists p in the registry's store so ReloadAll finds it.
@@ -170,6 +181,99 @@ func TestService_ReloadAll_KeepsCachedKeysWhenIdPUnreachable(t *testing.T) {
 
 	if _, err := r.ResolveKey("k1", "https://idp.example", ""); err != nil {
 		t.Fatalf("ResolveKey after ReloadAll with IdP down: %v (cached keys were destroyed)", err)
+	}
+}
+
+func TestRegistry_WarmupRetryLoop_WarmsWhenIdPComesUp(t *testing.T) {
+	// The one-shot startup warm-up loses the race against an IdP that boots
+	// later than cyoda. The retry loop must keep re-attempting the warm-up
+	// until the IdP is reachable — without any lifecycle call or restart.
+	idp := NewFixtureIdP(t)
+	uri := idp.Issuer + "/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &flakyDiscovery{err: ErrDiscoveryFailed}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true, WarmupRetryInterval: 20 * time.Millisecond})
+
+	p := testProvider(idp.Issuer, uri)
+	plantProvider(t, r, p)
+	ctx := context.Background()
+	if err := r.LoadProvidersFromKV(ctx); err != nil {
+		t.Fatalf("LoadProvidersFromKV: %v", err)
+	}
+	r.WarmJWKSAsync(ctx) // one-shot warm-up fails: IdP still down
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	r.StartWarmupRetryLoop(loopCtx)
+
+	if _, err := r.ResolveKey("default", idp.Issuer, ""); !errors.Is(err, auth.ErrUnknownKID) {
+		t.Fatalf("ResolveKey while IdP down = %v, want ErrUnknownKID", err)
+	}
+
+	// IdP comes up.
+	disc.set(nil, map[string]*DiscoveryDoc{uri: {Issuer: idp.Issuer, JWKSURI: idp.JWKSURI}})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := r.ResolveKey("default", idp.Issuer, ""); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("provider never warmed by the retry loop after the IdP came up")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestRegistry_WarmupRetryLoop_SkipsWarmAndInactiveProviders(t *testing.T) {
+	// The retry loop must not refetch providers that are already warm, nor
+	// invalidated providers — only active, cold ones.
+	warmIdP := NewFixtureIdP(t)
+	warmURI := warmIdP.Issuer + "/.well-known/openid-configuration"
+	inactiveURI := "https://inactive.example/.well-known/openid-configuration"
+	store := newTestStore(t)
+	// The inactive provider's discovery doc is deliberately absent during the
+	// one-shot warm-up so its coordinate stays cold — otherwise it would be
+	// skipped as "already warm" and never exercise the active-only check.
+	disc := &flakyDiscovery{docs: map[string]*DiscoveryDoc{
+		warmURI: {Issuer: warmIdP.Issuer, JWKSURI: warmIdP.JWKSURI},
+	}}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true, WarmupRetryInterval: 20 * time.Millisecond})
+
+	warm := testProvider(warmIdP.Issuer, warmURI)
+	plantProvider(t, r, warm)
+	inactive := testProvider("https://inactive.example", inactiveURI)
+	invalidatedAt := time.Now()
+	inactive.InvalidatedAt = &invalidatedAt
+	plantProvider(t, r, inactive)
+
+	ctx := context.Background()
+	if err := r.LoadProvidersFromKV(ctx); err != nil {
+		t.Fatalf("LoadProvidersFromKV: %v", err)
+	}
+	r.WarmJWKSAsync(ctx) // warms warmURI; inactiveURI fetch fails (no doc yet)
+	warmBaseline := disc.fetchCount(warmURI)
+	inactiveBaseline := disc.fetchCount(inactiveURI)
+
+	// From here on the inactive provider's doc IS fetchable — only the
+	// active-only check keeps the loop away from it.
+	disc.set(nil, map[string]*DiscoveryDoc{
+		warmURI:     {Issuer: warmIdP.Issuer, JWKSURI: warmIdP.JWKSURI},
+		inactiveURI: {Issuer: "https://inactive.example", JWKSURI: "https://inactive.example/jwks"},
+	})
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	r.StartWarmupRetryLoop(loopCtx)
+
+	time.Sleep(200 * time.Millisecond) // ~10 ticks
+	if n := disc.fetchCount(warmURI); n != warmBaseline {
+		t.Errorf("retry loop refetched a warm provider: %d fetches after baseline %d", n, warmBaseline)
+	}
+	if n := disc.fetchCount(inactiveURI); n != inactiveBaseline {
+		t.Errorf("retry loop fetched an invalidated provider: %d fetches after baseline %d", n, inactiveBaseline)
 	}
 }
 

--- a/internal/auth/oidc/reload_warmup_test.go
+++ b/internal/auth/oidc/reload_warmup_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/auth"
 	"github.com/google/uuid"
 )
@@ -287,6 +288,97 @@ func TestRegistry_WarmupRetryLoop_StopsOnContextCancel(t *testing.T) {
 	if after := disc.fetchCount(uri); after != before {
 		t.Errorf("retry loop still fetching after ctx cancel: %d -> %d", before, after)
 	}
+}
+
+func TestRegistry_ReloadOne_PinMismatchDropsCarriedSource(t *testing.T) {
+	// An issuer-pin mismatch is an affirmative conflict, not a transient
+	// failure: the IdP has contradicted the binding the carried keys were
+	// fetched under. The carried source must be dropped — fail closed —
+	// not kept serving like it is on an unreachable IdP.
+	uri := "https://pinned.example/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &flakyDiscovery{docs: map[string]*DiscoveryDoc{
+		uri: {Issuer: "https://rogue.example", JWKSURI: "https://pinned.example/jwks"},
+	}}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true})
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	p := testProvider("https://pinned.example", uri)
+	r.installForTest(p, &fakeKeySource{kid: "k1", key: &priv.PublicKey},
+		&DiscoveryDoc{Issuer: "https://pinned.example", JWKSURI: "https://pinned.example/jwks"})
+
+	if _, err := r.ResolveKey("k1", "https://pinned.example", ""); err != nil {
+		t.Fatalf("baseline ResolveKey: %v", err)
+	}
+
+	r.reloadOne(context.Background(), spi.TenantID(p.OwnerLegalEntityID.String()), uri)
+
+	if _, err := r.ResolveKey("k1", "https://pinned.example", ""); err == nil {
+		t.Fatal("ResolveKey still succeeds after issuer-pin mismatch (carried source not dropped)")
+	}
+}
+
+func TestRegistry_ReloadAllAndWarm_ConcurrentCallsSerialize(t *testing.T) {
+	// Concurrent force-warm reloads (e.g. an admin looping the endpoint)
+	// must serialize into one fetch pool at a time, not multiply outbound
+	// traffic to every tenant's IdP.
+	uri := "https://slow.example/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &slowCountingDiscovery{delay: 50 * time.Millisecond}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true})
+
+	p := testProvider("https://slow.example", uri)
+	plantProvider(t, r, p)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = r.ReloadAllAndWarm(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	if peak := disc.peakConcurrent(); peak > 1 {
+		t.Errorf("peak concurrent discovery fetches = %d, want 1 (warm pools not serialized)", peak)
+	}
+}
+
+// slowCountingDiscovery fails every fetch after a delay while tracking the
+// peak number of concurrent Fetch calls.
+type slowCountingDiscovery struct {
+	mu      sync.Mutex
+	current int
+	peak    int
+	delay   time.Duration
+}
+
+func (s *slowCountingDiscovery) Fetch(ctx context.Context, _ string) (*DiscoveryDoc, error) {
+	s.mu.Lock()
+	s.current++
+	if s.current > s.peak {
+		s.peak = s.current
+	}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.current--
+	}()
+	select {
+	case <-time.After(s.delay):
+	case <-ctx.Done():
+	}
+	return nil, ErrDiscoveryFailed
+}
+
+func (s *slowCountingDiscovery) peakConcurrent() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.peak
 }
 
 func TestRegistry_ReloadAll_CarriedSourceForInactiveProviderDoesNotAuthenticate(t *testing.T) {

--- a/internal/auth/oidc/reload_warmup_test.go
+++ b/internal/auth/oidc/reload_warmup_test.go
@@ -381,6 +381,99 @@ func (s *slowCountingDiscovery) peakConcurrent() int {
 	return s.peak
 }
 
+// panickyDiscovery panics on every Fetch for uris in panicOn and delegates
+// to inner otherwise. panicsLeft bounds the panics so retry-based callers
+// can observe recovery.
+type panickyDiscovery struct {
+	mu         sync.Mutex
+	inner      Discovery
+	panicOn    map[string]bool
+	panicsLeft int
+}
+
+func (p *panickyDiscovery) Fetch(ctx context.Context, uri string) (*DiscoveryDoc, error) {
+	p.mu.Lock()
+	shouldPanic := p.panicOn[uri] && p.panicsLeft != 0
+	if shouldPanic && p.panicsLeft > 0 {
+		p.panicsLeft--
+	}
+	p.mu.Unlock()
+	if shouldPanic {
+		panic("discovery exploded")
+	}
+	return p.inner.Fetch(ctx, uri)
+}
+
+func TestRegistry_WarmJWKS_SurvivesPanickingFetch(t *testing.T) {
+	// A panic inside one provider's warm-up must not crash the process (the
+	// worker pool runs on its own goroutines) and must not prevent the other
+	// providers from warming.
+	idp := NewFixtureIdP(t)
+	goodURI := idp.Issuer + "/.well-known/openid-configuration"
+	badURI := "https://exploding.example/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &panickyDiscovery{
+		inner: &flakyDiscovery{docs: map[string]*DiscoveryDoc{
+			goodURI: {Issuer: idp.Issuer, JWKSURI: idp.JWKSURI},
+		}},
+		panicOn:    map[string]bool{badURI: true},
+		panicsLeft: -1, // panic forever
+	}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true})
+
+	plantProvider(t, r, testProvider(idp.Issuer, goodURI))
+	plantProvider(t, r, testProvider("https://exploding.example", badURI))
+
+	ctx := context.Background()
+	if err := r.LoadProvidersFromKV(ctx); err != nil {
+		t.Fatalf("LoadProvidersFromKV: %v", err)
+	}
+	r.WarmJWKS(ctx) // must not crash
+
+	if _, err := r.ResolveKey("default", idp.Issuer, ""); err != nil {
+		t.Fatalf("healthy provider not warmed alongside a panicking one: %v", err)
+	}
+}
+
+func TestRegistry_WarmupRetryLoop_SurvivesPanickingFetch(t *testing.T) {
+	// A panic during one retry tick must not crash the process or kill the
+	// loop: once the discovery stops panicking, the provider still warms.
+	idp := NewFixtureIdP(t)
+	uri := idp.Issuer + "/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &panickyDiscovery{
+		inner: &flakyDiscovery{docs: map[string]*DiscoveryDoc{
+			uri: {Issuer: idp.Issuer, JWKSURI: idp.JWKSURI},
+		}},
+		panicOn:    map[string]bool{uri: true},
+		panicsLeft: 2,
+	}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true, WarmupRetryInterval: 20 * time.Millisecond})
+
+	plantProvider(t, r, testProvider(idp.Issuer, uri))
+	ctx := context.Background()
+	if err := r.LoadProvidersFromKV(ctx); err != nil {
+		t.Fatalf("LoadProvidersFromKV: %v", err)
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	r.StartWarmupRetryLoop(loopCtx)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := r.ResolveKey("default", idp.Issuer, ""); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("provider never warmed after panicking ticks (loop died?)")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 func TestRegistry_ReloadAll_CarriedSourceForInactiveProviderDoesNotAuthenticate(t *testing.T) {
 	// Fail-closed side of the carry-over: if the fresh store snapshot says a
 	// provider is invalidated, its carried key source must not authenticate,

--- a/internal/auth/oidc/reload_warmup_test.go
+++ b/internal/auth/oidc/reload_warmup_test.go
@@ -1,0 +1,203 @@
+package oidc
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/internal/auth"
+	"github.com/google/uuid"
+)
+
+// Tests for ReloadAll key-source preservation and force-warm semantics.
+//
+// Contract under test: POST /oauth/oidc/providers/reload must force-warm the
+// JWKS of every provider it reloads, and must never leave the registry with
+// fewer warm key sources than before the call. A reload against an
+// unreachable IdP keeps serving the previously cached keys.
+
+// flakyDiscovery is a mutable, concurrency-safe Discovery fake: err can be
+// flipped at runtime to simulate an IdP that is down and later comes up.
+type flakyDiscovery struct {
+	mu   sync.Mutex
+	docs map[string]*DiscoveryDoc
+	err  error
+}
+
+func (f *flakyDiscovery) Fetch(_ context.Context, uri string) (*DiscoveryDoc, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return nil, f.err
+	}
+	if d, ok := f.docs[uri]; ok {
+		return d, nil
+	}
+	return nil, ErrDiscoveryFailed
+}
+
+func (f *flakyDiscovery) set(err error, docs map[string]*DiscoveryDoc) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+	if docs != nil {
+		f.docs = docs
+	}
+}
+
+// plantProvider persists p in the registry's store so ReloadAll finds it.
+func plantProvider(t *testing.T, r *Registry, p *OidcProvider) {
+	t.Helper()
+	if err := r.store.Register(context.Background(), p); err != nil {
+		t.Fatalf("store.Register: %v", err)
+	}
+}
+
+func testProvider(issuer, uri string) *OidcProvider {
+	return &OidcProvider{
+		ID:                 uuid.New(),
+		WellKnownConfigURI: uri,
+		Issuers:            []string{issuer},
+		CreatedAt:          time.Now(),
+		OwnerLegalEntityID: uuid.New(),
+	}
+}
+
+func TestRegistry_ReloadAll_PreservesInstalledSources(t *testing.T) {
+	// A provider whose key source is already warm must keep resolving after
+	// ReloadAll rebuilds the provider map, even though no warm-up runs.
+	r := newTestRegistry(t)
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	p := testProvider("https://idp.example", "https://idp.example/.well-known/openid-configuration")
+	r.installForTest(p, &fakeKeySource{kid: "k1", key: &priv.PublicKey},
+		&DiscoveryDoc{Issuer: "https://idp.example", JWKSURI: "https://idp.example/jwks"})
+	plantProvider(t, r, p)
+
+	if _, err := r.ResolveKey("k1", "https://idp.example", ""); err != nil {
+		t.Fatalf("baseline ResolveKey: %v", err)
+	}
+
+	if err := r.ReloadAll(context.Background()); err != nil {
+		t.Fatalf("ReloadAll: %v", err)
+	}
+
+	res, err := r.ResolveKey("k1", "https://idp.example", "")
+	if err != nil {
+		t.Fatalf("ResolveKey after ReloadAll: %v (installed source was not preserved)", err)
+	}
+	if res.Provider.ID != p.ID {
+		t.Errorf("resolved provider ID = %s, want %s", res.Provider.ID, p.ID)
+	}
+}
+
+func TestRegistry_ReloadAll_DropsSourcesForRemovedProviders(t *testing.T) {
+	// A provider deleted from the store must not survive ReloadAll via a
+	// carried-over source — carry-over applies only to coordinates that the
+	// fresh store snapshot still contains.
+	r := newTestRegistry(t)
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	p := testProvider("https://gone.example", "https://gone.example/.well-known/openid-configuration")
+	r.installForTest(p, &fakeKeySource{kid: "k1", key: &priv.PublicKey},
+		&DiscoveryDoc{Issuer: "https://gone.example", JWKSURI: "https://gone.example/jwks"})
+	// NOT planted in the store: the store snapshot is empty.
+
+	if err := r.ReloadAll(context.Background()); err != nil {
+		t.Fatalf("ReloadAll: %v", err)
+	}
+
+	if _, err := r.ResolveKey("k1", "https://gone.example", ""); !errors.Is(err, auth.ErrUnknownKID) {
+		t.Fatalf("ResolveKey after ReloadAll = %v, want ErrUnknownKID for removed provider", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for tenant, byURI := range r.sources {
+		if len(byURI) != 0 {
+			t.Errorf("sources for tenant %s not dropped: %d entries", tenant, len(byURI))
+		}
+	}
+}
+
+func TestService_ReloadAll_WarmsColdProviders(t *testing.T) {
+	// A provider present in the store but never warmed on this node (e.g. the
+	// post-registration warm-up race) must be resolvable after the reload
+	// endpoint runs: Service.ReloadAll force-warms what it loads.
+	idp := NewFixtureIdP(t)
+	uri := idp.Issuer + "/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &flakyDiscovery{docs: map[string]*DiscoveryDoc{
+		uri: {Issuer: idp.Issuer, JWKSURI: idp.JWKSURI},
+	}}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true})
+	s := NewService(store, r, nil)
+
+	p := testProvider(idp.Issuer, uri)
+	plantProvider(t, r, p)
+
+	if err := s.ReloadAll(context.Background()); err != nil {
+		t.Fatalf("ReloadAll: %v", err)
+	}
+
+	if _, err := r.ResolveKey("default", idp.Issuer, ""); err != nil {
+		t.Fatalf("ResolveKey after Service.ReloadAll: %v (cold provider was not warmed)", err)
+	}
+}
+
+func TestService_ReloadAll_KeepsCachedKeysWhenIdPUnreachable(t *testing.T) {
+	// Reload with the IdP down must not destroy the working key source: the
+	// warm-up fails, the carried-over source keeps serving.
+	store := newTestStore(t)
+	disc := &flakyDiscovery{err: ErrDiscoveryFailed}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true})
+	s := NewService(store, r, nil)
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	p := testProvider("https://idp.example", "https://idp.example/.well-known/openid-configuration")
+	r.installForTest(p, &fakeKeySource{kid: "k1", key: &priv.PublicKey},
+		&DiscoveryDoc{Issuer: "https://idp.example", JWKSURI: "https://idp.example/jwks"})
+	plantProvider(t, r, p)
+
+	if err := s.ReloadAll(context.Background()); err != nil {
+		t.Fatalf("ReloadAll: %v", err)
+	}
+
+	if _, err := r.ResolveKey("k1", "https://idp.example", ""); err != nil {
+		t.Fatalf("ResolveKey after ReloadAll with IdP down: %v (cached keys were destroyed)", err)
+	}
+}
+
+func TestHandleBroadcast_ReloadAllWarmsColdProviders(t *testing.T) {
+	// The cluster reload_all broadcast is the peer-side of the reload
+	// endpoint and must force-warm too, not just swap the provider map.
+	idp := NewFixtureIdP(t)
+	uri := idp.Issuer + "/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &flakyDiscovery{docs: map[string]*DiscoveryDoc{
+		uri: {Issuer: idp.Issuer, JWKSURI: idp.JWKSURI},
+	}}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true})
+
+	p := testProvider(idp.Issuer, uri)
+	plantProvider(t, r, p)
+
+	r.handleBroadcast([]byte(`{"op":"reload_all"}`))
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := r.ResolveKey("default", idp.Issuer, ""); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("provider never warmed after reload_all broadcast")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/auth/oidc/reload_warmup_test.go
+++ b/internal/auth/oidc/reload_warmup_test.go
@@ -16,9 +16,9 @@ import (
 // Tests for ReloadAll key-source preservation and force-warm semantics.
 //
 // Contract under test: POST /oauth/oidc/providers/reload must force-warm the
-// JWKS of every provider it reloads, and must never leave the registry with
-// fewer warm key sources than before the call. A reload against an
-// unreachable IdP keeps serving the previously cached keys.
+// JWKS of every active provider it reloads, and must never leave the registry
+// with fewer warm key sources than before the call. A reload whose discovery
+// fetch fails keeps serving the previously cached keys.
 
 // flakyDiscovery is a mutable, concurrency-safe Discovery fake: err can be
 // flipped at runtime to simulate an IdP that is down and later comes up.
@@ -29,7 +29,11 @@ type flakyDiscovery struct {
 	fetches map[string]int
 }
 
-func (f *flakyDiscovery) Fetch(_ context.Context, uri string) (*DiscoveryDoc, error) {
+func (f *flakyDiscovery) Fetch(ctx context.Context, uri string) (*DiscoveryDoc, error) {
+	// Respect ctx like the real HTTPDiscovery does.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.fetches == nil {
@@ -184,6 +188,136 @@ func TestService_ReloadAll_KeepsCachedKeysWhenIdPUnreachable(t *testing.T) {
 	}
 }
 
+func TestRegistry_WarmJWKS_SkipsInactiveProviders(t *testing.T) {
+	// The warm-up must not fetch discovery/JWKS for invalidated providers:
+	// an admin has explicitly distrusted those endpoints, and reactivation
+	// re-warms explicitly.
+	inactiveURI := "https://inactive.example/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &flakyDiscovery{docs: map[string]*DiscoveryDoc{
+		inactiveURI: {Issuer: "https://inactive.example", JWKSURI: "https://inactive.example/jwks"},
+	}}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true})
+
+	inactive := testProvider("https://inactive.example", inactiveURI)
+	invalidatedAt := time.Now()
+	inactive.InvalidatedAt = &invalidatedAt
+	plantProvider(t, r, inactive)
+
+	ctx := context.Background()
+	if err := r.LoadProvidersFromKV(ctx); err != nil {
+		t.Fatalf("LoadProvidersFromKV: %v", err)
+	}
+	r.WarmJWKS(ctx)
+
+	if n := disc.fetchCount(inactiveURI); n != 0 {
+		t.Errorf("WarmJWKS fetched an invalidated provider %d times, want 0", n)
+	}
+}
+
+func TestRegistry_ReloadAllAndWarm_DetachedFromCallerCancellation(t *testing.T) {
+	// The force-warm is a cluster-visible operation: an HTTP client
+	// disconnecting mid-request must not abort it half way. The warm phase
+	// runs detached from the caller's cancellation.
+	idp := NewFixtureIdP(t)
+	uri := idp.Issuer + "/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &flakyDiscovery{docs: map[string]*DiscoveryDoc{
+		uri: {Issuer: idp.Issuer, JWKSURI: idp.JWKSURI},
+	}}
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true})
+
+	p := testProvider(idp.Issuer, uri)
+	plantProvider(t, r, p)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel() // caller is already gone before the warm starts
+
+	if err := r.ReloadAllAndWarm(cancelled); err != nil {
+		t.Fatalf("ReloadAllAndWarm: %v", err)
+	}
+
+	if _, err := r.ResolveKey("default", idp.Issuer, ""); err != nil {
+		t.Fatalf("ResolveKey after cancelled-caller reload: %v (warm was aborted by caller cancellation)", err)
+	}
+}
+
+func TestRegistry_StartWarmupRetryLoop_SecondCallIsNoop(t *testing.T) {
+	r := newTestRegistry(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if started := r.StartWarmupRetryLoop(ctx); !started {
+		t.Error("first StartWarmupRetryLoop call = false, want true")
+	}
+	if started := r.StartWarmupRetryLoop(ctx); started {
+		t.Error("second StartWarmupRetryLoop call = true, want false (loop already running)")
+	}
+}
+
+func TestRegistry_WarmupRetryLoop_StopsOnContextCancel(t *testing.T) {
+	uri := "https://slow-idp.example/.well-known/openid-configuration"
+	store := newTestStore(t)
+	disc := &flakyDiscovery{err: ErrDiscoveryFailed} // stays down: every tick fetches
+	r := NewRegistry(store, disc, nil, NopMetrics{}, nil,
+		RegistryConfig{AllowPrivateNetworks: true, WarmupRetryInterval: 10 * time.Millisecond})
+
+	p := testProvider("https://slow-idp.example", uri)
+	plantProvider(t, r, p)
+	ctx := context.Background()
+	if err := r.LoadProvidersFromKV(ctx); err != nil {
+		t.Fatalf("LoadProvidersFromKV: %v", err)
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	r.StartWarmupRetryLoop(loopCtx)
+
+	// Let it tick a few times, then cancel and let any in-flight tick drain.
+	time.Sleep(60 * time.Millisecond)
+	cancel()
+	time.Sleep(60 * time.Millisecond)
+
+	before := disc.fetchCount(uri)
+	if before == 0 {
+		t.Fatal("retry loop never ticked before cancellation")
+	}
+	time.Sleep(200 * time.Millisecond)
+	if after := disc.fetchCount(uri); after != before {
+		t.Errorf("retry loop still fetching after ctx cancel: %d -> %d", before, after)
+	}
+}
+
+func TestRegistry_ReloadAll_CarriedSourceForInactiveProviderDoesNotAuthenticate(t *testing.T) {
+	// Fail-closed side of the carry-over: if the fresh store snapshot says a
+	// provider is invalidated, its carried key source must not authenticate,
+	// even though the source itself survived the swap.
+	r := newTestRegistry(t)
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	p := testProvider("https://idp.example", "https://idp.example/.well-known/openid-configuration")
+	r.installForTest(p, &fakeKeySource{kid: "k1", key: &priv.PublicKey},
+		&DiscoveryDoc{Issuer: "https://idp.example", JWKSURI: "https://idp.example/jwks"})
+
+	invalidated := *p
+	invalidatedAt := time.Now()
+	invalidated.InvalidatedAt = &invalidatedAt
+	plantProvider(t, r, &invalidated)
+
+	if _, err := r.ResolveKey("k1", "https://idp.example", ""); err != nil {
+		t.Fatalf("baseline ResolveKey: %v", err)
+	}
+
+	if err := r.ReloadAll(context.Background()); err != nil {
+		t.Fatalf("ReloadAll: %v", err)
+	}
+
+	if _, err := r.ResolveKey("k1", "https://idp.example", ""); err == nil {
+		t.Fatal("ResolveKey succeeded for an invalidated provider after ReloadAll (fail-closed violated)")
+	}
+}
+
 func TestRegistry_WarmupRetryLoop_WarmsWhenIdPComesUp(t *testing.T) {
 	// The one-shot startup warm-up loses the race against an IdP that boots
 	// later than cyoda. The retry loop must keep re-attempting the warm-up
@@ -201,7 +335,7 @@ func TestRegistry_WarmupRetryLoop_WarmsWhenIdPComesUp(t *testing.T) {
 	if err := r.LoadProvidersFromKV(ctx); err != nil {
 		t.Fatalf("LoadProvidersFromKV: %v", err)
 	}
-	r.WarmJWKSAsync(ctx) // one-shot warm-up fails: IdP still down
+	r.WarmJWKS(ctx) // one-shot warm-up fails: IdP still down
 
 	loopCtx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
@@ -253,7 +387,7 @@ func TestRegistry_WarmupRetryLoop_SkipsWarmAndInactiveProviders(t *testing.T) {
 	if err := r.LoadProvidersFromKV(ctx); err != nil {
 		t.Fatalf("LoadProvidersFromKV: %v", err)
 	}
-	r.WarmJWKSAsync(ctx) // warms warmURI; inactiveURI fetch fails (no doc yet)
+	r.WarmJWKS(ctx) // warms warmURI; inactiveURI fetch fails (no doc yet)
 	warmBaseline := disc.fetchCount(warmURI)
 	inactiveBaseline := disc.fetchCount(inactiveURI)
 

--- a/internal/auth/oidc/service.go
+++ b/internal/auth/oidc/service.go
@@ -245,10 +245,10 @@ func (s *Service) Delete(ctx context.Context, tenant spi.TenantID, providerID st
 	return nil
 }
 
-// ReloadAll implements §5.6. Rebuilds the in-memory registry from KV and
-// broadcasts reload_all.
+// ReloadAll implements §5.6. Rebuilds the in-memory registry from KV,
+// force-warms the JWKS of every loaded provider, and broadcasts reload_all.
 func (s *Service) ReloadAll(ctx context.Context) error {
-	if err := s.registry.ReloadAll(ctx); err != nil {
+	if err := s.registry.ReloadAllAndWarm(ctx); err != nil {
 		return fmt.Errorf("oidc: reload-all: %w", err)
 	}
 	s.registry.broadcastOp("reload_all", "", "")


### PR DESCRIPTION
Closes #434.

## Root cause

`Registry.ReloadAll` rebuilt the provider map from KV but installed **empty** key-source maps, and nothing on the reload endpoint's call chain ever re-warmed them — the trailing comment deferred to a warm-up that no caller ran. `POST /api/oauth/oidc/providers/reload` therefore destroyed every cached JWKS key source and installed none: all federated tokens failed with 401 `unknown kid` until a process restart, including tokens of providers that were healthy before the call. Separately, the startup warm-up was one-shot, so a provider whose IdP was not yet reachable at boot (compose stacks, IdP restarts) stayed keyless for the life of the process.

## Fix

- **`ReloadAll` carries warm key sources across the swap** for every (tenant, uri) coordinate still present in the fresh store snapshot — a reload is never a cache flush. Sources for providers removed from the store are dropped; the kid index rebuilds lazily.
- **The reload endpoint and the cluster `reload_all` broadcast force-warm** via `ReloadAllAndWarm`: after the swap, discovery + JWKS are re-fetched for every loaded **active** provider (invalidated providers are excluded — their endpoints are explicitly distrusted). A failed discovery fetch is non-fatal and leaves the carried source serving; key freshness stays governed by the standard JWKS cache TTL, fail closed. Startup phase 1 stays swap-only, preserving the listener-bind ordering.
- **Warm-up retry loop**: every 30s, active providers with no installed key source get their warm-up re-attempted until the IdP becomes reachable; recovery is logged. This also covers the registration-time warm-up race the help topic already described.
- **Docs**: `cyoda help auth oidc` previously pointed operators at `/reload` as the force-warm remedy while it was destructive, and promised a "next warmup cycle" that didn't exist. Both statements are true now and worded precisely. CHANGELOG updated.

## Review-gate findings folded in

Fresh-context code review and security review each ran; all Critical/Important/Low findings are fixed in-branch:

- `WarmJWKS` (renamed from `WarmJWKSAsync`; it is synchronous and `ReloadAllAndWarm` depends on that) skips invalidated providers.
- The warm phase runs under `context.WithoutCancel`, so an HTTP client disconnect cannot leave a cluster-visible force-warm half-completed; every fetch remains transport-bounded.
- `StartWarmupRetryLoop` is guarded against double start; regression tests pin loop shutdown on ctx cancel and the fail-closed behaviour of carried sources for invalidated providers.
- **Fail closed on issuer-pin mismatch**: a discovery doc contradicting the admin's pinned issuers now drops the carried key source instead of leaving it serving — an affirmative conflict is not a transient failure.
- **`ReloadAllAndWarm` is serialized**: concurrent force-warm calls queue behind one fetch pool instead of multiplying outbound discovery traffic to every tenant's IdP.

Deliberate decisions (recorded, not defects): the retry loop uses a constant 30s interval with a WARN per failed attempt — a provider that stays cold is an ongoing operator-visible condition, not something to back off into silence; the endpoint warm is synchronous so a 200 means the force-warm actually completed (the new parity scenarios rely on exactly that determinism).

## Coverage

- Unit (TDD, red verified for every behaviour change): `internal/auth/oidc/reload_warmup_test.go` — carry-over, force-warm, discovery-down resilience, broadcast-peer warm, retry loop (recovery, active-only, ctx-cancel shutdown, double-start guard), pin-mismatch drop, warm serialization, fail-closed carried-source gating.
- Cross-backend parity: `OidcReload_PreservesTokenAcceptance` and `OidcReload_AfterReactivateKeepsTokenAcceptance` (the two repros from the issue), verified to fail against the pre-fix binary and pass now; scenario count 231→233.
- No new error codes, no API-shape change — restoring documented behaviour of an existing endpoint, so no cloud-parity doc.

## Verification

- `go vet ./...` clean; full root suite green (60 packages, includes `internal/e2e` against real Postgres); `plugins/memory|sqlite|postgres` green; `make race` clean on the final code.

## Relation to #483

This closes the single-node half of the shared root cause (local cache never reconciled after local operations, plus the boot-race retry gap). The cross-node convergence work — TTL/periodic reconcile against the authoritative store and trusted-key propagation — remains #483's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLzH3YYHjgyHt2m8LkhQQ
