### PR TITLE
fix(search): a schema that cannot be loaded fails the query, it does not skip validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   the schema is not a dependency of that request.
 
 - **A condition naming a data path on a model that declares no fields is now
-  rejected**, on `/search/direct`, `/search/async` and conditional
-  `DELETE /entity/{name}/{version}`. Such a model was previously treated as
+  rejected**, on `/search/direct`, `/search/async`, conditional
+  `DELETE /entity/{name}/{version}` and grouped stats. Such a model was previously treated as
   "nothing to validate against", so any path at all was accepted and the query
   answered — and on the delete path that decided which rows were removed. It is
   instead a model in which the named path does not exist, and the request is
@@ -49,11 +49,27 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   it against an out-of-band or legacy row rather than against a request anyone
   can send today, which is why no E2E test accompanies it.
 
-  Grouped stats is **not** included: it performs no schema-membership
-  validation of any kind today — not for the condition, the `groupBy` paths, or
-  the aggregate fields — and adding it needs model-store plumbing the endpoint
-  does not have, so that a stale cached schema does not falsely reject a field
-  a peer node has already extended the model with. Tracked separately.
+- **Grouped stats now validates its paths against the model.** It previously
+  performed no schema-membership check of any kind — not on the condition, the
+  `groupBy` paths, or the aggregate fields — while `/search/direct` and
+  conditional delete both rejected an undeclared path with
+  `400 INVALID_FIELD_PATH`.
+
+  What made this worse than a missing check is that the answer looked real. A
+  condition leaf on an undeclared field annihilates to a non-match and returns
+  no buckets; an undeclared `groupBy` path buckets every entity together under
+  `"value": null`; and an undeclared `SUM` reports `"total": null` alongside a
+  correct `count`. All three returned `200`.
+
+  Its condition type check was schema-blind for the same reason — the service
+  passed a nil model, so only the model-independent arm ran. An operand parsing
+  into none of a declared field's types is now `400 CONDITION_TYPE_MISMATCH`,
+  matching `/search/direct`.
+
+  All three surfaces get the same bounded single schema refresh search and
+  delete already had, so a field a peer node has just added to the model is not
+  falsely rejected on a node whose cached descriptor predates the schema-change
+  event.
 
   A path's shape is held to the model on the endpoints that validate:
   `$.items[*].sku` asserts `items` is an array and `$.items.sku` asserts it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Breaking
 
-- **A search, conditional delete or grouped-stats query whose model schema
-  cannot be loaded now fails instead of answering.** Field-path validation
-  consults the model's schema to decide whether a condition's paths exist. When
-  that load failed — the model store unreachable, or the stored schema
-  unparseable — validation was skipped and the query ran anyway, returning
-  `200` with a result set.
+- **A search whose model schema cannot be loaded now fails instead of
+  answering.** Field-path validation consults the model's schema to decide
+  whether a condition's paths exist. When that load failed — the model store
+  unreachable, or the stored schema unparseable — validation was skipped and
+  the query ran anyway, returning `200` with a result set.
 
   The result set was not merely unvalidated, it was **wrong**. With no fields
   map the translator stamps an empty declared-type set on every leaf, and that
@@ -20,24 +19,46 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   `BETWEEN_INCLUSIVE`) collapse to a non-match while the other eighteen — the
   presence tests, the string and pattern operators, and the case-insensitive
   family — keep matching. Rows that should have matched were dropped, silently,
-  and the short page was indistinguishable from a complete one. An async job
-  recorded the same short page as `SUCCESSFUL`.
+  and the short page was indistinguishable from a complete one.
 
-  A schema-load failure is now `500` with a ticket id, on `/search/direct`,
-  `/search/async`, conditional `DELETE /entity/{name}/{version}` and
-  grouped stats, over HTTP and gRPC alike. An async job whose schema becomes
-  unreadable between submit and execution ends `FAILED` rather than
-  `SUCCESSFUL` with a truncated result set.
+  A schema-load failure is now `500` with a ticket id on `/search/direct` and
+  `/search/async`, over HTTP and gRPC alike. An async job whose schema becomes
+  unreadable between submit and execution — a load separate from the one submit
+  performed — ends `FAILED` rather than recording the same short page as
+  `SUCCESSFUL`.
+
+  Conditional `DELETE /entity/{name}/{version}` and grouped stats already
+  failed closed on this and are unchanged.
+
+  A **lifecycle-only** condition is unaffected and still succeeds: a meta leaf
+  takes its type from the static meta vocabulary, not from the model schema, so
+  the schema is not a dependency of that request.
 
 - **A condition naming a data path on a model that declares no fields is now
-  rejected.** Such a model was previously treated as "nothing to validate
-  against", so any path at all was accepted and the query answered. It is
+  rejected**, on `/search/direct`, `/search/async` and conditional
+  `DELETE /entity/{name}/{version}`. Such a model was previously treated as
+  "nothing to validate against", so any path at all was accepted and the query
+  answered — and on the delete path that decided which rows were removed. It is
   instead a model in which the named path does not exist, and the request is
-  `400 INVALID_FIELD_PATH` — the same answer any other unknown path already
-  received. A path's shape is held to the model: `$.items[*].sku` asserts
-  `items` is an array and `$.items.sku` asserts it is an object, and the
-  spelling that contradicts the model is an error rather than something to
-  reinterpret.
+  `400 INVALID_FIELD_PATH`, the same answer any other unknown path already
+  received.
+
+  This state is **not reachable through the public API**: model import always
+  stores a marshalled schema, and a schema declaring no fields still yields a
+  non-empty fields map, which already rejected unknown paths. The change closes
+  it against an out-of-band or legacy row rather than against a request anyone
+  can send today, which is why no E2E test accompanies it.
+
+  Grouped stats is **not** included: it performs no schema-membership
+  validation of any kind today — not for the condition, the `groupBy` paths, or
+  the aggregate fields — and adding it needs model-store plumbing the endpoint
+  does not have, so that a stale cached schema does not falsely reject a field
+  a peer node has already extended the model with. Tracked separately.
+
+  A path's shape is held to the model on the endpoints that validate:
+  `$.items[*].sku` asserts `items` is an array and `$.items.sku` asserts it is
+  an object, and the spelling that contradicts the model is rejected rather
+  than reinterpreted.
 
 - **An invalid `LIKE` or `MATCHES_PATTERN` operand is now rejected at the
   request boundary instead of being accepted.** The boundary used to compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Breaking
 
+- **A search, conditional delete or grouped-stats query whose model schema
+  cannot be loaded now fails instead of answering.** Field-path validation
+  consults the model's schema to decide whether a condition's paths exist. When
+  that load failed — the model store unreachable, or the stored schema
+  unparseable — validation was skipped and the query ran anyway, returning
+  `200` with a result set.
+
+  The result set was not merely unvalidated, it was **wrong**. With no fields
+  map the translator stamps an empty declared-type set on every leaf, and that
+  does not degrade leaves uniformly: the eight comparison and ordering
+  operators (`EQUALS`, `NOT_EQUAL`, the four inequalities, `BETWEEN`,
+  `BETWEEN_INCLUSIVE`) collapse to a non-match while the other eighteen — the
+  presence tests, the string and pattern operators, and the case-insensitive
+  family — keep matching. Rows that should have matched were dropped, silently,
+  and the short page was indistinguishable from a complete one. An async job
+  recorded the same short page as `SUCCESSFUL`.
+
+  A schema-load failure is now `500` with a ticket id, on `/search/direct`,
+  `/search/async`, conditional `DELETE /entity/{name}/{version}` and
+  grouped stats, over HTTP and gRPC alike. An async job whose schema becomes
+  unreadable between submit and execution ends `FAILED` rather than
+  `SUCCESSFUL` with a truncated result set.
+
+- **A condition naming a data path on a model that declares no fields is now
+  rejected.** Such a model was previously treated as "nothing to validate
+  against", so any path at all was accepted and the query answered. It is
+  instead a model in which the named path does not exist, and the request is
+  `400 INVALID_FIELD_PATH` — the same answer any other unknown path already
+  received. A path's shape is held to the model: `$.items[*].sku` asserts
+  `items` is an array and `$.items.sku` asserts it is an object, and the
+  spelling that contradicts the model is an error rather than something to
+  reinterpret.
+
 - **An invalid `LIKE` or `MATCHES_PATTERN` operand is now rejected at the
   request boundary instead of being accepted.** The boundary used to compile
   the operand on its own, while every evaluator compiles the *anchored* form,

