### PR TITLE
docs(search): name the sort surface everywhere the path grammar is described, and correct two caller-visibility claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -690,14 +690,17 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   character outside the segment charset, refusing at submit rather than
   failing a job later. HTTP behaviour is unchanged.
 
-- **An async search job now reports a storage backend's rejection of the
+- **An async search job now records a storage backend's rejection of the
   request as the client error it is.** The synchronous path classifies the
   cross-backend sentinels — a refused filter path, an exceeded result limit —
-  into a `400`; the async executor assigned the store's error straight through,
-  so the job record, which is the only report an async caller ever gets, read
-  `search failed unexpectedly` for input that was simply malformed. The same
-  classification now runs on both doors, for the iterate error and for a
-  sticky scan error surfaced at `Close`.
+  into a `400`; the async executor assigned the store's error straight
+  through, so the persisted job record read `search failed unexpectedly` for
+  input that was simply malformed, while the same cause on the synchronous
+  door read as a client error. The same classification now runs on both, for
+  the iterate error and for a sticky scan error surfaced at `Close`. Note the
+  record is not served to callers today — no status surface carries a failure
+  message — so this is an operator-facing and forward-looking fix, not a
+  change to any response.
 
 - **The grouped-statistics endpoint's error codes are now documented.** All ten
   codes the endpoint raises — `MALFORMED_REQUEST`, `MISSING_GROUP_BY`,

--- a/cmd/cyoda/help/content/search.md
+++ b/cmd/cyoda/help/content/search.md
@@ -345,7 +345,7 @@ Both sync and async search accept one or more `sort` query parameters. Repeat th
 
 **Key cap:** configurable via `CYODA_SEARCH_MAX_SORT_KEYS` (default 16); exceeding the cap returns `errors.INVALID_FIELD_PATH` (`400`), like any other malformed `sort` value.
 
-**Invalid paths:** unsortable, unknown, array, or non-scalar paths return `errors.INVALID_FIELD_PATH` (`400`).
+**Invalid paths:** unsortable, unknown, array, or non-scalar paths return `errors.INVALID_FIELD_PATH` (`400`). A path segment is drawn from `A-Za-z0-9_-`, and an array subscript or projection (`items[*].name`, `items[0].name`) is rejected — an ordering needs a single scalar, and being a recorded field is not enough: a scalar leaf inside an array of objects is one. The gRPC `orderBy.path` is held to the same grammar in the same resolver, so both transports answer a given path identically.
 
 ## PAGINATION
 

--- a/internal/domain/search/jsonpath_grammar.go
+++ b/internal/domain/search/jsonpath_grammar.go
@@ -37,7 +37,7 @@ const jsonPathLeader = "$."
 // "$.a[0].xé"). All of these wrap [errInvalidFieldPath], which every transport
 // maps to 400 INVALID_FIELD_PATH.
 //
-// Two surfaces share this grammar and differ on ONE point — a WELL-FORMED
+// The surfaces share this grammar and differ on ONE point — a WELL-FORMED
 // array subscript ("$.tags[*].name", "$.arr[0]", "$.matrix[*][*]"):
 //
 //   - [ValidateConditionJSONPath], the condition jsonPath surface, ACCEPTS
@@ -45,9 +45,13 @@ const jsonPathLeader = "$."
 //     spi.ConditionToFilter refuses them with a PLAIN error that does not wrap
 //     spi.ErrInvalidFilterPath, precisely so the caller falls back to the
 //     in-memory evaluator, which serves them.
-//   - [ValidateScalarJSONPath], the groupBy / aggregation-field surface,
-//     REJECTS them. Those paths must denote a single scalar; a projection has
-//     no fallback that could produce one.
+//   - [ValidateScalarJSONPath] — the groupBy, aggregation-field and SORT-key
+//     surfaces — REJECTS them. Those paths must denote a single scalar; a
+//     projection has no fallback that could produce one.
+//
+// A sort key differs from the other two scalar surfaces on the leader alone:
+// it is spelled bare over HTTP ("price"), so resolveOrderBy normalises before
+// validating rather than requiring "$." of the caller.
 //
 // Both scan the WHOLE path, subscripts included — the same scan spi's
 // stripDollarDot performs — and only differ in what they do with a well-formed
@@ -78,10 +82,10 @@ func ValidateConditionJSONPath(path string) error {
 	return validateJSONPath(path, true)
 }
 
-// ValidateScalarJSONPath checks a path that must denote a single scalar —
-// a grouped-stats groupBy entry or aggregation field — against the same
-// grammar, additionally rejecting array projections and subscripts. Errors
-// wrap [ErrInvalidFieldPath].
+// ValidateScalarJSONPath checks a path that must denote a single scalar — a
+// grouped-stats groupBy entry, an aggregation field, or a sort key — against
+// the same grammar, additionally rejecting array projections and subscripts.
+// Errors wrap [ErrInvalidFieldPath].
 //
 // Without it a malformed path is caught only when pushdown is actually used:
 // the grouped-stats service falls through to the in-process streaming tally
