### PR TITLE
docs(model): drop a TODO that the code below it had already discharged

### DIFF
--- a/internal/domain/model/schema/diff.go
+++ b/internal/domain/model/schema/diff.go
@@ -172,13 +172,8 @@ func diffArray(path string, oldN, newN *ModelNode, ops *[]SchemaOp) error {
 	if newElem == nil {
 		return fmt.Errorf("array element removed at %q", displayPath(path))
 	}
-	// Old was an empty array (no observed element yet). Treat this as an
-	// "unobserved element" transitioning to a concrete one. Only the
-	// LEAF case is expressible via the current op catalog.
-	// TODO(A.3 / issue #85): when oldElem is nil and newElem is non-LEAF
-	// (OBJECT/ARRAY element first seen via polymorphic write), the transition
-	// needs a new op kind beyond add_array_item_type. Tracked in Sub-project
-	// A.3 (polymorphic-slot kind conflicts).
+	// Old was an array observed with no content, so it declared no element
+	// type at all; the incoming one is establishing it.
 	if oldElem == nil {
 		// A scalar element uses the dedicated, cheaper op. Anything else is
 		// carried as the array branch itself: Apply materialises the element


### PR DESCRIPTION
Follow-up to #535.

`diffArray`'s comment said an unobserved array element gaining an OBJECT or ARRAY element "needs a new op kind beyond `add_array_item_type`", tracked in #85. Three lines below it, the code emits `add_kind_branch` for exactly that case — #535 discharged the TODO and left the comment behind, so it now contradicts the block it introduces.

Found while auditing the claims I had just made in a comment on #85, one of which was that this TODO was gone. It was not; `grep` said so. The other claims in that comment — that `ErrPolymorphicSlot` and the `isNullOnlyLeaf` carve-outs are gone, and that no skip remains in the axis-2 matrix — I re-checked and they hold.

Comment-only. `go vet`, `gofmt`, and `./internal/domain/model/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J77TNkduTR2dp4WFuyyZJW