--- a/app/app.go
+++ b/app/app.go
@@ -700,24 +700,24 @@ func New(cfg Config) *App {
 	// (non-ErrNotFound from Get or RefreshAndGet) surface as Internal(500)
 	// and are propagated to the 500-with-ticket path.
 	storeFactory := a.storeFactory
-	groupedStatsResolver := func(r *http.Request, entityName, modelVersion string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
+	groupedStatsResolver := func(r *http.Request, entityName, modelVersion string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
 		ctx := r.Context()
 		modelStore, err := storeFactory.ModelStore(ctx)
 		if err != nil {
-			return nil, spi.ModelRef{}, nil, false, err
+			return nil, spi.ModelRef{}, nil, nil, false, err
 		}
 		ref := spi.ModelRef{EntityName: entityName, ModelVersion: modelVersion}
 		if appErr := common.EnsureModelRegistered(ctx, modelStore, ref); appErr != nil {
 			if appErr.Status == http.StatusNotFound {
 				// Not registered after one bounded refresh → handler emits 404 MODEL_NOT_FOUND.
-				return nil, ref, nil, false, nil
+				return nil, ref, nil, nil, false, nil
 			}
 			// Genuine store error → propagate to 500-with-ticket path.
-			return nil, ref, nil, false, appErr
+			return nil, ref, nil, nil, false, appErr
 		}
 		entityStore, err := storeFactory.EntityStore(ctx)
 		if err != nil {
-			return nil, ref, nil, false, err
+			return nil, ref, nil, nil, false, err
 		}
 		// Load the model's declared field types so grouped-stats comparison is
 		// type-directed (temporal data fields compare temporally), consistent
@@ -729,9 +729,9 @@ func New(cfg Config) *App {
 		// non-type-directed comparison, same as the search fallback.
 		fields, err := search.LoadFieldsMap(ctx, modelStore, ref)
 		if err != nil {
-			return nil, ref, nil, false, err
+			return nil, ref, nil, nil, false, err
 		}
-		return entityStore, ref, fields, true, nil
+		return entityStore, ref, fields, modelStore, true, nil
 	}
 	groupedStatsHandler := entity.NewGroupedStatsHandler(groupedStatsResolver, cfg.StatsGroupMax)
 	mux.Handle("POST /entity/stats/{entityName}/{modelVersion}/query", authMW(txJoinMW(groupedStatsHandler)))

--- a/docs/cloud-parity/condition-jsonpath-grammar.md
+++ b/docs/cloud-parity/condition-jsonpath-grammar.md
@@ -164,15 +164,19 @@ would build in more places than cyoda-go has it.
 | `POST /search/direct/…` | yes | yes | 5xx |
 | `POST /search/async/…` | yes | yes | 5xx (submit), job `FAILED` (execution) |
 | `DELETE /entity/{entityName}/{modelVersion}` | yes | yes | 5xx |
-| `POST /entity/stats/…/query` | yes | **no** | 5xx |
+| `POST /entity/stats/…/query` | yes | yes | 5xx |
 
-Grouped stats validates the condition's grammar, its patterns and its
-model-independent operand types, but performs **no schema-membership check** —
-on the condition, the `groupBy` paths or the aggregate fields. A condition
-naming a field the model does not declare is accepted there and answered from a
-filter whose comparison leaves annihilate. Cloud should not read the rows above
-as licence to skip it; cyoda-go intends to close it, and the gap is recorded
-here rather than papered over.
+Grouped stats holds **three** path surfaces to the model, not one: the
+condition's leaves, the `groupBy` entries and the aggregate fields. All three
+answer `400 INVALID_FIELD_PATH` for a path the model does not declare. Cloud
+must reject on all three — a partial implementation returns an answer that
+looks real rather than an obvious failure: an undeclared condition leaf yields
+no buckets, an undeclared `groupBy` buckets every entity under a `null` key, and
+an undeclared `SUM` reports a `null` total beside a correct `count`.
+
+All four surfaces apply one bounded `RefreshAndGet` before refusing, so a field
+a peer node has just added is not falsely rejected on a node whose cached
+descriptor predates the schema-change event.
 
 **Workflow criteria are out of scope of this document.** Criteria evaluate
 through the in-process predicate evaluator, never through `ConditionToFilter`,

--- a/docs/cloud-parity/condition-jsonpath-grammar.md
+++ b/docs/cloud-parity/condition-jsonpath-grammar.md
@@ -135,6 +135,10 @@ request, per `.claude/rules/correctness-over-availability.md`.
 - **Model declares no fields:** every data path the condition names is unknown
   → **400 `INVALID_FIELD_PATH`**. A schema-less model is a model in which
   nothing is declared, not a model that accepts anything.
+- **Lifecycle-only conditions are exempt.** A meta leaf takes its type from the
+  static meta vocabulary, not from the model schema, so such a request is
+  answerable without the schema and must not be failed when it cannot be
+  loaded.
 
 Answering without the schema is a *wrong* answer, not merely an unvalidated
 one. With no fields map the translator stamps an empty declared-type set on
@@ -149,6 +153,26 @@ distinct lookups and the one contradicting the model is rejected
 `400 INVALID_FIELD_PATH`. A positional subscript canonicalises to the wildcard
 key (`$.arr[0]` resolves against `$.arr[*]`) — see
 `positional-subscript-path.md`.
+
+### Where cyoda-go implements this today
+
+Stated precisely, because a contract this document overstates is one Cloud
+would build in more places than cyoda-go has it.
+
+| surface | grammar | path existence | schema-load failure |
+|---|---|---|---|
+| `POST /search/direct/…` | yes | yes | 5xx |
+| `POST /search/async/…` | yes | yes | 5xx (submit), job `FAILED` (execution) |
+| `DELETE /entity/{entityName}/{modelVersion}` | yes | yes | 5xx |
+| `POST /entity/stats/…/query` | yes | **no** | 5xx |
+
+Grouped stats validates the condition's grammar, its patterns and its
+model-independent operand types, but performs **no schema-membership check** —
+on the condition, the `groupBy` paths or the aggregate fields. A condition
+naming a field the model does not declare is accepted there and answered from a
+filter whose comparison leaves annihilate. Cloud should not read the rows above
+as licence to skip it; cyoda-go intends to close it, and the gap is recorded
+here rather than papered over.
 
 **Workflow criteria are out of scope of this document.** Criteria evaluate
 through the in-process predicate evaluator, never through `ConditionToFilter`,

--- a/docs/cloud-parity/condition-jsonpath-grammar.md
+++ b/docs/cloud-parity/condition-jsonpath-grammar.md
@@ -121,6 +121,35 @@ identically. On gRPC the refusal is an envelope error (`success=false`,
 `Error.Code = CLIENT_ERROR`, `INVALID_FIELD_PATH` in the message) — never an
 empty stream, which a client would read as "no matches".
 
+## Path validation must run, or the request fails
+
+Grammar is checked without the model; **existence** is checked against it. The
+model's schema decides whether a condition's paths are real, so a schema that
+cannot be loaded is not a reason to skip the check — it is a reason to fail the
+request, per `.claude/rules/correctness-over-availability.md`.
+
+- **Schema load fails** (model store unreachable, stored schema unparseable):
+  **5xx with a ticket id.** Never a result set. An async job whose schema
+  becomes unreadable between submit and execution ends `FAILED`, not
+  `SUCCESSFUL` with a short page.
+- **Model declares no fields:** every data path the condition names is unknown
+  → **400 `INVALID_FIELD_PATH`**. A schema-less model is a model in which
+  nothing is declared, not a model that accepts anything.
+
+Answering without the schema is a *wrong* answer, not merely an unvalidated
+one. With no fields map the translator stamps an empty declared-type set on
+every leaf, which collapses the eight comparison and ordering operators to a
+non-match while the other eighteen keep matching — so rows that should have
+matched are dropped and the short page looks complete.
+
+**Path shape is held to the model.** `$.items[*].sku` asserts `items` is an
+array (or polymorphic with an array member); `$.items.sku` asserts `items` is
+an object. The fields-map keys carry the `[*]` hops, so the two spellings are
+distinct lookups and the one contradicting the model is rejected
+`400 INVALID_FIELD_PATH`. A positional subscript canonicalises to the wildcard
+key (`$.arr[0]` resolves against `$.arr[*]`) — see
+`positional-subscript-path.md`.
+
 **Workflow criteria are out of scope of this document.** Criteria evaluate
 through the in-process predicate evaluator, never through `ConditionToFilter`,
 so a bare criterion `jsonPath` is unaffected by this change. They are covered by

--- a/e2e/parity/search_path_key.go
+++ b/e2e/parity/search_path_key.go
@@ -1,7 +1,9 @@
 package parity
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
@@ -220,25 +222,35 @@ func RunSearchPathTypeMismatch400(t *testing.T, fixture BackendFixture) {
 // no other backend — a divergence, and storage internals exposed as a
 // queryable surface.
 //
-// It probes through grouped stats, NOT /search, and that choice is the whole
-// point: /search validates every data-field path against the model first, so
-// "$._meta.state" is rejected 400 INVALID_FIELD_PATH before any evaluator runs
-// and the probe would pass vacuously on a leaking backend. Grouped stats runs
-// no data-field path validation, so the condition reaches the residual
-// evaluator — which is the code this guards. Verified by reverting the fix:
-// through /search the scenario passes either way; through grouped stats it
-// fails.
+// # This scenario changed shape when grouped stats gained path validation
+//
+// It used to probe the residual EVALUATOR through grouped stats, because
+// grouped stats was the one condition surface that validated no data-field
+// path: /search rejects "$._meta.state" as an unknown field before any
+// evaluator runs, so the same probe there would pass vacuously on a leaking
+// backend.
+//
+// Grouped stats now validates its condition, groupBy and aggregate paths
+// against the model like every other surface, so that route is closed and no
+// client-supplied path can reach the evaluator with "_meta" in it. What this
+// scenario can still pin is the boundary: every surface rejects the path
+// identically.
+//
+// **The underlying leak is unreachable, not fixed.** PostgreSQL still stores
+// the domain data and the storage "_meta" block merged into one document, so
+// the residual evaluator would still resolve a "_meta" path if one ever
+// reached it — as would the groupBy / ORDER BY / aggregate arms and the
+// IS_NULL / NOT_NULL operators, which compile straight to SQL with no kernel
+// re-check. Nesting the domain data rather than merging it (cyoda-go#489)
+// removes the shared namespace outright. Until then the only thing standing
+// between a client and storage internals is the boundary check asserted below,
+// and a model that legitimately DECLARES a field named "_meta" would collide
+// with the storage block on PostgreSQL and reach the evaluator through a path
+// the model knows — the probe #489 should carry when it lands.
 //
 // Every path here carries the "$." leader. That is not cosmetic: without it
 // the request is rejected as malformed at the boundary and the probe would
-// again pass vacuously, testing the path grammar instead of the meta block.
-//
-// DELIBERATELY NOT COVERED: the groupBy / ORDER BY / aggregate arms, and the
-// IS_NULL / NOT_NULL operators. Those are compiled straight to SQL against the
-// merged document with no kernel re-check, so they still resolve _meta on
-// PostgreSQL. The fix for that (nesting the domain data rather than merging
-// it) removes the shared namespace outright and closes all of them at once.
-// When it lands, extend this scenario and delete this note.
+// pass vacuously, testing the path grammar instead of the meta block.
 func RunSearchMetaBlockNotMatchableAsDataPath(t *testing.T, fixture BackendFixture) {
 	tenant := fixture.NewTenant(t)
 	c := client.NewClient(fixture.BaseURL(), tenant.Token)
@@ -277,27 +289,40 @@ func RunSearchMetaBlockNotMatchableAsDataPath(t *testing.T, fixture BackendFixtu
 	//
 	// Verified by reverting the fix: with EQUALS the scenario passes either way;
 	// with CONTAINS all three probes fail.
+	// The storage meta block is not a declared field, so naming it is naming an
+	// unknown path — rejected identically on grouped stats and on /search. Each
+	// operand is a value the entity's metadata ACTUALLY holds, so a backend
+	// that leaked would return a non-empty result rather than an empty one if
+	// the boundary check were ever removed.
 	for _, tc := range []struct {
 		label string
-		cond  client.AggregationCond
+		path  string
+		value string
 	}{
-		{"$._meta.state", client.AggregationCond{"type": "simple", "jsonPath": "$._meta.state", "operatorType": "CONTAINS", "value": "CREATE"}},
-		{"$._meta.tenant_id", client.AggregationCond{"type": "simple", "jsonPath": "$._meta.tenant_id", "operatorType": "CONTAINS", "value": tenant.ID}},
-		{"$._meta.model_name", client.AggregationCond{"type": "simple", "jsonPath": "$._meta.model_name", "operatorType": "CONTAINS", "value": modelName}},
+		{"$._meta.state", "$._meta.state", "CREATE"},
+		{"$._meta.tenant_id", "$._meta.tenant_id", tenant.ID},
+		{"$._meta.model_name", "$._meta.model_name", modelName},
 	} {
-		buckets, err := c.QueryGroupedStats(t, modelName, modelVersion, client.GroupedStatsRequest{
+		cond := client.AggregationCond{"type": "simple", "jsonPath": tc.path, "operatorType": "CONTAINS", "value": tc.value}
+		_, err := c.QueryGroupedStats(t, modelName, modelVersion, client.GroupedStatsRequest{
 			GroupBy:   []string{"$.status"},
-			Condition: &tc.cond,
+			Condition: &cond,
 		})
-		if err != nil {
-			t.Fatalf("[%s] QueryGroupedStats: %v", tc.label, err)
+		if err == nil {
+			t.Errorf("[%s] grouped stats accepted a condition on the storage meta block; "+
+				"it is not a declared field and every surface must reject it", tc.label)
+		} else if !strings.Contains(err.Error(), "INVALID_FIELD_PATH") {
+			t.Errorf("[%s] grouped stats rejected with %v, want INVALID_FIELD_PATH", tc.label, err)
 		}
-		total := int64(0)
-		for _, b := range buckets {
-			total += b.Count
+
+		// The same path on /search, so the two surfaces cannot drift apart.
+		raw := fmt.Sprintf(`{"type":"simple","jsonPath":%q,"operatorType":"CONTAINS","value":%q}`, tc.path, tc.value)
+		status, body, sErr := c.SyncSearchRaw(t, modelName, modelVersion, raw)
+		if sErr != nil {
+			t.Fatalf("[%s] SyncSearchRaw: %v", tc.label, sErr)
 		}
-		if total != 0 {
-			t.Errorf("[%s] matched %d entities: the storage meta block is addressable as entity data on this backend", tc.label, total)
+		if status != http.StatusBadRequest || !containsErrorCode(body, "INVALID_FIELD_PATH") {
+			t.Errorf("[%s] /search returned %d body=%s, want 400 INVALID_FIELD_PATH", tc.label, status, body)
 		}
 	}
 

--- a/internal/domain/entity/delete_selection_refresh_test.go
+++ b/internal/domain/entity/delete_selection_refresh_test.go
@@ -79,3 +79,43 @@ func TestPlanDeleteSelection_GenuinelyUnknownPath_StillRejects(t *testing.T) {
 		t.Errorf("expected exactly 1 refresh (bounded), got %d", ms.RefreshCount())
 	}
 }
+
+// TestPlanDeleteSelection_SchemaLessModel_RejectsTheDataPath closes a
+// divergence between conditional delete and /search/direct.
+//
+// planDeleteSelection guarded its whole path check with `if fields != nil`,
+// citing validateConditionPaths as doing the same. It no longer does: a model
+// declaring no fields is a model in which the named path does not exist, and
+// search answers 400 INVALID_FIELD_PATH. Delete accepted the path and then
+// translated the condition against a nil fields map — which does not make the
+// filter inert, it makes it SKEWED, because an empty declared-type set
+// annihilates the comparison operators while the string operators keep
+// matching.
+//
+// That skew decides which rows get DELETED. Of the three endpoints sharing
+// this contract, this is the one where guessing is least acceptable.
+func TestPlanDeleteSelection_SchemaLessModel_RejectsTheDataPath(t *testing.T) {
+	h := &Handler{}
+	ref := spi.ModelRef{EntityName: "E", ModelVersion: "1"}
+	// A descriptor carrying no schema at all — not an empty schema.
+	bare := &spi.ModelDescriptor{Ref: ref, State: spi.ModelLocked}
+	ms := &refreshingStore{
+		getQueue:     []*spi.ModelDescriptor{bare},
+		refreshQueue: []*spi.ModelDescriptor{bare},
+	}
+
+	cond, err := predicate.ParseCondition([]byte(`{"type":"simple","jsonPath":"$.name","operatorType":"EQUALS","value":"x"}`))
+	if err != nil {
+		t.Fatalf("ParseCondition: %v", err)
+	}
+
+	_, planErr := h.planDeleteSelection(context.Background(), ms, ref, cond)
+	var appErr *common.AppError
+	if !errors.As(planErr, &appErr) {
+		t.Fatalf("conditional delete accepted a data path against a model declaring "+
+			"no fields (err = %v); /search/direct rejects it 400 INVALID_FIELD_PATH", planErr)
+	}
+	if appErr.Code != common.ErrCodeInvalidFieldPath {
+		t.Errorf("code = %q, want %q", appErr.Code, common.ErrCodeInvalidFieldPath)
+	}
+}

--- a/internal/domain/entity/grouped_stats_handler.go
+++ b/internal/domain/entity/grouped_stats_handler.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
 )
 
 // maxGroupedStatsBodySize bounds the request body for the grouped-stats
@@ -28,12 +30,18 @@ const maxGroupedStatsBodySize = 10 * 1024 * 1024
 // the model is not found for the calling tenant — the handler maps that to
 // 404 MODEL_NOT_FOUND.
 //
+// modelStore is returned alongside so the handler can hold the condition,
+// groupBy and aggregate paths to the model the way /search/direct and
+// conditional delete do — including their bounded single RefreshAndGet, which
+// is what stops a stale cached schema from falsely rejecting a field a peer
+// node has already extended the model with (.claude/rules/multi-node-primary.md).
+//
 // The handler holds a StoreResolver rather than (factory, modelStore)
 // directly so it can be unit-tested in isolation: tests inject a
 // closure that returns the desired fake store + model. Production
 // wiring at app construction supplies a closure that uses the existing
 // StoreFactory + ModelStore plumbing (see app/app.go).
-type StoreResolver func(r *http.Request, entityName, modelVersion string) (store any, model spi.ModelRef, fields map[string]schema.FieldDescriptor, ok bool, err error)
+type StoreResolver func(r *http.Request, entityName, modelVersion string) (store any, model spi.ModelRef, fields map[string]schema.FieldDescriptor, modelStore spi.ModelStore, ok bool, err error)
 
 // GroupedStatsHandler is the HTTP handler for
 // POST /api/entity/stats/{entityName}/{modelVersion}/query.
@@ -133,7 +141,7 @@ func (h *GroupedStatsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 	entityName := r.PathValue("entityName")
 	modelVersion := r.PathValue("modelVersion")
-	store, model, fields, ok, err := h.resolve(r, entityName, modelVersion)
+	store, model, fields, modelStore, ok, err := h.resolve(r, entityName, modelVersion)
 	if err != nil {
 		common.WriteError(w, r, common.Internal("failed to resolve store", err))
 		return
@@ -144,6 +152,55 @@ func (h *GroupedStatsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			"model not found",
 		))
 		return
+	}
+
+	// Hold every path this request names to the model, the way /search/direct
+	// and conditional DELETE do. Grouped stats used to check none of them, so
+	// a condition, a groupBy or an aggregate naming a field the model does not
+	// declare was answered rather than refused — and the numbers came back
+	// looking like a real answer: an undeclared condition leaf annihilates to
+	// a non-match, an undeclared groupBy buckets every entity under "absent",
+	// and an undeclared SUM reports 0 as though it were the total.
+	//
+	// modelStore may be nil only from a test resolver that supplies none; a
+	// request that reached here in production always carries one.
+	if modelStore != nil {
+		refreshed, pErr := search.ValidateKnownPaths(
+			r.Context(), modelStore, model, requestFieldPaths(validated), fields)
+		if pErr != nil {
+			var appErr *common.AppError
+			if !errors.As(pErr, &appErr) {
+				appErr = common.Internal("field-path validation failed", pErr)
+			}
+			common.WriteError(w, r, appErr)
+			return
+		}
+		fields = refreshed
+
+		// Type-soundness against the REAL model. The service layer also calls
+		// ValidateConditionValueTypes, but with a nil model, so only its
+		// model-independent arm (meta fields, temporal operands) ran and an
+		// operand parsing into none of a declared field's types was accepted
+		// where /search/direct returns 400 CONDITION_TYPE_MISMATCH.
+		if len(validated.Condition) > 0 {
+			node, nErr := search.LoadModelNode(r.Context(), modelStore, model)
+			if nErr != nil {
+				common.WriteError(w, r, common.Internal("failed to load model schema for condition validation", nErr))
+				return
+			}
+			if node != nil {
+				if cond, pErr := predicate.ParseCondition(validated.Condition); pErr == nil {
+					if tErr := search.ValidateConditionValueTypes(node, cond); tErr != nil {
+						code := common.ErrCodeConditionTypeMismatch
+						if errors.Is(tErr, search.ErrInvalidFieldPath) {
+							code = common.ErrCodeInvalidFieldPath
+						}
+						common.WriteError(w, r, common.Operational(http.StatusBadRequest, code, tErr.Error()))
+						return
+					}
+				}
+			}
+		}
 	}
 
 	// Dispatch to the service layer. QueryGroupedStats already classifies
@@ -162,4 +219,48 @@ func (h *GroupedStatsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	common.WriteJSON(w, http.StatusOK, buckets)
+}
+
+// requestFieldPaths collects every data path a grouped-stats request names —
+// the condition's leaves, the groupBy entries and the aggregate fields — as one
+// set for [search.ValidateKnownPaths].
+//
+// The groupBy "state" entry addresses entity metadata, not a schema field, and
+// is excluded; validateGroupedStatsRequest has already marked it IsState. Both
+// remaining kinds are stored in wire form ("$.x"), which is the fields-map key
+// convention, so they need no rewriting.
+//
+// A condition that will not parse contributes nothing rather than failing here:
+// the service layer parses it too and produces the classified INVALID_CONDITION
+// this handler would otherwise pre-empt with a worse diagnostic.
+func requestFieldPaths(req *ValidatedGroupedStatsRequest) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(p string) {
+		if p == "" {
+			return
+		}
+		if _, dup := seen[p]; dup {
+			return
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+
+	if len(req.Condition) > 0 {
+		if cond, err := predicate.ParseCondition(req.Condition); err == nil {
+			for _, p := range search.ConditionFieldPaths(cond) {
+				add(p)
+			}
+		}
+	}
+	for _, g := range req.GroupBy {
+		if !g.IsState {
+			add(g.Path)
+		}
+	}
+	for _, a := range req.Aggregations {
+		add(a.Field)
+	}
+	return out
 }

--- a/internal/domain/entity/grouped_stats_handler_test.go
+++ b/internal/domain/entity/grouped_stats_handler_test.go
@@ -2,6 +2,7 @@ package entity_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -93,8 +94,8 @@ func TestGroupedStatsHandler_RejectsUnknownTopLevelField(t *testing.T) {
 }
 
 func TestGroupedStatsHandler_Returns404OnUnknownModel(t *testing.T) {
-	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-		return nil, spi.ModelRef{}, nil, false, nil
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return nil, spi.ModelRef{}, nil, nil, false, nil
 	}
 	h := entity.NewGroupedStatsHandler(resolver, 10000)
 	body := strings.NewReader(`{"groupBy":["state"]}`)
@@ -114,8 +115,8 @@ func TestGroupedStatsHandler_Returns404OnUnknownModel(t *testing.T) {
 func TestGroupedStatsHandler_BackendNotSupportedReturns501(t *testing.T) {
 	// "store" satisfies neither Iterable nor GroupedAggregator.
 	type empty struct{}
-	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-		return empty{}, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, true, nil
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return empty{}, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, nil, true, nil
 	}
 	h := entity.NewGroupedStatsHandler(resolver, 10000)
 	body := strings.NewReader(`{"groupBy":["state"]}`)
@@ -139,8 +140,8 @@ func TestGroupedStatsHandler_GroupCardinalityExceededReturns422(t *testing.T) {
 		{Meta: spi.EntityMeta{State: "allocated"}, Data: []byte(`{}`)},
 	}
 	store := &fakeIterable{entities: rows}
-	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, true, nil
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, nil, true, nil
 	}
 	h := entity.NewGroupedStatsHandler(resolver, 1)
 	body := strings.NewReader(`{"groupBy":["state"]}`)
@@ -162,8 +163,8 @@ func TestGroupedStatsHandler_InvalidConditionReturns400(t *testing.T) {
 		{Meta: spi.EntityMeta{State: "available"}, Data: []byte(`{}`)},
 	}
 	store := &fakeIterable{entities: rows}
-	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, true, nil
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, nil, true, nil
 	}
 	h := entity.NewGroupedStatsHandler(resolver, 10000)
 	// Condition with bogus "type" — predicate.ParseCondition rejects it.
@@ -186,8 +187,8 @@ func TestGroupedStatsHandler_LifecycleTemporalTypeMismatchReturns400(t *testing.
 		{Meta: spi.EntityMeta{State: "available"}, Data: []byte(`{}`)},
 	}
 	store := &fakeIterable{entities: rows}
-	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, true, nil
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, nil, true, nil
 	}
 	h := entity.NewGroupedStatsHandler(resolver, 10000)
 	// Parse-based (spec §6): a comparison operand that parses into no temporal
@@ -212,8 +213,8 @@ func TestGroupedStatsHandler_UnknownMetaFieldReturns400(t *testing.T) {
 		{Meta: spi.EntityMeta{State: "available"}, Data: []byte(`{}`)},
 	}
 	store := &fakeIterable{entities: rows}
-	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, true, nil
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, nil, true, nil
 	}
 	h := entity.NewGroupedStatsHandler(resolver, 10000)
 	// "bogus" is not a recognized meta filter field — parity with /search's
@@ -237,8 +238,8 @@ func TestGroupedStatsHandler_MalformedBetweenArityReturns400(t *testing.T) {
 		{Meta: spi.EntityMeta{State: "available"}, Data: []byte(`{"price":10}`)},
 	}
 	store := &fakeIterable{entities: rows}
-	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, true, nil
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, nil, true, nil
 	}
 	h := entity.NewGroupedStatsHandler(resolver, 10000)
 	body := strings.NewReader(`{"groupBy":["state"],"condition":{"type":"simple","jsonPath":"$.price","operatorType":"BETWEEN","value":[10]}}`)
@@ -262,8 +263,8 @@ func TestGroupedStatsHandler_HappyPathReturns200(t *testing.T) {
 		{Meta: spi.EntityMeta{State: "allocated"}, Data: []byte(`{}`)},
 	}
 	store := &fakeIterable{entities: rows}
-	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, true, nil
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return store, spi.ModelRef{EntityName: "X", ModelVersion: "1"}, nil, nil, true, nil
 	}
 	h := entity.NewGroupedStatsHandler(resolver, 10000)
 	body := strings.NewReader(`{"groupBy":["state"]}`)
@@ -292,8 +293,8 @@ func TestGroupedStatsHandler_HappyPathReturns200(t *testing.T) {
 }
 
 func TestGroupedStatsHandler_ResolverError_Returns500(t *testing.T) {
-	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-		return nil, spi.ModelRef{}, nil, false, errors.New("boom")
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return nil, spi.ModelRef{}, nil, nil, false, errors.New("boom")
 	}
 	h := entity.NewGroupedStatsHandler(resolver, 10000)
 	body := strings.NewReader(`{"groupBy":["state"]}`)
@@ -309,6 +310,136 @@ func TestGroupedStatsHandler_ResolverError_Returns500(t *testing.T) {
 
 // Compile-time sanity: confirm the StoreResolver signature is what the
 // router-wiring site expects.
-var _ entity.StoreResolver = func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, bool, error) {
-	return nil, spi.ModelRef{}, nil, false, nil
+var _ entity.StoreResolver = func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+	return nil, spi.ModelRef{}, nil, nil, false, nil
+}
+
+// --- Schema-membership validation (grouped stats) ---
+//
+// /search/direct and conditional DELETE both reject a condition naming a field
+// the model does not declare, with 400 INVALID_FIELD_PATH. Grouped stats did
+// not check at all — not the condition, not the groupBy paths, not the
+// aggregate fields — so such a request was answered from a filter whose
+// comparison leaves annihilate while its string leaves keep matching. The
+// numbers came back looking like a real answer.
+
+// declaredFieldsModelStore serves a descriptor declaring the given String
+// leaves. It implements no RefreshAndGet: the cached miss is authoritative,
+// which is the same shape validateConditionPaths treats as final.
+type declaredFieldsModelStore struct {
+	ref    spi.ModelRef
+	fields []string
+}
+
+func (s *declaredFieldsModelStore) Get(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	node := schema.NewObjectNode()
+	for _, f := range s.fields {
+		dt := schema.String
+		if f == "age" {
+			dt = schema.Integer
+		}
+		node.SetChild(f, schema.NewLeafNode(dt))
+	}
+	raw, err := schema.Marshal(node)
+	if err != nil {
+		return nil, err
+	}
+	return &spi.ModelDescriptor{Ref: s.ref, State: spi.ModelLocked, Schema: raw}, nil
+}
+
+func (s *declaredFieldsModelStore) Save(context.Context, *spi.ModelDescriptor) error { return nil }
+func (s *declaredFieldsModelStore) GetAll(context.Context) ([]spi.ModelRef, error)   { return nil, nil }
+func (s *declaredFieldsModelStore) Delete(context.Context, spi.ModelRef) error       { return nil }
+func (s *declaredFieldsModelStore) Lock(context.Context, spi.ModelRef) error         { return nil }
+func (s *declaredFieldsModelStore) Unlock(context.Context, spi.ModelRef) error       { return nil }
+func (s *declaredFieldsModelStore) IsLocked(context.Context, spi.ModelRef) (bool, error) {
+	return true, nil
+}
+func (s *declaredFieldsModelStore) SetChangeLevel(context.Context, spi.ModelRef, spi.ChangeLevel) error {
+	return nil
+}
+func (s *declaredFieldsModelStore) ExtendSchema(context.Context, spi.ModelRef, spi.SchemaDelta) error {
+	return nil
+}
+
+var _ spi.ModelStore = (*declaredFieldsModelStore)(nil)
+
+// groupedStatsPathReq drives one request against a model declaring "name",
+// returning the recorder.
+func groupedStatsPathReq(t *testing.T, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	ref := spi.ModelRef{EntityName: "X", ModelVersion: "1"}
+	ms := &declaredFieldsModelStore{ref: ref, fields: []string{"name", "age"}}
+	fields := map[string]schema.FieldDescriptor{
+		"$.name": {Path: "$.name", Types: []spi.DataType{spi.String}},
+		"$.age":  {Path: "$.age", Types: []spi.DataType{spi.Integer}},
+	}
+	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, map[string]schema.FieldDescriptor, spi.ModelStore, bool, error) {
+		return &fakeIterable{}, ref, fields, ms, true, nil
+	}
+	h := entity.NewGroupedStatsHandler(resolver, 10000)
+	req := httptest.NewRequest(http.MethodPost, "/api/entity/stats/X/1/query", strings.NewReader(body))
+	req.SetPathValue("entityName", "X")
+	req.SetPathValue("modelVersion", "1")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestGroupedStatsHandler_UnknownConditionPath_Rejected(t *testing.T) {
+	rec := groupedStatsPathReq(t, `{"groupBy":["state"],"condition":{"type":"simple","jsonPath":"$.nope","operatorType":"EQUALS","value":"x"}}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400 — /search/direct rejects this condition (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeProblemErrorCode(t, rec.Body.Bytes()); got != "INVALID_FIELD_PATH" {
+		t.Fatalf("errorCode=%s, want INVALID_FIELD_PATH", got)
+	}
+}
+
+func TestGroupedStatsHandler_UnknownGroupByPath_Rejected(t *testing.T) {
+	rec := groupedStatsPathReq(t, `{"groupBy":["$.nope"]}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400: grouping by a field the model does not declare "+
+			"buckets every entity under \"absent\" and reports it as a result (body: %s)",
+			rec.Code, rec.Body.String())
+	}
+	if got := decodeProblemErrorCode(t, rec.Body.Bytes()); got != "INVALID_FIELD_PATH" {
+		t.Fatalf("errorCode=%s, want INVALID_FIELD_PATH", got)
+	}
+}
+
+func TestGroupedStatsHandler_UnknownAggregateField_Rejected(t *testing.T) {
+	rec := groupedStatsPathReq(t, `{"groupBy":["state"],"aggregations":[{"op":"sum","field":"$.nope","as":"s"}]}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400: summing a field the model does not declare "+
+			"reports 0 as though it were the total (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeProblemErrorCode(t, rec.Body.Bytes()); got != "INVALID_FIELD_PATH" {
+		t.Fatalf("errorCode=%s, want INVALID_FIELD_PATH", got)
+	}
+}
+
+// The accept side: a declared path on every surface still runs.
+func TestGroupedStatsHandler_DeclaredPaths_StillAccepted(t *testing.T) {
+	rec := groupedStatsPathReq(t, `{"groupBy":["$.name"],"condition":{"type":"simple","jsonPath":"$.name","operatorType":"EQUALS","value":"x"}}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200 for paths the model declares (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestGroupedStatsHandler_ConditionTypeMismatch_Rejected closes the other half
+// of grouped stats' schema blindness. The service deliberately passed a nil
+// model to ValidateConditionValueTypes — commented as "grouped-stats has no
+// model-schema plumbing" — so the schema-DEPENDENT arm of that check was
+// skipped and an operand that parses into none of a declared field's types was
+// accepted. /search/direct answers 400 CONDITION_TYPE_MISMATCH for the same
+// condition. The plumbing exists now.
+func TestGroupedStatsHandler_ConditionTypeMismatch_Rejected(t *testing.T) {
+	rec := groupedStatsPathReq(t, `{"groupBy":["state"],"condition":{"type":"simple","jsonPath":"$.age","operatorType":"GREATER_THAN","value":"not-a-number"}}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeProblemErrorCode(t, rec.Body.Bytes()); got != "CONDITION_TYPE_MISMATCH" {
+		t.Fatalf("errorCode=%s, want CONDITION_TYPE_MISMATCH", got)
+	}
 }

--- a/internal/domain/entity/grouped_stats_service.go
+++ b/internal/domain/entity/grouped_stats_service.go
@@ -175,16 +175,19 @@ func (s *GroupedStatsService) queryGroupedStatsInner(
 
 	// Condition type-soundness (correctness-over-availability): mirrors the
 	// search path's validateConditionTypes boundary for its model-independent
-	// parts. A nil model is passed deliberately — grouped-stats has no
-	// model-schema plumbing (a separate, unflagged concern), but the
-	// lifecycle/temporal/meta-field rules validateLifecycleType enforces
-	// (known meta field; valid operator + RFC3339 operand on temporal
-	// fields) don't need the schema at all, and ValidateConditionValueTypes
-	// gracefully skips the schema-dependent data-field check when model is
-	// nil. Without this, e.g. a CONTAINS operator against the temporal
-	// creationDate meta field would silently produce an empty result here
-	// (never matching in ConditionToFilter/match.Prepare) instead of the 400
-	// CONDITION_TYPE_MISMATCH the equivalent /search request returns.
+	// parts — the lifecycle/temporal/meta-field rules validateLifecycleType
+	// enforces (known meta field; valid operator + RFC3339 operand on temporal
+	// fields), which need no schema. Without this, e.g. a CONTAINS operator
+	// against the temporal creationDate meta field would silently produce an
+	// empty result here instead of the 400 CONDITION_TYPE_MISMATCH the
+	// equivalent /search request returns.
+	//
+	// A nil model is passed because this layer has none. The SCHEMA-dependent
+	// arm — an operand parsing into none of a declared field's types — runs at
+	// the handler, which holds the model store and validates the condition's,
+	// groupBy's and aggregates' paths against the model in the same place. A
+	// direct caller of this service that bypasses the handler gets only the
+	// model-independent half, which is why the handler is the boundary.
 	if parsedCond != nil {
 		if tErr := search.ValidateConditionValueTypes(nil, parsedCond); tErr != nil {
 			// Propagate tErr directly (not re-wrapped): it already wraps

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -1083,10 +1083,15 @@ func (h *Handler) planDeleteSelection(ctx context.Context, modelStore spi.ModelS
 	}
 
 	// Condition type-soundness — mirrors SearchService.Search's
-	// validateConditionTypes boundary. A schema-load hiccup degrades to
-	// "skip this check" exactly like Search's own loadModelNode does,
-	// rather than 5xx-ing on an infra flake.
-	if node := deleteModelSchemaNode(ctx, modelStore, ref); node != nil {
+	// validateConditionTypes boundary, including its failure policy: a schema
+	// that cannot be loaded fails the request. A conditional delete decided
+	// against a condition nobody could type-check is the last place to prefer
+	// an available answer to a correct one.
+	node, nodeErr := deleteModelSchemaNode(ctx, modelStore, ref)
+	if nodeErr != nil {
+		return deleteSelectionPlan{}, fmt.Errorf("failed to load model schema for condition validation: %w", nodeErr)
+	}
+	if node != nil {
 		if tErr := search.ValidateConditionValueTypes(node, cond); tErr != nil {
 			code := common.ErrCodeConditionTypeMismatch
 			if errors.Is(tErr, search.ErrInvalidFieldPath) {
@@ -1118,20 +1123,22 @@ func (h *Handler) planDeleteSelection(ctx context.Context, modelStore spi.ModelS
 }
 
 // deleteModelSchemaNode loads and parses ref's schema for
-// planDeleteSelection's type-soundness check, mirroring search's
-// unexported loadModelNode. Returns nil (skip the check) on any load/parse
-// hiccup or an unbound schema; the caller has already gated model
-// existence separately.
-func deleteModelSchemaNode(ctx context.Context, modelStore spi.ModelStore, ref spi.ModelRef) *schema.ModelNode {
+// planDeleteSelection's type-soundness check, mirroring search's unexported
+// loadModelNode — failure policy included. A load or parse failure is an
+// ERROR: the schema is what the check needs. A (nil, nil) return means the
+// descriptor carries no schema, so there is no type constraint to apply. The
+// caller has already gated model existence separately.
+func deleteModelSchemaNode(ctx context.Context, modelStore spi.ModelStore, ref spi.ModelRef) (*schema.ModelNode, error) {
 	desc, err := modelStore.Get(ctx, ref)
-	if err != nil || desc == nil || len(desc.Schema) == 0 {
-		return nil
-	}
-	node, err := schema.Unmarshal(desc.Schema)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return node
+	if desc == nil || len(desc.Schema) == 0 {
+		// No schema bound: the model declares no typed fields, so there is no
+		// constraint to apply. Distinct from a failure to read it.
+		return nil, nil
+	}
+	return schema.Unmarshal(desc.Schema)
 }
 
 // drainDeleteSelection opens a spi.Iterable iterator scoped to ctx (pass a

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -1039,51 +1039,21 @@ func (h *Handler) planDeleteSelection(ctx context.Context, modelStore spi.ModelS
 	}
 
 	// Unknown data-field paths (TestDeleteEntities_UnknownFieldPath, error
-	// matrix row deleteEntities/INVALID_FIELD_PATH) — mirrors SearchService's
-	// unexported validateConditionPaths via the exported
-	// search.FindUnknownFieldPaths, minus its negative-cache (a Search
-	// hot-path concern this lower-volume endpoint doesn't need). It DOES
-	// keep the bounded single-refresh-then-fail retry: that refresh is the
-	// correctness half, not the optimisation. On a cluster, node A can
-	// extend a model with a new field and node B's cached descriptor map
-	// won't see it until the schema-change event arrives; without a refresh
-	// here, a condition on that field would 400 INVALID_FIELD_PATH on node B
-	// while the identical /search/direct condition succeeds via
-	// validateConditionPaths' own refresh — a cross-node false rejection.
-	// A nil fields map — no schema bound — is NOT a reason to skip the check.
-	// It is a model declaring no fields, in which every data path the
-	// condition names is unknown, and that is what /search/direct answers via
-	// validateConditionPaths. Guarding this block on `fields != nil` let a
-	// conditional DELETE proceed on an unvalidated path and then translate
-	// against a nil map, which does not make the filter inert but skewed:
-	// empty declared types annihilate the comparison operators while the
-	// string operators keep matching. That skew decides which rows are
-	// deleted.
-	if unknown := search.FindUnknownFieldPaths(cond, fields); len(unknown) > 0 {
-		freshFields, refreshed, refreshErr := search.RefreshFieldsMap(ctx, modelStore, ref)
-		switch {
-		case !refreshed:
-			// Store has no cache layer to refresh — the pre-refresh
-			// miss is authoritative, same as validateConditionPaths.
-		case refreshErr != nil:
-			if errors.Is(refreshErr, spi.ErrNotFound) {
-				// Model was deleted between the earlier load and
-				// RefreshAndGet — the miss is authoritative, there is
-				// no schema left to consult.
-				break
-			}
-			slog.Debug("schema refresh failed while validating delete condition paths",
-				"pkg", "entity", "entityName", ref.EntityName, "modelVersion", ref.ModelVersion, "error", refreshErr)
-		case freshFields != nil:
-			unknown = search.FindUnknownFieldPaths(cond, freshFields)
-		}
-		if len(unknown) > 0 {
-			return deleteSelectionPlan{}, common.Operational(http.StatusBadRequest, common.ErrCodeInvalidFieldPath,
-				fmt.Sprintf("condition references unknown field path(s): %s", strings.Join(unknown, ", ")))
-		}
-		if freshFields != nil {
-			fields = freshFields
-		}
+	// matrix row deleteEntities/INVALID_FIELD_PATH). Shared with
+	// /search/direct and grouped stats through search.ValidateKnownPaths, so
+	// the three endpoints cannot drift on what counts as a known path — this
+	// block was previously a hand-copied twin of validateConditionPaths and
+	// had already drifted once, guarding itself on `fields != nil` and so
+	// accepting any path at all against a model declaring no fields.
+	//
+	// The bounded single refresh lives in the shared helper: it is the
+	// correctness half, not the optimisation, because on a cluster node A can
+	// extend a model with a new field before node B's cached descriptor sees
+	// the schema-change event. Search's negative cache stays Search's own — a
+	// hot-path concern this lower-volume endpoint does not need.
+	fields, pathErr := search.ValidateKnownPaths(ctx, modelStore, ref, search.ConditionFieldPaths(cond), fields)
+	if pathErr != nil {
+		return deleteSelectionPlan{}, pathErr
 	}
 
 	// Condition type-soundness — mirrors SearchService.Search's

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -1050,35 +1050,39 @@ func (h *Handler) planDeleteSelection(ctx context.Context, modelStore spi.ModelS
 	// here, a condition on that field would 400 INVALID_FIELD_PATH on node B
 	// while the identical /search/direct condition succeeds via
 	// validateConditionPaths' own refresh — a cross-node false rejection.
-	// fields == nil means no schema is bound at all — same as
-	// validateConditionPaths, skip the check rather than flagging every path
-	// "unknown" against an empty map.
-	if fields != nil {
-		if unknown := search.FindUnknownFieldPaths(cond, fields); len(unknown) > 0 {
-			freshFields, refreshed, refreshErr := search.RefreshFieldsMap(ctx, modelStore, ref)
-			switch {
-			case !refreshed:
-				// Store has no cache layer to refresh — the pre-refresh
-				// miss is authoritative, same as validateConditionPaths.
-			case refreshErr != nil:
-				if errors.Is(refreshErr, spi.ErrNotFound) {
-					// Model was deleted between the earlier load and
-					// RefreshAndGet — the miss is authoritative, there is
-					// no schema left to consult.
-					break
-				}
-				slog.Debug("schema refresh failed while validating delete condition paths",
-					"pkg", "entity", "entityName", ref.EntityName, "modelVersion", ref.ModelVersion, "error", refreshErr)
-			case freshFields != nil:
-				unknown = search.FindUnknownFieldPaths(cond, freshFields)
+	// A nil fields map — no schema bound — is NOT a reason to skip the check.
+	// It is a model declaring no fields, in which every data path the
+	// condition names is unknown, and that is what /search/direct answers via
+	// validateConditionPaths. Guarding this block on `fields != nil` let a
+	// conditional DELETE proceed on an unvalidated path and then translate
+	// against a nil map, which does not make the filter inert but skewed:
+	// empty declared types annihilate the comparison operators while the
+	// string operators keep matching. That skew decides which rows are
+	// deleted.
+	if unknown := search.FindUnknownFieldPaths(cond, fields); len(unknown) > 0 {
+		freshFields, refreshed, refreshErr := search.RefreshFieldsMap(ctx, modelStore, ref)
+		switch {
+		case !refreshed:
+			// Store has no cache layer to refresh — the pre-refresh
+			// miss is authoritative, same as validateConditionPaths.
+		case refreshErr != nil:
+			if errors.Is(refreshErr, spi.ErrNotFound) {
+				// Model was deleted between the earlier load and
+				// RefreshAndGet — the miss is authoritative, there is
+				// no schema left to consult.
+				break
 			}
-			if len(unknown) > 0 {
-				return deleteSelectionPlan{}, common.Operational(http.StatusBadRequest, common.ErrCodeInvalidFieldPath,
-					fmt.Sprintf("condition references unknown field path(s): %s", strings.Join(unknown, ", ")))
-			}
-			if freshFields != nil {
-				fields = freshFields
-			}
+			slog.Debug("schema refresh failed while validating delete condition paths",
+				"pkg", "entity", "entityName", ref.EntityName, "modelVersion", ref.ModelVersion, "error", refreshErr)
+		case freshFields != nil:
+			unknown = search.FindUnknownFieldPaths(cond, freshFields)
+		}
+		if len(unknown) > 0 {
+			return deleteSelectionPlan{}, common.Operational(http.StatusBadRequest, common.ErrCodeInvalidFieldPath,
+				fmt.Sprintf("condition references unknown field path(s): %s", strings.Join(unknown, ", ")))
+		}
+		if freshFields != nil {
+			fields = freshFields
 		}
 	}
 

--- a/internal/domain/search/condition_type_validate.go
+++ b/internal/domain/search/condition_type_validate.go
@@ -321,30 +321,27 @@ func operandElements(v any) []any {
 }
 
 // loadModelNode fetches and parses the model schema for ref, returning the
-// *schema.ModelNode used for condition-type validation. Returns nil when
-// the store lookup fails, the descriptor has no schema bound, or the schema
-// fails to parse — callers treat this as "no type constraints available"
-// rather than failing the search on a schema-load hiccup. EnsureModelRegistered
-// has already confirmed the model exists by the time this runs, so in the
-// normal case the node is present.
-func loadModelNode(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) *schema.ModelNode {
+// *schema.ModelNode used for condition-type validation.
+//
+// A load or parse FAILURE is an error, not an absent node: the schema is what
+// the check needs, and answering the request without it is the fail-open this
+// function used to perform. A (nil, nil) return means something different and
+// benign — the descriptor carries no schema, so the model declares no typed
+// fields and there is no constraint to apply. EnsureModelRegistered has
+// already confirmed the model exists by the time this runs.
+func loadModelNode(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) (*schema.ModelNode, error) {
 	// Reuse the store's cached parse when it has one; see loadFieldsMap.
 	if p, ok := store.(schemaNodeProvider); ok {
-		node, err := p.SchemaNode(ctx, ref)
-		if err != nil {
-			return nil
-		}
-		return node
+		return p.SchemaNode(ctx, ref)
 	}
 	desc, err := store.Get(ctx, ref)
-	if err != nil || desc == nil || len(desc.Schema) == 0 {
-		return nil
-	}
-	node, err := schema.Unmarshal(desc.Schema)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return node
+	if desc == nil || len(desc.Schema) == 0 {
+		return nil, nil
+	}
+	return schema.Unmarshal(desc.Schema)
 }
 
 // validateConditionTypes is the single boundary enforcing condition
@@ -356,16 +353,23 @@ func loadModelNode(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) 
 // anything else → CONDITION_TYPE_MISMATCH (the value is type-incompatible
 // with a known field/operator).
 //
-// A schema-load hiccup (see loadModelNode) returns nil — the search proceeds
-// without pre-rejecting type-unsound conditions rather than 5xx-ing on an infra
-// flake. This is safe, not a wrong-but-available result: with no model the eval
-// path stamps empty Declared too, so comparison leaves degrade to non-match
-// (empty results, never a wrong match), and existence is already gated upstream
-// by EnsureModelRegistered. It is deliberately more lenient here than the
-// workflow engine (which fails closed on the same load error) — a search
-// prefers empty-on-flake to a 5xx.
+// A schema-load failure fails the request. The previous behaviour — skip the
+// check and search anyway — was justified in a comment here as "empty results,
+// never a wrong match", on the reasoning that a missing model leaves every leaf
+// with an empty Declared and so degrades uniformly. That reasoning is wrong,
+// and spi.ConditionToFilter's own godoc says why: an empty declared set
+// annihilates the eight comparison and ordering leaves to a non-match while the
+// other eighteen — the presence tests, the string and pattern operators, and
+// the whole case-insensitive family — keep evaluating normally. The result set
+// is skewed, not empty, and it is returned as though it were complete.
+//
+// The workflow engine already fails closed on the same load error; search now
+// matches it, per .claude/rules/correctness-over-availability.md.
 func (s *SearchService) validateConditionTypes(ctx context.Context, modelStore spi.ModelStore, modelRef spi.ModelRef, cond predicate.Condition) *common.AppError {
-	node := loadModelNode(ctx, modelStore, modelRef)
+	node, err := loadModelNode(ctx, modelStore, modelRef)
+	if err != nil {
+		return common.Internal("failed to load model schema for condition type validation", err)
+	}
 	if node == nil {
 		return nil
 	}

--- a/internal/domain/search/condition_type_validate.go
+++ b/internal/domain/search/condition_type_validate.go
@@ -368,6 +368,13 @@ func loadModelNode(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) 
 func (s *SearchService) validateConditionTypes(ctx context.Context, modelStore spi.ModelStore, modelRef spi.ModelRef, cond predicate.Condition) *common.AppError {
 	node, err := loadModelNode(ctx, modelStore, modelRef)
 	if err != nil {
+		// Same dependency rule as validateConditionPaths: the schema is
+		// required only for a condition that addresses a data path. A
+		// lifecycle-only condition is answerable without it, so an
+		// unreadable schema must not fail it.
+		if len(extractFieldPaths(cond)) == 0 {
+			return nil
+		}
 		return common.Internal("failed to load model schema for condition type validation", err)
 	}
 	if node == nil {

--- a/internal/domain/search/condition_type_validate.go
+++ b/internal/domain/search/condition_type_validate.go
@@ -389,3 +389,16 @@ func (s *SearchService) validateConditionTypes(ctx context.Context, modelStore s
 	}
 	return nil
 }
+
+// LoadModelNode fetches and parses the model schema for ref.
+//
+// Exported for callers outside this package that must run
+// [ValidateConditionValueTypes] against the real model rather than against nil
+// — currently the grouped-stats handler, whose type check was schema-blind
+// while every other condition surface's was not. Failure policy is the one
+// stated on the unexported loader: a load or parse failure is an error, while
+// (nil, nil) means the descriptor carries no schema and there is no type
+// constraint to apply.
+func LoadModelNode(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) (*schema.ModelNode, error) {
+	return loadModelNode(ctx, store, ref)
+}

--- a/internal/domain/search/handler_residual_scan_sqlite_test.go
+++ b/internal/domain/search/handler_residual_scan_sqlite_test.go
@@ -13,6 +13,7 @@ import (
 
 	genapi "github.com/cyoda-platform/cyoda-go/api"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
 	"github.com/cyoda-platform/cyoda-go/plugins/sqlite"
 )
@@ -26,7 +27,15 @@ func saveMinimalModelSqlite(t *testing.T, ctx context.Context, factory *sqlite.S
 	if err != nil {
 		t.Fatalf("ModelStore: %v", err)
 	}
-	if err := ms.Save(ctx, &spi.ModelDescriptor{Ref: ref}); err != nil {
+	node := schema.NewObjectNode()
+	// The residual scan drives MATCHES_PATTERN over $.val; an undeclared path
+	// is now rejected before the scan is reached.
+	node.SetChild("val", schema.NewLeafNode(schema.String))
+	raw, err := schema.Marshal(node)
+	if err != nil {
+		t.Fatalf("schema.Marshal: %v", err)
+	}
+	if err := ms.Save(ctx, &spi.ModelDescriptor{Ref: ref, Schema: raw}); err != nil {
 		t.Fatalf("Save model: %v", err)
 	}
 }

--- a/internal/domain/search/path_validate.go
+++ b/internal/domain/search/path_validate.go
@@ -2,7 +2,9 @@ package search
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go-spi/predicate"
@@ -266,4 +268,71 @@ func fieldsFromDescriptor(desc *spi.ModelDescriptor) (map[string]schema.FieldDes
 		return nil, fmt.Errorf("failed to unmarshal model schema: %w", err)
 	}
 	return node.FieldsMap(), nil
+}
+
+// ConditionFieldPaths returns every data-field JSONPath cond names, normalised
+// to the FieldsMap key convention. Lifecycle, function and nil sub-conditions
+// contribute nothing. Duplicates are folded out.
+//
+// Exported so a caller outside this package can assemble a path set spanning
+// more than a condition — grouped stats also holds its groupBy paths and
+// aggregate fields to the model — and hand the whole set to
+// [ValidateKnownPaths] in one call.
+func ConditionFieldPaths(cond predicate.Condition) []string {
+	return extractFieldPaths(cond)
+}
+
+// ValidateKnownPaths holds every path in paths to the fields the model
+// declares, returning the fields map they validated against.
+//
+// A path absent from fields triggers exactly ONE RefreshAndGet before the
+// request is refused, and the recheck decides. That refresh is the correctness
+// half, not an optimisation: on a cluster, node A can extend a model with a new
+// field while node B's cached descriptor still predates the schema-change
+// event, and without it node B answers 400 for a field the model genuinely has
+// while the identical request succeeds on node A. Bounded to one attempt so a
+// misconfigured client cannot amplify into a refresh storm.
+//
+// A nil fields map is not "nothing to check against": it is a model declaring
+// no fields, in which every path is unknown.
+//
+// The returned error is a 400 INVALID_FIELD_PATH *common.AppError naming the
+// paths that remain unknown. On success the returned map is the refreshed one
+// when a refresh happened, so the caller types its leaves against the schema
+// the paths were actually validated against rather than the stale one.
+func ValidateKnownPaths(
+	ctx context.Context,
+	modelStore spi.ModelStore,
+	ref spi.ModelRef,
+	paths []string,
+	fields map[string]schema.FieldDescriptor,
+) (map[string]schema.FieldDescriptor, error) {
+	if len(paths) == 0 {
+		return fields, nil
+	}
+	unknown := findUnknownPaths(paths, fields)
+	if len(unknown) == 0 {
+		return fields, nil
+	}
+
+	freshFields, refreshed, refreshErr := RefreshFieldsMap(ctx, modelStore, ref)
+	switch {
+	case !refreshed:
+		// No cache layer to refresh — the miss is authoritative.
+	case refreshErr != nil:
+		if !errors.Is(refreshErr, spi.ErrNotFound) {
+			slog.Debug("schema refresh failed during field-path validation",
+				"pkg", "search", "entityName", ref.EntityName,
+				"modelVersion", ref.ModelVersion, "error", refreshErr)
+		}
+		// ErrNotFound: the model was deleted between the two reads, so there
+		// is no schema authority left and the miss stands.
+	case freshFields != nil:
+		unknown = findUnknownPaths(unknown, freshFields)
+		fields = freshFields
+	}
+	if len(unknown) > 0 {
+		return nil, invalidPathError(unknown)
+	}
+	return fields, nil
 }

--- a/internal/domain/search/path_validate.go
+++ b/internal/domain/search/path_validate.go
@@ -16,10 +16,14 @@ import (
 //
 // Returned paths are normalised so they line up with the FieldsMap keys
 // produced by *schema.ModelNode.FieldsMap (paths begin with "$." and use
-// "[*]" to mark array-wildcard hops). Unrecognised path syntax is
-// dropped — pre-execution validation is best-effort and the matcher
-// will still fail the request downstream if the path is genuinely
-// inaccessible.
+// "[*]" to mark array-wildcard hops).
+//
+// Nothing downstream re-checks what this misses. The matcher has no
+// field-path check at all: an inaccessible path resolves to nothing and
+// answers an empty page, which the caller cannot tell from a legitimate
+// empty result. Path syntax is grammar-checked at the model-independent
+// condition boundary (ValidateCondition) before this walk runs, so a
+// surviving path is well-formed and the walk drops nothing.
 //
 // Duplicate paths are folded out so callers can rely on the slice as a
 // set without further work.
@@ -160,9 +164,12 @@ func LoadFieldsMap(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) 
 // loadFieldsMap fetches and parses the cached schema for ref, returning
 // the path → FieldDescriptor view used by pre-execution validation.
 //
-// Returns (nil, nil) when the descriptor has no schema bound. Other errors
-// propagate so the caller can log and skip validation rather than
-// mistakenly reject the search.
+// Returns (nil, nil) when the descriptor has no schema bound — a model
+// declaring no fields, which is a real answer and not a failure. Every other
+// error propagates and every caller FAILS the request on it: the schema is
+// what decides whether a condition's paths exist, so proceeding without it
+// answers with a filter whose comparison leaves annihilate while its string
+// leaves keep matching (see spi.ConditionToFilter).
 func loadFieldsMap(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) (map[string]schema.FieldDescriptor, error) {
 	// Prefer the cached derived parse when the store offers one. Rebuilding it
 	// per call is 80-99% of a criterion evaluation and scales with schema size;

--- a/internal/domain/search/pattern_validate_test.go
+++ b/internal/domain/search/pattern_validate_test.go
@@ -9,6 +9,7 @@ import (
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go-spi/predicate"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
@@ -24,7 +25,14 @@ func newPatternTestService(t *testing.T, tenant string, ref spi.ModelRef) (*sear
 	svc := search.NewSearchService(factory, uuids, searchStore)
 
 	ctx := tenantCtx(tenant)
-	saveMinimalModel(t, ctx, factory, ref)
+	// These tests address $.name (string operators) and $.age (a numeric
+	// comparison), so both must be declared with the types they are compared
+	// against — an undeclared path now fails the request before any pattern
+	// is examined, and a String "age" would fail on the operand's type.
+	saveModelWithFields(t, ctx, factory, ref, map[string]schema.DataType{
+		"name": schema.String,
+		"age":  schema.Integer,
+	})
 	return svc, ctx
 }
 

--- a/internal/domain/search/schema_load_fails_closed_test.go
+++ b/internal/domain/search/schema_load_fails_closed_test.go
@@ -1,0 +1,271 @@
+package search_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// A search validates its condition's field paths against the model's schema.
+// When that schema cannot be loaded, validateConditionPaths returned nil —
+// "validation passed" — and the search answered anyway.
+//
+// The answer it gives is not merely unvalidated, it is wrong. With no fields
+// map, spi.ConditionToFilter stamps an empty Declared on every leaf, and per
+// its own godoc that does not degrade every leaf the same way: the eight
+// comparison and ordering leaves annihilate to a non-match while the other
+// eighteen evaluate normally. So a comparison that should have matched
+// silently matches nothing, and the caller receives 200 with a short result
+// set indistinguishable from a legitimate one.
+
+// brokenSchemaModelStore answers Get with a descriptor whose schema blob does
+// not parse. Model EXISTENCE therefore still resolves — EnsureModelRegistered
+// only needs Get to succeed — while every schema-derived view of the model
+// fails. That is the split this test needs: the request gets far enough to
+// reach path validation, and path validation is what breaks.
+//
+// It deliberately implements neither RefreshAndGet nor SchemaNode, so
+// loadFieldsMap takes its Get + Unmarshal route and the single-refresh retry
+// is not in play.
+type brokenSchemaModelStore struct {
+	ref    spi.ModelRef
+	schema []byte
+}
+
+func (s *brokenSchemaModelStore) Get(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	return &spi.ModelDescriptor{
+		Ref:    s.ref,
+		State:  spi.ModelLocked,
+		Schema: s.schema,
+	}, nil
+}
+
+func (s *brokenSchemaModelStore) Save(context.Context, *spi.ModelDescriptor) error { return nil }
+func (s *brokenSchemaModelStore) GetAll(context.Context) ([]spi.ModelRef, error)   { return nil, nil }
+func (s *brokenSchemaModelStore) Delete(context.Context, spi.ModelRef) error       { return nil }
+func (s *brokenSchemaModelStore) Lock(context.Context, spi.ModelRef) error         { return nil }
+func (s *brokenSchemaModelStore) Unlock(context.Context, spi.ModelRef) error       { return nil }
+func (s *brokenSchemaModelStore) IsLocked(context.Context, spi.ModelRef) (bool, error) {
+	return true, nil
+}
+func (s *brokenSchemaModelStore) SetChangeLevel(context.Context, spi.ModelRef, spi.ChangeLevel) error {
+	return nil
+}
+func (s *brokenSchemaModelStore) ExtendSchema(context.Context, spi.ModelRef, spi.SchemaDelta) error {
+	return nil
+}
+
+var _ spi.ModelStore = (*brokenSchemaModelStore)(nil)
+
+// TestSearch_SchemaLoadFails_FailsClosedInsteadOfAnswering pins the rule from
+// .claude/rules/correctness-over-availability.md: an unavailable dependency a
+// correct result requires fails the operation, it does not downgrade it.
+//
+// The entity stored here DOES satisfy the condition. Before the fix the search
+// returned 200 with zero results — a wrong answer the caller cannot tell from
+// "nothing matched".
+func TestSearch_SchemaLoadFails_FailsClosedInsteadOfAnswering(t *testing.T) {
+	base := memory.NewStoreFactory()
+	defer base.Close()
+
+	ctx := tenantCtx("tenant-1")
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+	saveEntity(t, ctx, base, ref, "e1", []byte(`{"name":"Alice"}`))
+
+	factory := &modelStoreFactory{
+		StoreFactory: base,
+		modelStore:   &brokenSchemaModelStore{ref: ref, schema: []byte(`{"this is": not valid json`)},
+	}
+	searchStore, _ := base.AsyncSearchStore(context.Background())
+	svc := search.NewSearchService(factory, common.NewTestUUIDGenerator(), searchStore)
+
+	cond := &predicate.SimpleCondition{
+		JsonPath:     "$.name",
+		OperatorType: "EQUALS",
+		Value:        "Alice",
+	}
+
+	results, err := svc.Search(ctx, ref, cond, search.SearchOptions{})
+	if err == nil {
+		t.Fatalf("Search returned no error with an unloadable schema; got %d result(s). "+
+			"A model-store read failure must not produce a result set.", len(results))
+	}
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+	}
+	if appErr.Status < 500 {
+		t.Errorf("appErr.Status = %d, want 5xx: an unloadable schema is a dependency "+
+			"failure, not client fault", appErr.Status)
+	}
+}
+
+// TestSearch_ModelCarriesNoSchema_RejectsTheDataPath covers the sibling arm:
+// the descriptor loads cleanly but declares no fields at all, so loadFieldsMap
+// returns (nil, nil). That was also treated as "nothing to validate against"
+// and the search answered.
+//
+// A model declaring no fields declares no $.name. Under the rule that a query
+// whose path shape contradicts the model is an error — we do not interpret
+// model syntax errors flexibly — the path is unknown and the request is client
+// fault, not a dependency failure.
+func TestSearch_ModelCarriesNoSchema_RejectsTheDataPath(t *testing.T) {
+	base := memory.NewStoreFactory()
+	defer base.Close()
+
+	ctx := tenantCtx("tenant-1")
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+	saveEntity(t, ctx, base, ref, "e1", []byte(`{"name":"Alice"}`))
+
+	factory := &modelStoreFactory{
+		StoreFactory: base,
+		modelStore:   &brokenSchemaModelStore{ref: ref, schema: nil},
+	}
+	searchStore, _ := base.AsyncSearchStore(context.Background())
+	svc := search.NewSearchService(factory, common.NewTestUUIDGenerator(), searchStore)
+
+	cond := &predicate.SimpleCondition{
+		JsonPath:     "$.name",
+		OperatorType: "EQUALS",
+		Value:        "Alice",
+	}
+
+	results, err := svc.Search(ctx, ref, cond, search.SearchOptions{})
+	if err == nil {
+		t.Fatalf("Search accepted a data path against a model declaring no fields; "+
+			"got %d result(s)", len(results))
+	}
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+	}
+	if appErr.Code != common.ErrCodeInvalidFieldPath {
+		t.Errorf("appErr.Code = %q, want %q", appErr.Code, common.ErrCodeInvalidFieldPath)
+	}
+}
+
+// switchableModelStore serves a good descriptor until Break is called, then a
+// descriptor whose schema blob does not parse. It exists to reach the async
+// executor's OWN schema load: submit-time validation and the background job
+// are two separate loads, and only the second one can be broken in isolation.
+type switchableModelStore struct {
+	mu     sync.Mutex
+	ref    spi.ModelRef
+	good   []byte
+	broken bool
+}
+
+func (s *switchableModelStore) Break() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.broken = true
+}
+
+func (s *switchableModelStore) Get(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	raw := s.good
+	if s.broken {
+		raw = []byte(`{"this is": not valid json`)
+	}
+	return &spi.ModelDescriptor{Ref: s.ref, State: spi.ModelLocked, Schema: raw}, nil
+}
+
+func (s *switchableModelStore) Save(context.Context, *spi.ModelDescriptor) error { return nil }
+func (s *switchableModelStore) GetAll(context.Context) ([]spi.ModelRef, error)   { return nil, nil }
+func (s *switchableModelStore) Delete(context.Context, spi.ModelRef) error       { return nil }
+func (s *switchableModelStore) Lock(context.Context, spi.ModelRef) error         { return nil }
+func (s *switchableModelStore) Unlock(context.Context, spi.ModelRef) error       { return nil }
+func (s *switchableModelStore) IsLocked(context.Context, spi.ModelRef) (bool, error) {
+	return true, nil
+}
+func (s *switchableModelStore) SetChangeLevel(context.Context, spi.ModelRef, spi.ChangeLevel) error {
+	return nil
+}
+func (s *switchableModelStore) ExtendSchema(context.Context, spi.ModelRef, spi.SchemaDelta) error {
+	return nil
+}
+
+var _ spi.ModelStore = (*switchableModelStore)(nil)
+
+// breakOnCreateStore breaks the model schema at the moment the job row is
+// created — synchronously inside SubmitAsync, after submit-time validation has
+// already run and before the worker picks the job up. That makes the window
+// deterministic instead of racing the goroutine.
+type breakOnCreateStore struct {
+	spi.AsyncSearchStore
+	ms *switchableModelStore
+}
+
+func (s *breakOnCreateStore) CreateJob(ctx context.Context, job *spi.SearchJob) error {
+	s.ms.Break()
+	return s.AsyncSearchStore.CreateJob(ctx, job)
+}
+
+// TestAsyncSearch_SchemaBreaksAfterSubmit_JobFails covers the executor's own
+// load. runAsyncJob discarded the fields-map error outright
+// ("fields, _ := loadFieldsMap(...) // best-effort; nil-tolerant") and
+// translated the condition against a nil map, so the job completed
+// SUCCESSFUL with a result set built from part-annihilated leaves.
+func TestAsyncSearch_SchemaBreaksAfterSubmit_JobFails(t *testing.T) {
+	base := memory.NewStoreFactory()
+	defer base.Close()
+
+	ctx := tenantCtx("tenant-async-broken")
+	ref := spi.ModelRef{EntityName: "asyncbroken", ModelVersion: "1"}
+	saveEntity(t, ctx, base, ref, "e1", []byte(`{"name":"Alice"}`))
+
+	ms := &switchableModelStore{ref: ref, good: goodStringSchema(t, "name")}
+	factory := &modelStoreFactory{StoreFactory: base, modelStore: ms}
+
+	realAsync, err := base.AsyncSearchStore(context.Background())
+	if err != nil {
+		t.Fatalf("AsyncSearchStore: %v", err)
+	}
+	store := &breakOnCreateStore{AsyncSearchStore: realAsync, ms: ms}
+
+	pool := search.NewWorkerPool(2, 8)
+	t.Cleanup(func() { pool.Drain(context.Background()) })
+	svc := search.NewSearchService(factory, common.NewTestUUIDGenerator(), store).WithAsyncPool(pool)
+
+	cond := &predicate.SimpleCondition{
+		JsonPath:     "$.name",
+		OperatorType: "EQUALS",
+		Value:        "Alice",
+	}
+	jobID, err := svc.SubmitAsync(ctx, ref, cond, search.SearchOptions{})
+	if err != nil {
+		t.Fatalf("SubmitAsync: %v", err)
+	}
+
+	status := pollUntilTerminal(t, svc, ctx, jobID, 5*time.Second)
+	if status.Status != "FAILED" {
+		t.Fatalf("job status = %q with %d result(s), want FAILED: the executor could "+
+			"not load the schema its condition must be typed against, so it must not "+
+			"report a result set", status.Status, status.Total)
+	}
+}
+
+// goodStringSchema marshals an object schema declaring each named field as a
+// String leaf.
+func goodStringSchema(t *testing.T, fields ...string) []byte {
+	t.Helper()
+	node := schema.NewObjectNode()
+	for _, f := range fields {
+		node.SetChild(f, schema.NewLeafNode(schema.String))
+	}
+	raw, err := schema.Marshal(node)
+	if err != nil {
+		t.Fatalf("schema.Marshal: %v", err)
+	}
+	return raw
+}

--- a/internal/domain/search/schema_load_fails_closed_test.go
+++ b/internal/domain/search/schema_load_fails_closed_test.go
@@ -3,6 +3,7 @@ package search_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -106,6 +107,18 @@ func TestSearch_SchemaLoadFails_FailsClosedInsteadOfAnswering(t *testing.T) {
 	if appErr.Status < 500 {
 		t.Errorf("appErr.Status = %d, want 5xx: an unloadable schema is a dependency "+
 			"failure, not client fault", appErr.Status)
+	}
+	// Pin WHICH guard refused. validateConditionTypes loads the same schema
+	// immediately afterwards and now also fails closed, so a test asserting
+	// only "some error" passes with the path-validation guard reverted — it
+	// would be satisfied by the downstream one and the primary fix would be
+	// unprotected. These two messages are the only thing that tells them
+	// apart at the boundary.
+	if !strings.Contains(appErr.Message, "for condition validation") {
+		t.Errorf("appErr.Message = %q, want the path-validation guard "+
+			"(%q); the type-validation guard firing instead means "+
+			"validateConditionPaths let the request through",
+			appErr.Message, "failed to load model schema for condition validation")
 	}
 }
 
@@ -268,4 +281,43 @@ func goodStringSchema(t *testing.T, fields ...string) []byte {
 		t.Fatalf("schema.Marshal: %v", err)
 	}
 	return raw
+}
+
+// TestSearch_LifecycleOnlyCondition_DoesNotNeedTheSchema guards against paying
+// for a schema load a condition cannot use. A lifecycle condition names a
+// member of the closed meta vocabulary; spi.ConditionToFilter's godoc is
+// explicit that "Meta leaves are unaffected: their types come from the static
+// meta vocabulary, not from fields, so a nil map does not degrade them at
+// all." Failing such a search because the schema is unreadable trades an
+// answer that was correct for a 500 that buys nothing.
+func TestSearch_LifecycleOnlyCondition_DoesNotNeedTheSchema(t *testing.T) {
+	base := memory.NewStoreFactory()
+	defer base.Close()
+
+	ctx := tenantCtx("tenant-lifecycle-only")
+	ref := spi.ModelRef{EntityName: "lifecycleonly", ModelVersion: "1"}
+	saveEntity(t, ctx, base, ref, "e1", []byte(`{"name":"Alice"}`))
+
+	factory := &modelStoreFactory{
+		StoreFactory: base,
+		modelStore:   &brokenSchemaModelStore{ref: ref, schema: []byte(`{"this is": not valid json`)},
+	}
+	searchStore, _ := base.AsyncSearchStore(context.Background())
+	svc := search.NewSearchService(factory, common.NewTestUUIDGenerator(), searchStore)
+
+	cond := &predicate.LifecycleCondition{
+		Field:        "state",
+		OperatorType: "EQUALS",
+		Value:        "NEW",
+	}
+
+	results, err := svc.Search(ctx, ref, cond, search.SearchOptions{})
+	if err != nil {
+		t.Fatalf("lifecycle-only search failed on an unreadable schema: %v. "+
+			"A meta leaf takes its type from the static vocabulary, so the model "+
+			"schema is not a dependency of this request.", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("got %d result(s), want 1", len(results))
+	}
 }

--- a/internal/domain/search/schema_node_reuse_test.go
+++ b/internal/domain/search/schema_node_reuse_test.go
@@ -77,7 +77,10 @@ func TestLoadModelNode_UsesCachedParseWhenOffered(t *testing.T) {
 	store := &countingSchemaStore{node: testNode(t)}
 	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
 
-	node := loadModelNode(context.Background(), store, ref)
+	node, err := loadModelNode(context.Background(), store, ref)
+	if err != nil {
+		t.Fatalf("loadModelNode: %v", err)
+	}
 	if node == nil {
 		t.Fatal("expected a node")
 	}

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -1179,11 +1179,10 @@ func (s *SearchService) runAsyncJob(jobCtx context.Context, cancel context.Cance
 		// jobFailureMessage to the generic fallback, so a tenant whose model
 		// store is down would read an actionable code on /search/direct and
 		// "search failed unexpectedly" here, for one and the same outage.
-		msg := jobFailureMessage(fieldsErr)
-		if appErr := common.Internal("failed to load model schema for condition validation", fieldsErr); appErr != nil {
-			msg = jobFailureMessage(appErr)
-		}
-		s.writeAsyncFailure(jobCtx, jobID, msg, time.Now(), time.Since(start).Milliseconds())
+		// common.Internal always returns a non-nil *AppError, and only its
+		// Message reaches the persisted job record — never its Detail.
+		appErr := common.Internal("failed to load model schema for condition validation", fieldsErr)
+		s.writeAsyncFailure(jobCtx, jobID, jobFailureMessage(appErr), time.Now(), time.Since(start).Milliseconds())
 		return
 	}
 	filter, translateErr := spi.ConditionToFilter(cond, fields)
@@ -1648,6 +1647,16 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelStore s
 		return nil, invalidPathError(missing)
 	}
 	if freshFields == nil {
+		// The refresh produced no schema, so the descriptor carries none.
+		// Deliberately NOT negative-cached, for the same reason as the
+		// ErrNotFound branch above: the cache records "this path is absent
+		// from a schema we read", and here there is no schema to have read
+		// it from. The cost is a Get + RefreshAndGet per repeat request on
+		// such a model. Unreachable through the model API — every Save
+		// writes marshalled schema bytes, and an empty schema still yields a
+		// non-nil fields map that takes the cached route above — so this is
+		// a bound on an out-of-band or legacy row, not on anything a caller
+		// can provoke.
 		return nil, invalidPathError(missing)
 	}
 

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -18,6 +18,7 @@ import (
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/pagination"
 	"github.com/cyoda-platform/cyoda-go/internal/match"
 
@@ -596,7 +597,8 @@ func (s *SearchService) Search(ctx context.Context, modelRef spi.ModelRef, cond 
 		return nil, appErr
 	}
 
-	if vErr := s.validateConditionPaths(ctx, modelRef, cond); vErr != nil {
+	validatedFields, vErr := s.validateConditionPaths(ctx, modelStore, modelRef, cond)
+	if vErr != nil {
 		return nil, vErr
 	}
 	if rErr := ValidatePatterns(cond); rErr != nil {
@@ -655,8 +657,13 @@ func (s *SearchService) Search(ctx context.Context, modelRef spi.ModelRef, cond 
 	searcher, storeIsSearcher := store.(spi.Searcher)
 	iterableStore, storeIsIterable := store.(spi.Iterable)
 	if (storeIsSearcher && opts.Limit > 0) || (storeIsIterable && opts.Limit <= 0) {
-		fields, _ := loadFieldsMap(ctx, modelStore, modelRef) // best-effort; nil-tolerant
-		filter, translateErr := spi.ConditionToFilter(cond, fields)
+		// Reuse the map validateConditionPaths already loaded and validated
+		// the condition's paths against. Loading it a second time here both
+		// repeated the work and discarded its error, so a schema that became
+		// unreadable between the two loads translated against nil — which is
+		// not "no types", it is a filter whose comparison leaves annihilate
+		// while its string leaves keep matching.
+		filter, translateErr := spi.ConditionToFilter(cond, validatedFields)
 		if translateErr == nil {
 			if opts.Limit > 0 {
 				res, sErr := searcher.Search(ctx, filter, spi.SearchOptions{
@@ -930,7 +937,7 @@ func (s *SearchService) SubmitAsync(ctx context.Context, modelRef spi.ModelRef, 
 		return "", appErr
 	}
 
-	if vErr := s.validateConditionPaths(ctx, modelRef, cond); vErr != nil {
+	if _, vErr := s.validateConditionPaths(ctx, modelStore, modelRef, cond); vErr != nil {
 		return "", vErr
 	}
 	if rErr := ValidatePatterns(cond); rErr != nil {
@@ -1159,7 +1166,18 @@ func (s *SearchService) runAsyncJob(jobCtx context.Context, cancel context.Cance
 		s.writeAsyncFailure(jobCtx, jobID, jobFailureMessage(err), time.Now(), time.Since(start).Milliseconds())
 		return
 	}
-	fields, _ := loadFieldsMap(jobCtx, modelStore, modelRef) // best-effort; nil-tolerant, mirrors Search
+	// Fail the job rather than answering without the schema. This load is
+	// SEPARATE from the one submit-time validation performed, so the schema
+	// can become unreadable in between — and a nil fields map does not make
+	// the condition unevaluable, it makes it evaluate WRONGLY: empty Declared
+	// annihilates the eight comparison and ordering leaves to a non-match
+	// while the other eighteen keep matching (see spi.ConditionToFilter), so
+	// the job would record a short result set as SUCCESSFUL.
+	fields, fieldsErr := loadFieldsMap(jobCtx, modelStore, modelRef)
+	if fieldsErr != nil {
+		s.writeAsyncFailure(jobCtx, jobID, jobFailureMessage(fieldsErr), time.Now(), time.Since(start).Milliseconds())
+		return
+	}
 	filter, translateErr := spi.ConditionToFilter(cond, fields)
 
 	var (
@@ -1543,10 +1561,14 @@ func (s *SearchService) CancelAsyncSearch(ctx context.Context, snapshotID string
 // Returns nil when validation passes or when no data-field paths are
 // addressed (lifecycle-only conditions). Validator failures surface as a
 // 4xx common.AppError with the missing paths listed.
-func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi.ModelRef, cond predicate.Condition) error {
+func (s *SearchService) validateConditionPaths(ctx context.Context, modelStore spi.ModelStore, modelRef spi.ModelRef, cond predicate.Condition) (map[string]schema.FieldDescriptor, error) {
 	paths := extractFieldPaths(cond)
 	if len(paths) == 0 {
-		return nil
+		// A lifecycle-only condition addresses no schema path, so there is
+		// nothing to check — but the caller still needs the fields map to
+		// type its leaves, and loading it HERE rather than again downstream
+		// is what keeps the load (and its failure handling) in one place.
+		return loadFieldsMap(ctx, modelStore, modelRef)
 	}
 
 	// Negative cache fast-path: if any path is recorded as confirmed
@@ -1556,40 +1578,36 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 	// per (tenant, modelRef, path) tuple between schema events.
 	tenant := common.TenantFromContext(ctx)
 	if cachedMissing := s.cachedAbsentPaths(tenant, modelRef, paths); len(cachedMissing) > 0 {
-		return invalidPathError(cachedMissing)
-	}
-
-	modelStore, err := s.factory.ModelStore(ctx)
-	if err != nil {
-		// A factory that cannot produce a ModelStore cannot validate;
-		// log and proceed so the search itself can still surface a
-		// useful error from the matcher.
-		slog.Debug("model store unavailable; skipping pre-execution path validation",
-			"pkg", "search", "error", err)
-		return nil
+		return nil, invalidPathError(cachedMissing)
 	}
 
 	fields, err := loadFieldsMap(ctx, modelStore, modelRef)
 	if err != nil {
-		// Model existence is guaranteed by EnsureModelRegistered before we
-		// reach here; a schema-decode failure is upstream — log and proceed
-		// so the matcher's own error path can still surface a useful error.
-		slog.Debug("failed to load schema for pre-execution validation",
-			"pkg", "search",
-			"entityName", modelRef.EntityName,
-			"modelVersion", modelRef.ModelVersion,
-			"error", err)
-		return nil
+		// Fail closed. The schema is what decides whether this condition's
+		// paths exist, and nothing downstream re-asks: the matcher has no
+		// field-path check, so an unvalidated search answers an empty page
+		// for a path that is wrong and for a path that simply matched
+		// nothing, identically. Worse, translating against a nil fields map
+		// stamps an empty Declared on every leaf, which annihilates the
+		// eight comparison and ordering operators to a non-match while the
+		// other eighteen keep evaluating (see spi.ConditionToFilter) — so
+		// the result set is not merely unvalidated, it is short.
+		//
+		// Per .claude/rules/correctness-over-availability.md, a dependency a
+		// correct result requires fails the operation rather than
+		// downgrading it.
+		return nil, common.Internal("failed to load model schema for condition validation", err)
 	}
-	if fields == nil {
-		// Descriptor returned nil — no schema bound to validate against.
-		return nil
-	}
-
+	// A nil fields map is NOT "nothing to validate against" — it is a model
+	// declaring no fields, against which every data path the condition names
+	// is unknown. findUnknownPaths reports exactly that, and the bounded
+	// single-refresh retry below still gets its chance to discover a schema
+	// this node has not yet seen. Returning early here accepted any path at
+	// all on such a model.
 	missing := findUnknownPaths(paths, fields)
 	if len(missing) == 0 {
 		s.markPathsPresent(tenant, modelRef, paths)
-		return nil
+		return fields, nil
 	}
 
 	// Some paths are unknown to the cached schema. Refresh exactly once
@@ -1600,7 +1618,7 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 	if !refreshed {
 		// Store has no cache layer — the cached miss is authoritative.
 		s.markPathsAbsent(tenant, modelRef, missing)
-		return invalidPathError(missing)
+		return nil, invalidPathError(missing)
 	}
 	if refreshErr != nil {
 		if errors.Is(refreshErr, spi.ErrNotFound) {
@@ -1608,26 +1626,28 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 			// back to the cached fields outcome (paths are unknown
 			// because there is no model). Do NOT populate the negative
 			// cache: there is no schema authority to invalidate against.
-			return invalidPathError(missing)
+			return nil, invalidPathError(missing)
 		}
 		slog.Debug("schema refresh failed during pre-execution validation",
 			"pkg", "search",
 			"entityName", modelRef.EntityName,
 			"modelVersion", modelRef.ModelVersion,
 			"error", refreshErr)
-		return invalidPathError(missing)
+		return nil, invalidPathError(missing)
 	}
 	if freshFields == nil {
-		return invalidPathError(missing)
+		return nil, invalidPathError(missing)
 	}
 
 	stillMissing := findUnknownPaths(missing, freshFields)
 	if len(stillMissing) == 0 {
 		s.markPathsPresent(tenant, modelRef, paths)
-		return nil
+		// The refresh is authoritative — hand back the schema the paths
+		// actually validated against, not the stale one.
+		return freshFields, nil
 	}
 	s.markPathsAbsent(tenant, modelRef, stillMissing)
-	return invalidPathError(stillMissing)
+	return nil, invalidPathError(stillMissing)
 }
 
 // cachedAbsentPaths returns the subset of paths recorded as confirmed

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -1175,7 +1175,15 @@ func (s *SearchService) runAsyncJob(jobCtx context.Context, cancel context.Cance
 	// the job would record a short result set as SUCCESSFUL.
 	fields, fieldsErr := loadFieldsMap(jobCtx, modelStore, modelRef)
 	if fieldsErr != nil {
-		s.writeAsyncFailure(jobCtx, jobID, jobFailureMessage(fieldsErr), time.Now(), time.Since(start).Milliseconds())
+		// Classify before recording. A raw error falls through
+		// jobFailureMessage to the generic fallback, so a tenant whose model
+		// store is down would read an actionable code on /search/direct and
+		// "search failed unexpectedly" here, for one and the same outage.
+		msg := jobFailureMessage(fieldsErr)
+		if appErr := common.Internal("failed to load model schema for condition validation", fieldsErr); appErr != nil {
+			msg = jobFailureMessage(appErr)
+		}
+		s.writeAsyncFailure(jobCtx, jobID, msg, time.Now(), time.Since(start).Milliseconds())
 		return
 	}
 	filter, translateErr := spi.ConditionToFilter(cond, fields)
@@ -1564,11 +1572,15 @@ func (s *SearchService) CancelAsyncSearch(ctx context.Context, snapshotID string
 func (s *SearchService) validateConditionPaths(ctx context.Context, modelStore spi.ModelStore, modelRef spi.ModelRef, cond predicate.Condition) (map[string]schema.FieldDescriptor, error) {
 	paths := extractFieldPaths(cond)
 	if len(paths) == 0 {
-		// A lifecycle-only condition addresses no schema path, so there is
-		// nothing to check — but the caller still needs the fields map to
-		// type its leaves, and loading it HERE rather than again downstream
-		// is what keeps the load (and its failure handling) in one place.
-		return loadFieldsMap(ctx, modelStore, modelRef)
+		// The model schema is a dependency of a condition exactly when the
+		// condition addresses a DATA path. This one addresses none — it is
+		// lifecycle-only — so there is nothing to validate and nothing the
+		// caller needs the fields map for: a meta leaf takes its type from
+		// the static meta vocabulary, not from the map (see
+		// spi.ConditionToFilter, "Meta leaves are unaffected"). Loading the
+		// schema here anyway would fail requests that are answerable, which
+		// is availability spent for no correctness.
+		return nil, nil
 	}
 
 	// Negative cache fast-path: if any path is recorded as confirmed

--- a/internal/domain/search/service_test.go
+++ b/internal/domain/search/service_test.go
@@ -35,15 +35,27 @@ func tenantCtx(tenantID string) context.Context {
 }
 
 // helper: register a minimal model descriptor so EnsureModelRegistered passes.
-func saveMinimalModel(t *testing.T, ctx context.Context, factory *memory.StoreFactory, ref spi.ModelRef) {
+// saveMinimalModel registers a model for tests whose subject is something
+// other than the schema — limits, cancellation, sentinel mapping, transport
+// plumbing. It still declares the leaves those tests address, because a model
+// declaring NO fields is a state production cannot reach: every entity write
+// goes through validateOrExtend, which extends the model's schema before the
+// data lands. Saving a bare descriptor and then writing entities straight to
+// the entity store fabricated a model with data but no schema, and search
+// answered such a model by skipping field-path validation entirely.
+//
+// Defaults to a String "name" leaf, which is what most of these tests query.
+// Pass explicit names when the test addresses something else.
+func saveMinimalModel(t *testing.T, ctx context.Context, factory *memory.StoreFactory, ref spi.ModelRef, fields ...string) {
 	t.Helper()
-	ms, err := factory.ModelStore(ctx)
-	if err != nil {
-		t.Fatalf("ModelStore: %v", err)
+	if len(fields) == 0 {
+		fields = []string{"name"}
 	}
-	if err := ms.Save(ctx, &spi.ModelDescriptor{Ref: ref}); err != nil {
-		t.Fatalf("Save model: %v", err)
+	typed := make(map[string]schema.DataType, len(fields))
+	for _, f := range fields {
+		typed[f] = schema.String
 	}
+	saveModelWithFields(t, ctx, factory, ref, typed)
 }
 
 // helper: register a model whose schema declares the given top-level leaf
@@ -780,7 +792,7 @@ func TestSubmitAsync_SelfExecutingStore_SkipsGoroutine(t *testing.T) {
 
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
-	saveMinimalModel(t, ctx, factory, ref)
+	saveMinimalModel(t, ctx, factory, ref, "x")
 	cond := &predicate.SimpleCondition{
 		JsonPath:     "$.x",
 		OperatorType: "EQUALS",

--- a/internal/e2e/grouped_stats_invalid_path_test.go
+++ b/internal/e2e/grouped_stats_invalid_path_test.go
@@ -245,3 +245,75 @@ func TestGroupedStats_NonJSONPathCondition_Returns400(t *testing.T) {
 		})
 	}
 }
+
+// --- Schema membership, not just grammar ---
+//
+// The tests above cover paths outside the path GRAMMAR. A grammatically
+// perfect path naming a field the model does not declare was a different
+// matter: grouped stats performed no schema-membership check at all, on any of
+// its three path surfaces, where /search/direct and conditional DELETE both
+// answer 400 INVALID_FIELD_PATH. The answer it gave looked real — an
+// undeclared condition leaf annihilates to a non-match, an undeclared groupBy
+// buckets every entity together, and an undeclared SUM reports 0 as the total.
+
+// TestGroupedStats_UnknownGroupByField_Returns400 groups by a well-formed path
+// the model does not declare.
+func TestGroupedStats_UnknownGroupByField_Returns400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+
+	const model = "e2e-grouped-stats-unknown-groupby"
+	setupStatsModel(t, model)
+	createEntityE2E(t, model, 1, `{"variantId":"v1","price":10.0}`)
+
+	path := fmt.Sprintf("/api/entity/stats/%s/1/query", model)
+	resp := doAuth(t, http.MethodPost, path, `{"groupBy": ["$.noSuchField"]}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, readBody(t, resp))
+	}
+	commontest.ExpectErrorCode(t, resp, "INVALID_FIELD_PATH")
+}
+
+// TestGroupedStats_UnknownConditionField_Returns400 filters on a well-formed
+// path the model does not declare — the same condition /search/direct refuses.
+func TestGroupedStats_UnknownConditionField_Returns400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+
+	const model = "e2e-grouped-stats-unknown-cond"
+	setupStatsModel(t, model)
+	createEntityE2E(t, model, 1, `{"variantId":"v1","price":10.0}`)
+
+	body := `{"groupBy": ["$.variantId"], "condition": {"type":"simple","jsonPath":"$.noSuchField","operatorType":"EQUALS","value":"x"}}`
+	path := fmt.Sprintf("/api/entity/stats/%s/1/query", model)
+	resp := doAuth(t, http.MethodPost, path, body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, readBody(t, resp))
+	}
+	commontest.ExpectErrorCode(t, resp, "INVALID_FIELD_PATH")
+}
+
+// TestGroupedStats_UnknownAggregationField_Returns400 sums a well-formed path
+// the model does not declare. Pre-fix this answered 200 with 0 as the total.
+func TestGroupedStats_UnknownAggregationField_Returns400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+
+	const model = "e2e-grouped-stats-unknown-agg"
+	setupStatsModel(t, model)
+	createEntityE2E(t, model, 1, `{"variantId":"v1","price":10.0}`)
+
+	body := `{"groupBy": ["$.variantId"], "aggregations": [{"op":"sum","field":"$.noSuchField","as":"total"}]}`
+	path := fmt.Sprintf("/api/entity/stats/%s/1/query", model)
+	resp := doAuth(t, http.MethodPost, path, body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, readBody(t, resp))
+	}
+	commontest.ExpectErrorCode(t, resp, "INVALID_FIELD_PATH")
+}

--- a/internal/grpc/search_test.go
+++ b/internal/grpc/search_test.go
@@ -1136,3 +1136,73 @@ func TestEntitySearch_SnapshotCancel_Envelope(t *testing.T) {
 		t.Errorf("status = %v, want CANCELLED", cancelTyped.Status.Status)
 	}
 }
+
+// brokenSchemaModelStoreG answers Get with a descriptor whose schema blob does
+// not parse: model existence still resolves, every schema-derived view fails.
+type brokenSchemaModelStoreG struct{ ref spi.ModelRef }
+
+func (s *brokenSchemaModelStoreG) Get(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	return &spi.ModelDescriptor{Ref: s.ref, State: spi.ModelLocked, Schema: []byte(`{"x": not json`)}, nil
+}
+func (s *brokenSchemaModelStoreG) Save(context.Context, *spi.ModelDescriptor) error { return nil }
+func (s *brokenSchemaModelStoreG) GetAll(context.Context) ([]spi.ModelRef, error)   { return nil, nil }
+func (s *brokenSchemaModelStoreG) Delete(context.Context, spi.ModelRef) error       { return nil }
+func (s *brokenSchemaModelStoreG) Lock(context.Context, spi.ModelRef) error         { return nil }
+func (s *brokenSchemaModelStoreG) Unlock(context.Context, spi.ModelRef) error       { return nil }
+func (s *brokenSchemaModelStoreG) IsLocked(context.Context, spi.ModelRef) (bool, error) {
+	return true, nil
+}
+func (s *brokenSchemaModelStoreG) SetChangeLevel(context.Context, spi.ModelRef, spi.ChangeLevel) error {
+	return nil
+}
+func (s *brokenSchemaModelStoreG) ExtendSchema(context.Context, spi.ModelRef, spi.SchemaDelta) error {
+	return nil
+}
+
+var _ spi.ModelStore = (*brokenSchemaModelStoreG)(nil)
+
+// brokenModelFactoryG serves the broken model store while delegating everything
+// else to the embedded factory.
+type brokenModelFactoryG struct {
+	spi.StoreFactory
+	ms spi.ModelStore
+}
+
+func (f *brokenModelFactoryG) ModelStore(context.Context) (spi.ModelStore, error) { return f.ms, nil }
+
+// TestDirectSearch_SchemaLoadFails_ServerErrorEnvelope covers the gRPC half of
+// the fail-closed rule. HTTP and gRPC are separate entry points
+// (.claude/rules/test-coverage.md), and the failure mode this guards against is
+// gRPC-specific: an empty stream reads to a client as "no matches", which is
+// exactly the wrong-but-available answer the fix exists to prevent.
+func TestDirectSearch_SchemaLoadFails_ServerErrorEnvelope(t *testing.T) {
+	base := memory.NewStoreFactory()
+	defer base.Close()
+	ctx := grpcTenantCtx()
+	ref := spi.ModelRef{EntityName: "brokenschema", ModelVersion: "1"}
+
+	factory := &brokenModelFactoryG{StoreFactory: base, ms: &brokenSchemaModelStoreG{ref: ref}}
+	searchStore, _ := base.AsyncSearchStore(context.Background())
+	svc := &CloudEventsServiceImpl{searchService: search.NewSearchService(factory, common.NewDefaultUUIDGenerator(), searchStore)}
+
+	ce := makeCE(EntitySearchRequest, map[string]any{
+		"id":        "s-brokenschema-1",
+		"model":     map[string]any{"name": "brokenschema", "version": 1},
+		"condition": map[string]any{"type": "simple", "jsonPath": "$.name", "operatorType": "EQUALS", "value": "Alice"},
+	})
+	stream := &mockEntityStream{ctx: ctx}
+	if err := svc.EntitySearchCollection(ce, stream); err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	if len(stream.sent) == 0 {
+		t.Fatal("no envelope sent; a schema-load failure must be reported, never an empty stream")
+	}
+	var typed events.EntityResponseJson
+	validateResponse(t, stream.sent[len(stream.sent)-1], &typed)
+	if typed.Success {
+		t.Fatalf("got Success=true for an unloadable schema; want a refusal")
+	}
+	if typed.Error == nil || typed.Error.Code != "SERVER_ERROR" {
+		t.Fatalf("Error = %+v, want Code=SERVER_ERROR", typed.Error)
+	}
+}

--- a/internal/grpc/search_test.go
+++ b/internal/grpc/search_test.go
@@ -11,6 +11,7 @@ import (
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	events "github.com/cyoda-platform/cyoda-go/api/grpc/events"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
@@ -783,15 +784,29 @@ func grpcTenantCtx() context.Context {
 	return spi.WithUserContext(context.Background(), uc)
 }
 
-// saveMinimalModelGRPC registers a minimal model descriptor so
-// EnsureModelRegistered passes.
-func saveMinimalModelGRPC(t *testing.T, ctx context.Context, factory *memory.StoreFactory, ref spi.ModelRef) {
+// saveMinimalModelGRPC registers a model descriptor so EnsureModelRegistered
+// passes AND the conditions these tests send have declared paths to resolve
+// against. A descriptor with no schema is not a lighter version of a real
+// model — it is a model declaring no fields, which a search now rejects rather
+// than answering unvalidated.
+func saveMinimalModelGRPC(t *testing.T, ctx context.Context, factory *memory.StoreFactory, ref spi.ModelRef, fields ...string) {
 	t.Helper()
 	ms, err := factory.ModelStore(ctx)
 	if err != nil {
 		t.Fatalf("ModelStore: %v", err)
 	}
-	if err := ms.Save(ctx, &spi.ModelDescriptor{Ref: ref}); err != nil {
+	if len(fields) == 0 {
+		fields = []string{"name"}
+	}
+	node := schema.NewObjectNode()
+	for _, f := range fields {
+		node.SetChild(f, schema.NewLeafNode(schema.String))
+	}
+	raw, err := schema.Marshal(node)
+	if err != nil {
+		t.Fatalf("schema.Marshal: %v", err)
+	}
+	if err := ms.Save(ctx, &spi.ModelDescriptor{Ref: ref, State: spi.ModelLocked, Schema: raw}); err != nil {
 		t.Fatalf("Save model: %v", err)
 	}
 }


### PR DESCRIPTION
Search consults the model schema to decide whether a condition's field paths exist. On a schema-load failure it returned "validation passed" and answered anyway.

The answer was wrong, not merely unvalidated. With no fields map the translator stamps an empty declared-type set on every leaf, and `spi.ConditionToFilter`'s own godoc says that does not degrade leaves uniformly: the eight comparison and ordering operators collapse to a non-match while the other eighteen keep matching. Rows that should have matched were dropped and the short page was indistinguishable from a complete one.

## What the failing tests observed first

| test | observed before the fix |
|---|---|
| `TestSearch_SchemaLoadFails_FailsClosedInsteadOfAnswering` | matching entity returned as **0 results, no error** |
| `TestSearch_ModelCarriesNoSchema_RejectsTheDataPath` | any path accepted on a model declaring no fields |
| `TestAsyncSearch_SchemaBreaksAfterSubmit_JobFails` | job **`SUCCESSFUL` with 0 results** |
| `TestPlanDeleteSelection_SchemaLessModel_RejectsTheDataPath` | conditional **delete** accepted an unvalidated path |
| `TestDirectSearch_SchemaLoadFails_ServerErrorEnvelope` (gRPC) | — |
| `TestSearch_LifecycleOnlyCondition_DoesNotNeedTheSchema` | regression introduced in the first commit |

Four further sites carried the same fail-open but had become unreachable once those landed — each a redundant load of a schema an earlier step now fails closed on. They are removed rather than "fixed", since no honest test can reach them: `validateConditionPaths` takes the `modelStore` its callers already hold and returns the fields map it validated against, so `Search` stops loading it again and discarding the error.

`loadModelNode`'s comment justified its skip as *"safe, not a wrong-but-available result … empty results, never a wrong match"*. The annihilation asymmetry above refutes it; the comment is replaced, not kept.

## The rule, stated once

**The model schema is a dependency of a condition exactly when the condition addresses a data path.** A lifecycle-only condition takes its types from the static meta vocabulary and still succeeds on an unreadable schema — the first commit got this wrong and the second fixes it.

## Review

A fresh-context reviewer found six issues, all acted on in the second commit — including a regression I introduced (lifecycle-only), a divergence I missed (conditional delete, where the skew decides which rows are **deleted**), and that the headline test did not actually pin the headline fix: reverting only that guard left it green because a second guard caught it. Both new tests were RED-verified by reverting their production hunk alone.

## Test churn

33 unit tests used `saveMinimalModel`, which saved a bare descriptor and then wrote entities straight to the entity store — a model with data but no schema, which `validateOrExtend` makes unreachable in production. The helper now declares the leaves its tests address.

## Grouped stats — now included

It performed **no** schema-membership check of any kind. Measured by reverting the fix under the new e2e tests, all `200`:

```
groupBy $.noSuchField  -> [{"groupKey":[{"path":"$.noSuchField","value":null}],"count":1}]
condition on it        -> []
sum of it              -> [{...,"count":1,"aggregations":{"total":null}}]
```

A caller cannot tell any of those from a real result.

The plumbing I thought was missing was already there: `StoreResolver`'s production closure holds the model store, so returning it is a five-to-six-value change with one wiring site. That buys the same bounded single `RefreshAndGet` search and delete have, so a field a peer node just added is not falsely rejected on a node whose cached descriptor predates the schema-change event — the reason a partial fix was worth avoiding.

The check is now **shared, not copied**: `search.ValidateKnownPaths` + `search.ConditionFieldPaths` replace the block conditional delete had hand-copied from `validateConditionPaths` — a copy that had already drifted, guarding on `fields != nil` and so accepting any path against a schema-less model. Three endpoints, one implementation.

Its condition **type** check was schema-blind for the same reason (nil model passed), so an operand parsing into none of a declared field's types is now `400 CONDITION_TYPE_MISMATCH` here too.

## E2E coverage and waiver

The grouped-stats change **is** reachable through the public API and carries three e2e tests on a running postgres, each RED-verified by disabling the handler block.

The schema-load-failure and schema-less-model arms are not reachable through the API — model import always stores a marshalled schema, and no E2E harness can inject a store fault — so they are covered at unit level. Waiver recorded per `.claude/rules/test-coverage.md`.

## Verification

`go build`, `go vet`, `go test -short ./...`, `make test-short-all` (root + all three plugin submodules), `internal/grpc`, and the full E2E suite (407s) all green.

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpvMHjVL36mhdhL97vde5n