@@ -90,6 +94,11 @@ func ValidateConditionJSONPath(path string) error {
 // misses, and buckets every entity as null — a wrong-but-available 200 rather
 // than an error. Validating at the boundary makes both execution paths reject
 // identically and leaves each plugin's own check as a backstop.
+//
+// resolveOrderBy applies it to a SORT key for the same reason, and there the
+// in-memory branch has no plugin backstop at all: the engine sorts the drained
+// slice itself, so an unvalidated projection was answered as an unsorted page
+// rather than refused.
 func ValidateScalarJSONPath(path string) error {
 	return validateJSONPath(path, false)
 }

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -94,11 +94,16 @@ type asyncScanScoper interface {
 // jobFailureMessage is what gets written into the job record when an async
 // search fails.
 //
-// The record is the only report a caller of the async API ever gets, and GetJob
-// serves it back verbatim, so it follows the same 4xx/5xx split as every other
-// response: a classified client error carries its own already-safe text, and
-// everything else — a storage failure, a driver error, an unclassified
-// wrapper — collapses to a fixed string with the detail left in the log.
+// It follows the same 4xx/5xx split as every other response: a classified
+// client error carries its own already-safe text, and everything else — a
+// storage failure, a driver error, an unclassified wrapper — collapses to a
+// fixed string with the detail left in the log.
+//
+// No status surface serves this string today: neither SearchJobStatus nor
+// SnapshotStatus carries a failure message, so an async caller sees FAILED and
+// no reason. Hold it to the response contract regardless — it is a persisted,
+// servable artefact, and the day a status surface does carry it must not be
+// the day its sanitisation is first considered.
 func jobFailureMessage(err error) string {
 	var ceiling searchCeilingExceeded
 	if errors.As(err, &ceiling) && ceiling.SearchCeilingExceeded() {

--- a/internal/domain/search/sortparam.go
+++ b/internal/domain/search/sortparam.go
@@ -11,8 +11,11 @@ import (
 // ParseSortParam parses repeatable `sort` query values into OrderKeys.
 // Grammar: [@]path[:asc|:desc]. Bare ⇒ data; leading '@' ⇒ meta (flat name).
 // A leading "$." on a data path is tolerated. Direction defaults to asc.
-// Duplicate paths and >maxKeys keys are rejected. Semantic validation
-// (schema scalar-leaf, meta allowlist) happens later in the service.
+// Duplicate paths and >maxKeys keys are rejected. The path GRAMMAR is checked
+// here too, but it is not this parser's to own: resolveOrderBy applies it to
+// every key whatever the transport, because gRPC builds an OrderKey without
+// passing through here. Semantic validation (schema scalar-leaf, meta
+// allowlist) happens there as well.
 func ParseSortParam(values []string, maxKeys int) ([]OrderKey, error) {
 	keys := make([]OrderKey, 0, len(values))
 	for _, raw := range values {


### PR DESCRIPTION
Follow-up to #520 — comments, CHANGELOG wording and help content only. No behaviour change. Milestone v0.8.4, step 4 of #516.

Written to survive a context reset: the point is that a later reader, human or agent, should not be able to draw a wrong conclusion from a stale sentence.

## The sort key became a third surface and three places still said two

- `internal/domain/search/jsonpath_grammar.go` — the header said "Two surfaces share this grammar", and `ValidateScalarJSONPath`'s doc named only the groupBy and aggregation-field surfaces. Both now name the sort key, plus the single point on which it differs (the `$.` leader is supplied by `normalisePath`, not required of the caller) and why it needs the check most: on the in-memory branch the engine sorts the drained slice itself, so unlike groupBy there is no plugin backstop.
- `internal/domain/search/sortparam.go` — `ParseSortParam`'s doc said semantic validation "happens later in the service" and said nothing about the grammar, which now runs in both places and belongs to `resolveOrderBy`, since gRPC builds an `OrderKey` without passing through the parser at all.
- `cmd/cyoda/help/content/search.md` — the "Invalid paths" line listed the semantic rejections but not the grammar, so a caller could read it as permitting `items[*].name`.

## Two claims about caller visibility that were simply untrue

The security review of #520 turned this up and I verified it independently: **neither `SearchJobStatus` nor `SnapshotStatus` carries a failure message**, and no HTTP or gRPC status surface emits `job.Error`. An async caller sees `FAILED` and no reason.

- #520's CHANGELOG entry called the job record "the only report an async caller ever gets". It now says the record is not served to callers today, which makes that fix operator-facing and forward-looking rather than a change to any response.
- `jobFailureMessage`'s own doc comment (pre-existing, not from #520) asserted the same thing. It now states the reachability accurately and keeps the sanitisation requirement on its real footing: the record is a persisted, servable artefact, and the day a status surface carries it must not be the day its sanitisation is first considered.

**Separate question, not settled here:** whether an async caller should be told *why* their job failed. That is a contract change on a public status surface, so it needs a decision rather than a drive-by field.