### PR TITLE
fix(grpc): carry entity payload bytes verbatim to the unstorable-payload guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -428,10 +428,14 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   both forms to U+FFFD, so validating the decoded value cannot see them, and
   re-serialising it would store a replacement character the client never sent.
   Correctly paired surrogates, literal emoji and a client-sent U+FFFD remain valid
-  payload content. Note this covers the HTTP ingress: the gRPC entity API decodes
-  its payload into a Go value before the guard runs, which normalises these two
-  forms away, so they cannot be detected there — tracked separately.
-  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25))
+  payload content. The gRPC entity API now carries the client's payload bytes
+  verbatim to the same guard: it previously decoded and re-marshalled the payload
+  before validation, which rewrote both forms to U+FFFD — storing a character the
+  client never sent — and collapsed duplicate keys instead of rejecting them. All
+  five gRPC entity write events (create, update, patch, create-collection,
+  update-collection) now enforce the full guard set, matching HTTP.
+  ([#25](https://github.com/Cyoda-platform/cyoda-go/issues/25),
+  [#468](https://github.com/Cyoda-platform/cyoda-go/issues/468))
 
 - **An entity payload containing a NUL (U+0000) is now rejected with 400 on every
   backend.** `{"name":"a\u0000b"}` is valid JSON and passes schema validation, but

--- a/api/grpc/events/types.go
+++ b/api/grpc/events/types.go
@@ -689,7 +689,7 @@ func (j *EntityCreateCollectionRequestJson) UnmarshalJSON(value []byte) error {
 
 type EntityCreatePayloadJson struct {
 	// Payload data.
-	Data interface{} `json:"data" yaml:"data" mapstructure:"data"`
+	Data json.RawMessage `json:"data" yaml:"data" mapstructure:"data"`
 
 	// Entity model to use for this payload.
 	Model ModelSpecJson `json:"model" yaml:"model" mapstructure:"model"`
@@ -2591,7 +2591,7 @@ type EntityPatchPayloadJson struct {
 	IfMatch *string `json:"ifMatch,omitempty" yaml:"ifMatch,omitempty" mapstructure:"ifMatch,omitempty"`
 
 	// The patch document (RFC 7386 merge patch).
-	Patch interface{} `json:"patch" yaml:"patch" mapstructure:"patch"`
+	Patch json.RawMessage `json:"patch" yaml:"patch" mapstructure:"patch"`
 
 	// Transition to apply, or omit for loopback.
 	Transition *string `json:"transition,omitempty" yaml:"transition,omitempty" mapstructure:"transition,omitempty"`
@@ -4080,7 +4080,7 @@ func (j *EntityUpdateCollectionRequestJson) UnmarshalJSON(value []byte) error {
 
 type EntityUpdatePayloadJson struct {
 	// Entity payload data.
-	Data interface{} `json:"data" yaml:"data" mapstructure:"data"`
+	Data json.RawMessage `json:"data" yaml:"data" mapstructure:"data"`
 
 	// ID of the entity.
 	EntityID string `json:"entityId" yaml:"entityId" mapstructure:"entityId"`

--- a/internal/grpc/entity.go
+++ b/internal/grpc/entity.go
@@ -51,16 +51,15 @@ func (s *CloudEventsServiceImpl) EntityManage(ctx context.Context, ce *cepb.Clou
 		if format == "" {
 			format = "JSON"
 		}
-		dataBytes, err := json.Marshal(req.Payload.Data)
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "failed to marshal data: %v", err)
-		}
-
+		// The payload bytes go to the entity service verbatim — no
+		// decode→re-marshal round-trip, which would rewrite unpaired
+		// surrogates and invalid UTF-8 to U+FFFD and collapse duplicate
+		// keys before the unstorable-payload guard could see them.
 		result, err := s.entityHandler.CreateEntity(opCtx, entity.CreateEntityInput{
 			EntityName:   req.Payload.Model.Name,
 			ModelVersion: fmt.Sprintf("%d", req.Payload.Model.Version),
 			Format:       format,
-			Data:         dataBytes,
+			Data:         req.Payload.Data,
 		})
 		if err != nil {
 			if appErr := common.ClassifyRequestTimeout(opCtx, err, common.ErrCodeTransactionTimeout); appErr != nil {
@@ -104,11 +103,6 @@ func (s *CloudEventsServiceImpl) EntityManage(ctx context.Context, ce *cepb.Clou
 		if format == "" {
 			format = "JSON"
 		}
-		dataBytes, err := json.Marshal(req.Payload.Data)
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "failed to marshal data: %v", err)
-		}
-
 		transition := ""
 		if req.Payload.Transition != nil {
 			transition = *req.Payload.Transition
@@ -117,7 +111,7 @@ func (s *CloudEventsServiceImpl) EntityManage(ctx context.Context, ce *cepb.Clou
 		result, err := s.entityHandler.UpdateEntity(opCtx, entity.UpdateEntityInput{
 			EntityID:   req.Payload.EntityID,
 			Format:     format,
-			Data:       dataBytes,
+			Data:       req.Payload.Data,
 			Transition: transition,
 		})
 		if err != nil {
@@ -163,17 +157,13 @@ func (s *CloudEventsServiceImpl) EntityManage(ctx context.Context, ce *cepb.Clou
 				http.StatusPreconditionRequired, common.ErrCodePreconditionRequired,
 				"missing ifMatch: provide the transactionId from your last read, or \"*\" to accept last-writer-wins"))
 		}
-		patchBytes, err := json.Marshal(req.Payload.Patch)
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "failed to marshal patch: %v", err)
-		}
 		transition := ""
 		if req.Payload.Transition != nil {
 			transition = *req.Payload.Transition
 		}
 		result, err := s.entityHandler.PatchEntity(opCtx, entity.PatchEntityInput{
 			EntityID:    req.Payload.EntityID,
-			Patch:       patchBytes,
+			Patch:       req.Payload.Patch,
 			PatchFormat: string(req.PatchFormat),
 			Transition:  transition,
 			IfMatch:     *req.Payload.IfMatch,
@@ -316,14 +306,10 @@ func (s *CloudEventsServiceImpl) EntityManageCollection(ce *cepb.CloudEvent, str
 
 		items := make([]entity.CollectionItem, len(req.Payloads))
 		for i, p := range req.Payloads {
-			payloadBytes, err := json.Marshal(p.Data)
-			if err != nil {
-				return status.Errorf(codes.InvalidArgument, "failed to marshal payload %d: %v", i, err)
-			}
 			items[i] = entity.CollectionItem{
 				ModelName:    p.Model.Name,
 				ModelVersion: int32(p.Model.Version),
-				Payload:      payloadBytes,
+				Payload:      p.Data,
 			}
 		}
 
@@ -412,16 +398,6 @@ func (s *CloudEventsServiceImpl) EntityManageCollection(ce *cepb.CloudEvent, str
 				return stream.Send(respCE)
 			}
 
-			dataBytes, err := json.Marshal(p.Data)
-			if err != nil {
-				slog.Error("operation failed", "pkg", "grpc", "rpc", "entityManageCollection", "type", eventType, "ceId", ce.Id, "error", err.Error())
-				respCE, ceErr := entityTransactionError(ctx, ce.Id, fmt.Errorf("failed to marshal data: %v", err))
-				if ceErr != nil {
-					return status.Errorf(codes.Internal, "failed to build error response: %v", ceErr)
-				}
-				return stream.Send(respCE)
-			}
-
 			transition := ""
 			if p.Transition != nil {
 				transition = *p.Transition
@@ -430,7 +406,7 @@ func (s *CloudEventsServiceImpl) EntityManageCollection(ce *cepb.CloudEvent, str
 			result, err := s.entityHandler.UpdateEntity(opCtx, entity.UpdateEntityInput{
 				EntityID:   p.EntityID,
 				Format:     format,
-				Data:       dataBytes,
+				Data:       p.Data,
 				Transition: transition,
 			})
 			if err != nil {

--- a/internal/grpc/entity_unstorable_test.go
+++ b/internal/grpc/entity_unstorable_test.go
@@ -1,0 +1,204 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	cepb "github.com/cyoda-platform/cyoda-go/api/grpc/cloudevents"
+	events "github.com/cyoda-platform/cyoda-go/api/grpc/events"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+)
+
+// The unstorable-payload guard (ingest.RejectUnstorable) inspects the RAW
+// bytes the client sent: Go's decoder silently rewrites unpaired UTF-16
+// surrogates and invalid UTF-8 to U+FFFD and collapses duplicate keys, so a
+// decode→re-marshal round-trip destroys the evidence and stores data the
+// client never sent. These tests pin that every gRPC entity write event
+// carries the client's payload bytes to the guard untouched.
+
+// unstorablePlaceholderID never resolves to a real entity; the guard must
+// reject before any entity lookup, so update/patch tests don't create one.
+const unstorablePlaceholderID = "00000000-0000-0000-0000-000000000002"
+
+// makeRawCE builds a CloudEvent whose payload is the given raw bytes,
+// verbatim. BinaryData rather than TextData: proto3 strings must be valid
+// UTF-8 on the wire, so raw invalid bytes can only genuinely arrive through
+// the bytes variant — and ParseCloudEvent accepts both identically.
+func makeRawCE(eventType string, payload []byte) *cepb.CloudEvent {
+	return &cepb.CloudEvent{
+		Id:          "test-req-1",
+		Source:      "test",
+		SpecVersion: "1.0",
+		Type:        eventType,
+		Data:        &cepb.CloudEvent_BinaryData{BinaryData: payload},
+	}
+}
+
+// unstorableOp describes one gRPC entity write event and how to wrap a raw
+// data snippet into its CloudEvent payload, byte-for-byte.
+type unstorableOp struct {
+	name       string
+	eventType  string
+	collection bool
+	envelope   func(data string) string
+}
+
+func unstorableOps() []unstorableOp {
+	return []unstorableOp{
+		{
+			name:      "Create",
+			eventType: EntityCreateRequest,
+			envelope: func(data string) string {
+				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payload":{"model":{"name":"person","version":1},"data":%s}}`, data)
+			},
+		},
+		{
+			name:      "Update",
+			eventType: EntityUpdateRequest,
+			envelope: func(data string) string {
+				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payload":{"entityId":"%s","data":%s}}`, unstorablePlaceholderID, data)
+			},
+		},
+		{
+			name:      "Patch",
+			eventType: EntityPatchRequest,
+			envelope: func(data string) string {
+				return fmt.Sprintf(`{"id":"test","patchFormat":"MERGE_PATCH","payload":{"entityId":"%s","ifMatch":"*","patch":%s}}`, unstorablePlaceholderID, data)
+			},
+		},
+		{
+			name:       "CreateCollection",
+			eventType:  EntityCreateCollectionRequest,
+			collection: true,
+			envelope: func(data string) string {
+				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payloads":[{"model":{"name":"person","version":1},"data":%s}]}`, data)
+			},
+		},
+		{
+			name:       "UpdateCollection",
+			eventType:  EntityUpdateCollectionRequest,
+			collection: true,
+			envelope: func(data string) string {
+				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payloads":[{"entityId":"%s","data":%s}]}`, unstorablePlaceholderID, data)
+			},
+		},
+	}
+}
+
+// invokeRaw sends the raw CloudEvent payload through the right RPC and
+// returns the decoded transaction envelope.
+func (op unstorableOp) invokeRaw(t *testing.T, svc *CloudEventsServiceImpl, ctx context.Context, payload []byte) events.EntityTransactionResponseJson {
+	t.Helper()
+	ce := makeRawCE(op.eventType, payload)
+
+	var typed events.EntityTransactionResponseJson
+	if op.collection {
+		stream := &mockManageStream{ctx: ctx}
+		if err := svc.EntityManageCollection(ce, stream); err != nil {
+			t.Fatalf("%s: unexpected gRPC error: %v", op.name, err)
+		}
+		if len(stream.sent) != 1 {
+			t.Fatalf("%s: expected 1 response, got %d", op.name, len(stream.sent))
+		}
+		validateResponse(t, stream.sent[0], &typed)
+		return typed
+	}
+
+	resp, err := svc.EntityManage(ctx, ce)
+	if err != nil {
+		t.Fatalf("%s: unexpected gRPC error: %v", op.name, err)
+	}
+	validateResponse(t, resp, &typed)
+	return typed
+}
+
+// TestRPC_EntityWrite_UnstorablePayloadRejected pins that each rejection
+// class of the unstorable-payload guard fires on every gRPC entity write
+// event, returning an error envelope instead of storing substituted or
+// silently rewritten data.
+func TestRPC_EntityWrite_UnstorablePayloadRejected(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "Alice"})
+
+	classes := []struct {
+		name       string
+		data       string // raw JSON snippet, embedded verbatim
+		wantReason string // substring of the guard's rejection message
+	}{
+		{
+			name:       "UnpairedSurrogate",
+			data:       `{"name":"a\ud800b"}`,
+			wantReason: "unpaired UTF-16 surrogate",
+		},
+		{
+			name:       "InvalidUTF8",
+			data:       "{\"name\":\"a\xffb\"}",
+			wantReason: "not valid UTF-8",
+		},
+		{
+			name:       "DuplicateKey",
+			data:       `{"name":"a","name":"b"}`,
+			wantReason: "appears more than once",
+		},
+		{
+			name:       "NUL",
+			data:       `{"name":"a\u0000b"}`,
+			wantReason: "NUL character",
+		},
+		{
+			name:       "NumericRange",
+			data:       `{"name":1e131073}`,
+			wantReason: "too many digits before the decimal point",
+		},
+	}
+
+	for _, op := range unstorableOps() {
+		for _, class := range classes {
+			t.Run(op.name+"/"+class.name, func(t *testing.T) {
+				resp := op.invokeRaw(t, svc, ctx, []byte(op.envelope(class.data)))
+				if resp.Success {
+					t.Fatal("expected success=false, got success=true: unstorable payload was accepted")
+				}
+				if resp.Error == nil {
+					t.Fatal("expected error field to be populated")
+				}
+				if resp.Error.Code != "CLIENT_ERROR" {
+					t.Errorf("error code = %q, want CLIENT_ERROR", resp.Error.Code)
+				}
+				if !strings.HasPrefix(resp.Error.Message, common.ErrCodeBadRequest+":") {
+					t.Errorf("message = %q, want prefix %q", resp.Error.Message, common.ErrCodeBadRequest+":")
+				}
+				if !strings.Contains(resp.Error.Message, class.wantReason) {
+					t.Errorf("message = %q, want reason substring %q", resp.Error.Message, class.wantReason)
+				}
+			})
+		}
+	}
+}
+
+// TestRPC_EntityCreate_StorablePayloadStillAccepted pins the flip side of
+// the guard: content the guard must NOT fire on — a correctly PAIRED
+// surrogate escape (\ud83d\ude00, U+1F600) and a client-sent U+FFFD escape
+// (\ufffd) — remains valid payload, exactly as documented for the HTTP
+// ingress.
+func TestRPC_EntityCreate_StorablePayloadStillAccepted(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "Alice"})
+
+	payload := `{"id":"test","dataFormat":"JSON","payload":{"model":{"name":"person","version":1},"data":{"name":"a\ud83d\ude00b \ufffd c"}}}`
+
+	resp := unstorableOps()[0]
+	typed := resp.invokeRaw(t, svc, ctx, []byte(payload))
+	if !typed.Success {
+		msg := ""
+		if typed.Error != nil {
+			msg = typed.Error.Message
+		}
+		t.Fatalf("expected success, got error: %s", msg)
+	}
+	if len(typed.TransactionInfo.EntityIds) != 1 {
+		t.Fatalf("expected 1 entity id, got %d", len(typed.TransactionInfo.EntityIds))
+	}
+}

--- a/internal/grpc/entity_unstorable_test.go
+++ b/internal/grpc/entity_unstorable_test.go
@@ -37,12 +37,13 @@ func makeRawCE(eventType string, payload []byte) *cepb.CloudEvent {
 }
 
 // unstorableOp describes one gRPC entity write event and how to wrap a raw
-// data snippet into its CloudEvent payload, byte-for-byte.
+// data snippet into its CloudEvent payload, byte-for-byte. entityID is used
+// only by the update-shaped events; create-shaped events ignore it.
 type unstorableOp struct {
 	name       string
 	eventType  string
 	collection bool
-	envelope   func(data string) string
+	envelope   func(entityID, data string) string
 }
 
 func unstorableOps() []unstorableOp {
@@ -50,29 +51,29 @@ func unstorableOps() []unstorableOp {
 		{
 			name:      "Create",
 			eventType: EntityCreateRequest,
-			envelope: func(data string) string {
+			envelope: func(_, data string) string {
 				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payload":{"model":{"name":"person","version":1},"data":%s}}`, data)
 			},
 		},
 		{
 			name:      "Update",
 			eventType: EntityUpdateRequest,
-			envelope: func(data string) string {
-				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payload":{"entityId":"%s","data":%s}}`, unstorablePlaceholderID, data)
+			envelope: func(entityID, data string) string {
+				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payload":{"entityId":"%s","data":%s}}`, entityID, data)
 			},
 		},
 		{
 			name:      "Patch",
 			eventType: EntityPatchRequest,
-			envelope: func(data string) string {
-				return fmt.Sprintf(`{"id":"test","patchFormat":"MERGE_PATCH","payload":{"entityId":"%s","ifMatch":"*","patch":%s}}`, unstorablePlaceholderID, data)
+			envelope: func(entityID, data string) string {
+				return fmt.Sprintf(`{"id":"test","patchFormat":"MERGE_PATCH","payload":{"entityId":"%s","ifMatch":"*","patch":%s}}`, entityID, data)
 			},
 		},
 		{
 			name:       "CreateCollection",
 			eventType:  EntityCreateCollectionRequest,
 			collection: true,
-			envelope: func(data string) string {
+			envelope: func(_, data string) string {
 				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payloads":[{"model":{"name":"person","version":1},"data":%s}]}`, data)
 			},
 		},
@@ -80,8 +81,8 @@ func unstorableOps() []unstorableOp {
 			name:       "UpdateCollection",
 			eventType:  EntityUpdateCollectionRequest,
 			collection: true,
-			envelope: func(data string) string {
-				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payloads":[{"entityId":"%s","data":%s}]}`, unstorablePlaceholderID, data)
+			envelope: func(entityID, data string) string {
+				return fmt.Sprintf(`{"id":"test","dataFormat":"JSON","payloads":[{"entityId":"%s","data":%s}]}`, entityID, data)
 			},
 		},
 	}
@@ -157,7 +158,7 @@ func TestRPC_EntityWrite_UnstorablePayloadRejected(t *testing.T) {
 	for _, op := range unstorableOps() {
 		for _, class := range classes {
 			t.Run(op.name+"/"+class.name, func(t *testing.T) {
-				resp := op.invokeRaw(t, svc, ctx, []byte(op.envelope(class.data)))
+				resp := op.invokeRaw(t, svc, ctx, []byte(op.envelope(unstorablePlaceholderID, class.data)))
 				if resp.Success {
 					t.Fatal("expected success=false, got success=true: unstorable payload was accepted")
 				}
@@ -178,27 +179,43 @@ func TestRPC_EntityWrite_UnstorablePayloadRejected(t *testing.T) {
 	}
 }
 
-// TestRPC_EntityCreate_StorablePayloadStillAccepted pins the flip side of
+// TestRPC_EntityWrite_StorablePayloadStillAccepted pins the flip side of
 // the guard: content the guard must NOT fire on — a correctly PAIRED
 // surrogate escape (\ud83d\ude00, U+1F600) and a client-sent U+FFFD escape
 // (\ufffd) — remains valid payload, exactly as documented for the HTTP
 // ingress.
-func TestRPC_EntityCreate_StorablePayloadStillAccepted(t *testing.T) {
+func TestRPC_EntityWrite_StorablePayloadStillAccepted(t *testing.T) {
 	svc, ctx := newTestEnv(t)
 	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "Alice"})
 
-	payload := `{"id":"test","dataFormat":"JSON","payload":{"model":{"name":"person","version":1},"data":{"name":"a\ud83d\ude00b \ufffd c"}}}`
+	const storable = `{"name":"a\ud83d\ude00b \ufffd c"}`
 
-	resp := unstorableOps()[0]
-	typed := resp.invokeRaw(t, svc, ctx, []byte(payload))
-	if !typed.Success {
-		msg := ""
-		if typed.Error != nil {
-			msg = typed.Error.Message
-		}
-		t.Fatalf("expected success, got error: %s", msg)
+	ops := unstorableOps()
+	createOp := ops[0]
+
+	// Create first so the update-shaped events below have a real entity.
+	created := createOp.invokeRaw(t, svc, ctx, []byte(createOp.envelope("", storable)))
+	if !created.Success {
+		t.Fatalf("Create: expected success, got error: %s", errMsgOf(created))
 	}
-	if len(typed.TransactionInfo.EntityIds) != 1 {
-		t.Fatalf("expected 1 entity id, got %d", len(typed.TransactionInfo.EntityIds))
+	if len(created.TransactionInfo.EntityIds) != 1 {
+		t.Fatalf("Create: expected 1 entity id, got %d", len(created.TransactionInfo.EntityIds))
 	}
+	entityID := created.TransactionInfo.EntityIds[0]
+
+	for _, op := range ops[1:] {
+		t.Run(op.name, func(t *testing.T) {
+			resp := op.invokeRaw(t, svc, ctx, []byte(op.envelope(entityID, storable)))
+			if !resp.Success {
+				t.Fatalf("expected success, got error: %s", errMsgOf(resp))
+			}
+		})
+	}
+}
+
+func errMsgOf(resp events.EntityTransactionResponseJson) string {
+	if resp.Error == nil {
+		return ""
+	}
+	return resp.Error.Message
 }

--- a/scripts/generate-events.sh
+++ b/scripts/generate-events.sh
@@ -117,9 +117,19 @@ sed -i '' 's|json\.Unmarshal(value, &raw)|decodeWithUseNumber(value, \&raw)|g; s
 # raw-bytes guard exists to prevent. Scoped per struct: only the payload
 # fields the gRPC entity ingress forwards verbatim to the entity service.
 perl -0777 -i -pe '
-  s/(type EntityCreatePayloadJson struct \{.*?\n\tData )interface\{\}/${1}json.RawMessage/s;
-  s/(type EntityUpdatePayloadJson struct \{.*?\n\tData )interface\{\}/${1}json.RawMessage/s;
-  s/(type EntityPatchPayloadJson struct \{.*?\n\tPatch )interface\{\}/${1}json.RawMessage/s;
+  s/(type EntityCreatePayloadJson struct \{[^}]*?\n\tData )interface\{\}/${1}json.RawMessage/s;
+  s/(type EntityUpdatePayloadJson struct \{[^}]*?\n\tData )interface\{\}/${1}json.RawMessage/s;
+  s/(type EntityPatchPayloadJson struct \{[^}]*?\n\tPatch )interface\{\}/${1}json.RawMessage/s;
 ' "$OUT"
+
+# Fail loudly if the substitutions stop matching (e.g. a schema restructuring
+# renames a field): exactly three payload fields must have been retyped.
+# (The generator emits json.RawMessage on its own elsewhere, so count the
+# retyped fields specifically, not every occurrence.)
+RAW_COUNT=$(grep -cE '^	(Data|Patch) json\.RawMessage ' "$OUT")
+if [ "$RAW_COUNT" -ne 3 ]; then
+  echo "ERROR: expected exactly 3 retyped Data/Patch json.RawMessage fields in $OUT after post-processing, found $RAW_COUNT" >&2
+  exit 1
+fi
 
 echo "Generated $OUT ($(wc -l < "$OUT") lines)"

--- a/scripts/generate-events.sh
+++ b/scripts/generate-events.sh
@@ -108,4 +108,18 @@ sed -i '' 's/Success bool `json:"success,omitempty"/Success bool `json:"success"
 # values (issue #79).
 sed -i '' 's|json\.Unmarshal(value, &raw)|decodeWithUseNumber(value, \&raw)|g; s|json\.Unmarshal(value, &plain)|decodeWithUseNumber(value, \&plain)|g' "$OUT"
 
+# Post-process: type the inbound entity payload fields as json.RawMessage so
+# the client's bytes survive to the unstorable-payload guard
+# (internal/domain/model/ingest.RejectUnstorable). Decoding them into
+# interface{} and re-marshalling silently rewrites unpaired UTF-16
+# surrogates and invalid UTF-8 to U+FFFD and collapses duplicate keys, so
+# the guard cannot fire and substituted data is stored — exactly what the
+# raw-bytes guard exists to prevent. Scoped per struct: only the payload
+# fields the gRPC entity ingress forwards verbatim to the entity service.
+perl -0777 -i -pe '
+  s/(type EntityCreatePayloadJson struct \{.*?\n\tData )interface\{\}/${1}json.RawMessage/s;
+  s/(type EntityUpdatePayloadJson struct \{.*?\n\tData )interface\{\}/${1}json.RawMessage/s;
+  s/(type EntityPatchPayloadJson struct \{.*?\n\tPatch )interface\{\}/${1}json.RawMessage/s;
+' "$OUT"
+
 echo "Generated $OUT ($(wc -l < "$OUT") lines)"


### PR DESCRIPTION
## Problem

The gRPC entity API decoded a client's payload into `interface{}` and re-marshalled it before validation, so two of the unstorable-payload guards (unpaired UTF-16 surrogate, invalid UTF-8) could never fire there — and the round-trip itself silently rewrote both forms to U+FFFD and collapsed duplicate keys, storing data the client never sent. Closes #468.

## Fix

- Type the three inbound entity payload fields (`EntityCreatePayloadJson.Data`, `EntityUpdatePayloadJson.Data`, `EntityPatchPayloadJson.Patch`) as `json.RawMessage` via a scoped, self-checking post-processing step in `scripts/generate-events.sh` (`types.go` is generated; regeneration verified byte-stable).
- Pass the payload bytes straight through in `internal/grpc/entity.go` — five decode→re-marshal sites removed. The entity-service inputs already take `json.RawMessage`.
- All five write events (create, update, patch, create-collection, update-collection) now enforce the full guard set with the established error envelope (`Success=false`, code `CLIENT_ERROR`, message prefixed `BAD_REQUEST:`), matching the HTTP ingress.
- CHANGELOG's HTTP-only narrowing from #25 (still in [Unreleased]) replaced; no other doc carried it.

## Coverage

| Scenario | Layer |
|---|---|
| Unpaired surrogate, invalid UTF-8, duplicate key, NUL, numeric range × all 5 write events (25 cells) | `internal/grpc` (real service stack, memory backend) |
| Paired surrogate escape + client-sent U+FFFD accepted, all 5 events | `internal/grpc` |
| Same guard classes over HTTP | pre-existing `internal/e2e/entity_unstorable_test.go` |
| Cross-backend parity | pre-existing `e2e/parity/entity_unstorable.go` (guard is ingress-level, backend-agnostic) |

TDD: the 25-cell table failed on base with exactly the issue's signature (3 classes accepted/mangled, NUL + numeric already firing) — independently reproduced by the fresh-context reviewer — and passes after the fix.

## Verification

- `make test-all` (root + plugins + E2E) — pass
- `make race` — pass
- `go vet ./...` — pass
- Fresh-context code review: ready to merge; all findings (generator-script hardening, test polish) applied
- Security review: no findings (validation strengthened; no logging/error-surface/tenant-path changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLzH3YYHjgyHt2m8LkhQQ