### PR TITLE
fix(cyoda): single SIGTERM no longer races the second-signal hard-exit path

### DIFF
--- a/cmd/cyoda/main.go
+++ b/cmd/cyoda/main.go
@@ -128,24 +128,28 @@ func main() {
 	// Second-signal escape hatch: signal.NotifyContext only cancels on
 	// the first signal; subsequent signals are no-ops, leaving the
 	// operator with no recourse if the graceful drain hangs (stuck
-	// in-flight RPC, slow-closing storage pool). Register the hard-exit
-	// channel up-front so it is already armed when the first signal
-	// arrives — otherwise the second signal can race the goroutine
-	// setup and be lost. The goroutine only acts once rootCtx is
-	// cancelled, so the first signal still flows through the graceful
-	// path; only signals received AFTER cancellation force os.Exit(2).
-	hardExitCh := make(chan os.Signal, 1)
+	// in-flight RPC, slow-closing storage pool).
+	//
+	// hardExitCh is independent of rootCtx and gets every SIGINT/SIGTERM
+	// delivered to the process. It does NOT wait on <-rootCtx.Done() —
+	// the runtime delivers each signal to signal.NotifyContext's channel
+	// and to hardExitCh separately, not atomically together, so waiting
+	// on rootCtx first and then trying to tell "already consumed" apart
+	// from "second signal" by draining hardExitCh raced that gap: a
+	// drain that ran before the first signal reached hardExitCh saw it
+	// empty, then blocked and consumed the *first* signal as if it were
+	// the second, forcing a spurious hard exit on a single SIGTERM.
+	//
+	// Receiving twice, unconditionally, has no such gap: every delivered
+	// signal reaches hardExitCh exactly once, so receive #1 is always
+	// the first signal and receive #2 is always a genuine second one,
+	// regardless of rootCtx timing. Buffered to 2 so a second signal
+	// arriving in a tight burst is never dropped mid-receive.
+	hardExitCh := make(chan os.Signal, 2)
 	signal.Notify(hardExitCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		<-rootCtx.Done()
-		// Drain any signal that landed in the buffered channel before
-		// rootCtx was cancelled — that one is the first signal and is
-		// already being handled by signal.NotifyContext.
-		select {
-		case <-hardExitCh:
-		default:
-		}
-		<-hardExitCh
+		<-hardExitCh // first signal — the graceful path (signal.NotifyContext) is handling it
+		<-hardExitCh // a genuine second signal
 		slog.Warn("hard exit forced by second signal")
 		os.Exit(2)
 	}()


### PR DESCRIPTION
A single SIGTERM could exit the process with status 2 instead of draining gracefully. Go's signal fan-out delivers a raised signal to each registered channel independently; the hard-exit goroutine woke on `rootCtx.Done()` (cancelled via `signal.NotifyContext`'s channel), ran its non-blocking drain of `hardExitCh` before the runtime had delivered the same first signal there, then consumed that first signal as if it were a second one — spurious `os.Exit(2)`. Surfaced as a CI flake in `TestShutdown_OnSIGTERM_DrainsBothServers` (child logged "shutting down" and "hard exit forced by second signal" in the same millisecond from one SIGTERM).

Fix: drop the `rootCtx` dependency entirely — register `hardExitCh` with buffer 2 (a rapid second signal is never dropped by the runtime's non-blocking send) and double-receive: the first receive always corresponds to the first signal (handled gracefully by `NotifyContext`), the second receive is a genuine second signal. Race-free by construction.

Testing: both subprocess pins pass (`TestShutdown_OnSIGTERM_DrainsBothServers` = clean single-signal exit; `TestShutdown_SecondSignal_ForcesHardExit` = hard exit on two signals), plus a 15/15 stress run of the previously-flaky test and an independent reviewer's 20/20 run. A deterministic unit test of the race is waived: it is only reachable through OS signal-delivery timing, which is not injectable without restructuring `main`; the two semantic pins plus stress runs are the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLzH3YYHjgyHt2m8LkhQQ