### PR TITLE
fix(build): a test suite that did not run must not report ok

### DIFF
--- a/.claude/rules/race-testing.md
+++ b/.claude/rules/race-testing.md
@@ -12,7 +12,11 @@ Use `make race` (defined in `Makefile`) so local and CI run exactly the same sco
 ## Rules
 
 - **During iteration** (subagent dispatch, single-task verification, between commits):
-  use `go test -short ./...` or scoped tests like `go test ./internal/foo/...`. No `-race`.
+  use a scoped run like `go test ./internal/foo/...`, or `make test` for the
+  full iteration tier (~90s, unit + cross-backend parity). No `-race`.
+  Do NOT reach for `go test -short ./...`: it reports `ok` for the parity
+  suites and `internal/e2e` while running none of them, so its green means
+  less than it appears to. See `scripts/testreport`.
 - **Before PR creation** (and only then): run `make race` once as a sanity check.
   CI invokes the same target, so a local pass strongly predicts a CI pass.
 - **If a race-related bug is suspected**: run `-race` on the specific package

--- a/.claude/rules/race-testing.md
+++ b/.claude/rules/race-testing.md
@@ -13,7 +13,7 @@ Use `make race` (defined in `Makefile`) so local and CI run exactly the same sco
 
 - **During iteration** (subagent dispatch, single-task verification, between commits):
   use a scoped run like `go test ./internal/foo/...`, or `make test` for the
-  full iteration tier (~90s, unit + cross-backend parity). No `-race`.
+  full iteration tier (unit + cross-backend parity, ~90s cold and ~13s warm). No `-race`.
   Do NOT reach for `go test -short ./...`: it reports `ok` for the parity
   suites and `internal/e2e` while running none of them, so its green means
   less than it appears to. See `scripts/testreport`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,20 @@ jobs:
       # it under 2x headroom on a runner slower than a developer's machine. A
       # binary that trips the default reports as a panic with a goroutine dump,
       # which reads like a product defect rather than a budget being hit.
+      # scripts/testreport turns the -json stream into a summary plus verbatim
+      # failures, and — the reason it exists — FAILS when a package that was
+      # required to execute tests executed none. `go test` reports a TestMain
+      # that calls os.Exit(0) as `ok  pkg  2.80s` with zero tests run, which no
+      # amount of reading the log distinguishes from a pass. Built once here and
+      # reused by the plugin steps, which run in their own modules.
+      - name: Build test reporter
+        run: go build -o "$RUNNER_TEMP/testreport" ./scripts/testreport
+
       - name: Run tests
-        run: go test ./... -v -timeout 30m
+        run: |
+          set -o pipefail
+          go test -json ./... -timeout 30m | "$RUNNER_TEMP/testreport" \
+            -must-run 'e2e/parity/memory,e2e/parity/sqlite,e2e/parity/postgres,e2e/parity/multinode,e2e/parity/fixtureutil,internal/e2e'
 
       # Race detector. Scoped via `make race` to exclude `internal/e2e` —
       # see Makefile and `.claude/rules/race-testing.md` for rationale.
@@ -72,20 +84,28 @@ jobs:
       # does not recurse into them. Run tests inside each module so CI does
       # not miss regressions (issue #46). The postgres plugin's DB-backed
       # tests connect via CYODA_TEST_DB_URL (job-level postgres service
-      # above) and skip when it is unset.
+      # above) and skip when it is unset — which is why the postgres step
+      # requires its package to have executed tests rather than trusting a
+      # green that a wholly-skipped suite also produces.
       - name: Run plugins/memory tests
         working-directory: plugins/memory
-        run: go test -v ./...
+        run: |
+          set -o pipefail
+          go test -json ./... | "$RUNNER_TEMP/testreport"
 
       - name: Run plugins/sqlite tests
         working-directory: plugins/sqlite
-        run: go test -v ./...
+        run: |
+          set -o pipefail
+          go test -json ./... | "$RUNNER_TEMP/testreport"
 
       - name: Run plugins/postgres tests
         working-directory: plugins/postgres
         env:
           CYODA_TEST_DB_URL: postgres://cyoda:cyoda@localhost:5432/cyoda_test?sslmode=disable
-        run: go test -v ./...
+        run: |
+          set -o pipefail
+          go test -json ./... | "$RUNNER_TEMP/testreport" -must-run 'plugins/postgres'
 
       - name: Build
         run: go build -o bin/cyoda ./cmd/cyoda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,13 @@ jobs:
         working-directory: plugins/memory
         run: |
           set -o pipefail
-          go test -json ./... | "$RUNNER_TEMP/testreport"
+          go test -json ./... | "$RUNNER_TEMP/testreport" -must-run 'plugins/memory'
 
       - name: Run plugins/sqlite tests
         working-directory: plugins/sqlite
         run: |
           set -o pipefail
-          go test -json ./... | "$RUNNER_TEMP/testreport"
+          go test -json ./... | "$RUNNER_TEMP/testreport" -must-run 'plugins/sqlite'
 
       - name: Run plugins/postgres tests
         working-directory: plugins/postgres
@@ -151,7 +151,7 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck
-        run: shellcheck scripts/install.sh scripts/dev/run-docker-dev.sh scripts/check-spi-pin-sync.sh scripts/check-spi-pin-sync_test.sh scripts/check-generated-in-sync.sh
+        run: shellcheck scripts/install.sh scripts/dev/run-docker-dev.sh scripts/check-spi-pin-sync.sh scripts/check-spi-pin-sync_test.sh scripts/check-generated-in-sync.sh scripts/preflight-docker.sh
 
   # Continuous security gates (issue #67):
   #   - govulncheck scans the call graph for exploitable stdlib and third-party CVEs,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,8 @@ When changing the `WorkflowConfigurationDto` import surface — DTO shape, valid
 
 ### Gate 5: Verify before claiming done
 Use `superpowers:verification-before-completion` skill before claiming work is complete.
-Run `go test ./... -v` and confirm green (this includes E2E tests). Run `go vet ./...` for static analysis.
+Run `make test-full` and confirm green (root + every plugin submodule, including E2E). Run `go vet ./...` for static analysis.
+A raw `go test ./...` is not sufficient: it reports `ok` for suites that never ran.
 E2E tests spin up their own PostgreSQL + HTTP server automatically — just run them.
 Do not claim work is done if any test — unit, integration, or E2E — is failing.
 
@@ -138,16 +139,42 @@ on that task — no need to ask again. If anything still prevents dispatching on
 
 Plugin submodules (`plugins/memory`, `plugins/sqlite`, `plugins/postgres`)
 each have their own `go.mod`; Go's `./...` recursion does **not** cross
-module boundaries, so root-module commands miss them. Use the `-all`
-aggregator targets below when you want coverage across the whole repo.
+module boundaries, so root-module commands miss them. `make test-full` is the
+only target that covers the whole repo.
 
-- Test (root module): `go test ./... -v` — root incl. internal/e2e (requires Docker)
-- Test (root module, unit only): `go test -short ./... -v`
-- Test (root + every plugin submodule): `make test-all` — covers root + `plugins/memory|sqlite|postgres`; Docker required for postgres testcontainers
-- Test (root + plugins, short): `make test-short-all`
-- Test (E2E only): `go test ./internal/e2e/... -v`
-- Coverage (root module): `go test -coverprofile=coverage.out ./...` — run inside each `plugins/*` for per-plugin coverage
-- Race detector (root module, CI-parity scope): `make race` — runs `go test -race -timeout=15m` on every package except `internal/e2e`; same scope CI runs. Use `go test -race -timeout=20m ./internal/e2e/...` separately if you need race coverage on E2E.
+**Use `make test` and `make test-full`. Do not hand-roll `go test ./...`.**
+A raw `go test` cannot tell you that a suite did not run: a `TestMain` that
+calls `os.Exit(0)` — how the parity suites and `internal/e2e` opt out of
+`-short` — prints `ok  pkg  2.80s` with zero tests executed, which is
+indistinguishable from a pass. The make targets pipe through
+`scripts/testreport`, which fails the run when a required suite executed
+nothing and prints failures verbatim instead of burying them in `-v` output.
+
+- **Iteration: `make test`** — unit + cross-backend parity, ~3 min. Excludes
+  `internal/e2e` and the plugin submodules, and says so when it runs.
+- **End of deliverable: `make test-full`** — everything, root + all three
+  plugin submodules, ~15 min. This is the Gate 5 command.
+- Race detector (CI-parity scope): `make race` — `go test -race` on every
+  package except `internal/e2e`; the same scope CI runs. Use
+  `go test -race -timeout=20m ./internal/e2e/...` separately if you need race
+  coverage on E2E. Once before a PR, not per step.
+- One package while iterating: `go test ./internal/domain/search/...` is fine
+  — the tiers are for verification, not for every edit.
+
+**Do not add `-count=1`.** The targets deliberately leave Go's test cache
+enabled, so a re-run only re-executes packages whose inputs changed: measured
+89s cold and 13s warm for `make test`. Forcing `-count=1` throws that away and
+is the single easiest way to make verification slow again. Use it only when
+you are specifically hunting a flake.
+- Coverage (root module): `go test -coverprofile=coverage.out ./...` — run
+  inside each `plugins/*` for per-plugin coverage.
+
+**Docker is a hard requirement for both tiers and there is no Docker-free
+fallback.** `make preflight` checks that the daemon responds, that the probe
+image is present, and that the VM disk can take a write — a full Docker disk
+otherwise surfaces only as `container exited with code 1`. If pre-flight
+fails, fix Docker and say so; do not drop to a narrower run.
+
 - Build: `go build -o bin/cyoda ./cmd/cyoda`
 - Tidy: `go mod tidy`
 - Vet (root module): `go vet ./...` — the `per-module-hygiene` CI job vets each plugin separately

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,9 @@ When adding or changing user-facing behavior (API responses, workflow semantics,
 add or update E2E tests in `internal/e2e/` to cover the change through the full HTTP stack.
 E2E tests are self-contained: `TestMain` starts a PostgreSQL container via testcontainers-go
 and an in-process `httptest.Server` with JWT auth — no external instance needed.
-Just run `go test ./internal/e2e/... -v` (requires Docker running).
+Run `make test-full`, which includes them (requires Docker running). To iterate on
+E2E alone, `go test ./internal/e2e/...` is fine — but do not read a green from it
+as whole-suite verification, and do not add `-v`.
 For API/gRPC features the bar is **full coverage** — happy path AND every documented
 status/error code on a running backend, plus a cross-backend parity scenario for
 backend-agnostic behavior. See `.claude/rules/test-coverage.md` (the spec's error table is
@@ -150,7 +152,8 @@ indistinguishable from a pass. The make targets pipe through
 `scripts/testreport`, which fails the run when a required suite executed
 nothing and prints failures verbatim instead of burying them in `-v` output.
 
-- **Iteration: `make test`** — unit + cross-backend parity, ~3 min. Excludes
+- **Iteration: `make test`** — unit + cross-backend parity, ~90s cold and
+  ~13s warm against the test cache. Excludes
   `internal/e2e` and the plugin submodules, and says so when it runs.
 - **End of deliverable: `make test-full`** — everything, root + all three
   plugin submodules, ~15 min. This is the Gate 5 command.
@@ -163,7 +166,7 @@ nothing and prints failures verbatim instead of burying them in `-v` output.
 
 **Do not add `-count=1`.** The targets deliberately leave Go's test cache
 enabled, so a re-run only re-executes packages whose inputs changed: measured
-89s cold and 13s warm for `make test`. Forcing `-count=1` throws that away and
+89s cold and 13.3s warm for `make test`. Forcing `-count=1` throws that away and
 is the single easiest way to make verification slow again. Use it only when
 you are specifically hunting a flake.
 - Coverage (root module): `go test -coverprofile=coverage.out ./...` — run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,19 @@ Every feature must have tests at the appropriate level before it can be merged.
 **Reconciliation tests** (`test/recon/`, build tag `cyoda_recon`) compare Cyoda-Go responses against Cyoda Cloud to verify API-level compatibility. These are optional and require Cloud credentials.
 
 ```bash
-go test ./... -v                          # all unit tests (no Docker needed)
-go test ./internal/e2e/ -v               # E2E tests (requires Docker)
-make race                                 # race detector (CI-parity scope) — run before every PR
+make test        # iteration tier: unit + cross-backend parity (~3 min)
+make test-full   # everything, root + all three plugin submodules (~15 min)
+make race        # race detector (CI-parity scope) — once before a PR
 go test -tags cyoda_recon ./test/recon/   # reconciliation (optional, needs Cloud)
 ```
+
+Both tiers require Docker and there is no Docker-free alternative: if Docker
+cannot serve the suites, `make preflight` fails with what to fix. Prefer these
+targets over a hand-rolled `go test ./...`, which reports `ok` for a suite that
+never ran — a `TestMain` calling `os.Exit(0)` prints `ok  pkg  2.80s` having
+executed nothing. The targets pipe through `scripts/testreport`, which fails
+when a required suite ran no tests and prints failures verbatim rather than
+burying them in `-v` output.
 
 `make race` runs `go test -race -timeout=15m` over every package except
 `internal/e2e` and is what CI invokes — running it locally before a PR
@@ -54,7 +62,8 @@ and when to run `-race` against `./internal/e2e/...` manually.
 |---------|-------------|
 | `go run ./cmd/cyoda` | Run from source |
 | `go build -o bin/cyoda ./cmd/cyoda` | Build executable |
-| `go test ./... -v` | Run all tests |
+| `make test` | Iteration tier: unit + parity (~3 min) |
+| `make test-full` | Everything, root + plugin submodules (~15 min) |
 | `make race` | Run tests with race detector (CI-parity scope; excludes `internal/e2e`) |
 | `go test -coverprofile=coverage.out ./...` | Test coverage |
 | `./scripts/dev/run-docker-dev.sh` | Start with Docker + PostgreSQL |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Every feature follows this flow:
    c. Refactor — all tests stay green
    d. Commit
 3. Run E2E tests:
-   - If Docker socket is available: run directly (go test ./internal/e2e/ -v)
+   - If Docker socket is available: run directly (go test ./internal/e2e/), or `make test-full` for the whole suite
    - If sandboxed without Docker: human operator runs E2E tests and provides feedback
 4. Code review (code-reviewer)
    -> Fix all Critical/Important findings
@@ -37,7 +37,7 @@ Every feature must have tests at the appropriate level before it can be merged.
 **Reconciliation tests** (`test/recon/`, build tag `cyoda_recon`) compare Cyoda-Go responses against Cyoda Cloud to verify API-level compatibility. These are optional and require Cloud credentials.
 
 ```bash
-make test        # iteration tier: unit + cross-backend parity (~3 min)
+make test        # iteration tier: unit + cross-backend parity (~90s cold, ~13s warm)
 make test-full   # everything, root + all three plugin submodules (~15 min)
 make race        # race detector (CI-parity scope) — once before a PR
 go test -tags cyoda_recon ./test/recon/   # reconciliation (optional, needs Cloud)
@@ -62,7 +62,7 @@ and when to run `-race` against `./internal/e2e/...` manually.
 |---------|-------------|
 | `go run ./cmd/cyoda` | Run from source |
 | `go build -o bin/cyoda ./cmd/cyoda` | Build executable |
-| `make test` | Iteration tier: unit + parity (~3 min) |
+| `make test` | Iteration tier: unit + parity (~90s cold, ~13s warm) |
 | `make test-full` | Everything, root + plugin submodules (~15 min) |
 | `make race` | Run tests with race detector (CI-parity scope; excludes `internal/e2e`) |
 | `go test -coverprofile=coverage.out ./...` | Test coverage |

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -167,7 +167,7 @@ Do this as a single consolidated **release-prep** commit on the release branch,
    submodule). If a grouped PR was closed because it was entangled with the
    then-unresolvable SPI pin, apply its third-party updates by hand here.
 3. `go mod tidy` in every module.
-4. Verify: `make check-spi-pin-sync`, `make test-all`, `make race`.
+4. Verify: `make check-spi-pin-sync`, `make test-full`, `make race`.
 
 After this commit the branch is at latest on everything, so Dependabot's next
 run finds nothing to raise — a clean release with no immediate follow-on churn.
@@ -386,7 +386,7 @@ When you bump cyoda-go-spi:
 1. Bump in `go.mod` (root).
 2. Bump identically in `plugins/memory/go.mod`, `plugins/postgres/go.mod`, `plugins/sqlite/go.mod`.
 3. Run `go mod tidy` in each module.
-4. Run `make test-all` to verify cross-plugin interactions.
+4. Run `make test-full` to verify cross-plugin interactions.
 5. Run `make check-spi-pin-sync` locally to confirm green.
 
 This rule is in addition to the existing **plugin-version lockstep**

--- a/Makefile
+++ b/Makefile
@@ -101,18 +101,19 @@ PARITY_SUITES := e2e/parity/memory,e2e/parity/sqlite,e2e/parity/postgres,e2e/par
 preflight:             ## Verify Docker can actually serve the test suites
 	@./scripts/preflight-docker.sh
 
-test: preflight        ## Iteration tier: unit + cross-backend parity (~3 min). Excludes internal/e2e and plugin submodules.
+test: preflight        ## Iteration tier: unit + cross-backend parity (~90s cold, ~13s warm). Excludes internal/e2e and plugin submodules.
 	@echo "==> unit + parity — NOT in this tier: internal/e2e, plugin submodules (see test-full)"
 	@pkgs=$$(go list ./... | grep -v '^github.com/cyoda-platform/cyoda-go/internal/e2e$$'); \
-	go test -json $$pkgs | go run ./scripts/testreport -must-run '$(PARITY_SUITES)'
+	go test -json -timeout 20m $$pkgs | go run ./scripts/testreport -must-run '$(PARITY_SUITES)'
 
 test-full: preflight   ## End-of-deliverable: everything, root + every plugin submodule (~15 min)
 	@echo "==> root module, including internal/e2e"
 	@go test -json -timeout 30m ./... | go run ./scripts/testreport -must-run '$(PARITY_SUITES),internal/e2e'
-	@for m in $(PLUGIN_MODULES); do \
+	@rpt=$$(mktemp -t testreport); go build -o "$$rpt" ./scripts/testreport; \
+	for m in $(PLUGIN_MODULES); do \
 	  echo "==> $$m"; \
-	  (cd $$m && go test -json ./... | go run $(CURDIR)/scripts/testreport) || exit $$?; \
-	done
+	  (cd $$m && go test -json ./... | "$$rpt" -must-run "$$m") || { rm -f "$$rpt"; exit 1; }; \
+	done; rm -f "$$rpt"
 
 # Race detector — run once before opening a PR, not on every iteration.
 # Race instrumentation makes tests 2-10× slower (see .claude/rules/race-testing.md).
@@ -123,7 +124,7 @@ test-full: preflight   ## End-of-deliverable: everything, root + every plugin su
 race:                  ## Run race detector on race-sensitive packages (CI parity; excludes internal/e2e)
 	@pkgs=$$(go list ./... | grep -v '^github.com/cyoda-platform/cyoda-go/internal/e2e$$'); \
 	echo "race-testing $$(echo "$$pkgs" | wc -l | tr -d ' ') packages"; \
-	go test -json -race -timeout=15m $$pkgs | go run ./scripts/testreport
+	go test -json -race -timeout=15m $$pkgs | go run ./scripts/testreport -must-run '$(PARITY_SUITES)'
 
 dev-test: dev-up       ## Run all tests against the local postgres from dev-up
 	$(DEV_PG_ENV) go test -json -count=1 -timeout 30m ./... | go run ./scripts/testreport \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: dev-up dev-down dev-reset dev-ps dev-logs dev-run dev-test build test test-all test-short-all race clean docker-build docker-push todos check-spi-pin-sync check-codegen check-gofmt repin-plugins
+.PHONY: dev-up dev-down dev-reset dev-ps dev-logs dev-run dev-test build test test-full preflight race clean docker-build docker-push todos check-spi-pin-sync check-codegen check-gofmt repin-plugins
+
+# Recipes need pipefail: a `go test | testreport` pipeline must fail on the
+# LEFT side too, or a compile error in the test binary reports as success.
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -c
 
 # Plugin submodules: each has its own go.mod, so `go test ./...` from the
 # repo root does not recurse into them. The aggregator targets below close
@@ -67,21 +72,46 @@ endif
 
 # --- Testing ---
 
-test:                  ## Run root-module tests only (plugin submodules skipped — see test-all)
-	go test ./... -v
+# --- Tests ---
+#
+# Two tiers, and no Docker-free tier by design. Every tier that matters stands
+# up real containers; when Docker cannot serve them the answer is to fix
+# Docker, not to fall back to a narrower run that reports green.
+#
+# Both tiers pipe `go test -json` through scripts/testreport rather than using
+# -v. That buys two things:
+#
+#   1. A package that ran NO tests is reported as such and, when the tier
+#      required it, fails the run. `go test` cannot express this: a TestMain
+#      calling os.Exit(0) — how the parity suites and internal/e2e opt out of
+#      -short — emits a package-level "pass" with no test events, printing
+#      `ok  pkg  2.80s`, identical to a real pass. A green that cannot be
+#      falsified gets escalated to the full suite every round, which is what
+#      made verification the slowest part of delivery.
+#   2. Failures print verbatim and in full, with the passing majority reduced
+#      to a count. -v emitted 45,000 events for the fast tier alone, so output
+#      got piped through `tail` and real failures were lost.
 
-test-all:              ## Run root + every plugin submodule (requires Docker for postgres)
-	go test ./... -v
-	@for m in $(PLUGIN_MODULES); do \
-	  echo "==> go test ./... in $$m"; \
-	  (cd $$m && go test ./... -v) || exit $$?; \
-	done
+# The parity runners. Deliberately explicit rather than an `e2e/parity` prefix:
+# externalapi, scheduledfunction and scheduledtransition under that tree are
+# scenario libraries with no test files of their own, and requiring them would
+# report a hole that is not one.
+PARITY_SUITES := e2e/parity/memory,e2e/parity/sqlite,e2e/parity/postgres,e2e/parity/multinode,e2e/parity/fixtureutil
 
-test-short-all:        ## Run root + every plugin submodule with -short (quick coverage check)
-	go test -short ./... -v
+preflight:             ## Verify Docker can actually serve the test suites
+	@./scripts/preflight-docker.sh
+
+test: preflight        ## Iteration tier: unit + cross-backend parity (~3 min). Excludes internal/e2e and plugin submodules.
+	@echo "==> unit + parity — NOT in this tier: internal/e2e, plugin submodules (see test-full)"
+	@pkgs=$$(go list ./... | grep -v '^github.com/cyoda-platform/cyoda-go/internal/e2e$$'); \
+	go test -json $$pkgs | go run ./scripts/testreport -must-run '$(PARITY_SUITES)'
+
+test-full: preflight   ## End-of-deliverable: everything, root + every plugin submodule (~15 min)
+	@echo "==> root module, including internal/e2e"
+	@go test -json -timeout 30m ./... | go run ./scripts/testreport -must-run '$(PARITY_SUITES),internal/e2e'
 	@for m in $(PLUGIN_MODULES); do \
-	  echo "==> go test -short ./... in $$m"; \
-	  (cd $$m && go test -short ./... -v) || exit $$?; \
+	  echo "==> $$m"; \
+	  (cd $$m && go test -json ./... | go run $(CURDIR)/scripts/testreport) || exit $$?; \
 	done
 
 # Race detector — run once before opening a PR, not on every iteration.
@@ -93,10 +123,11 @@ test-short-all:        ## Run root + every plugin submodule with -short (quick c
 race:                  ## Run race detector on race-sensitive packages (CI parity; excludes internal/e2e)
 	@pkgs=$$(go list ./... | grep -v '^github.com/cyoda-platform/cyoda-go/internal/e2e$$'); \
 	echo "race-testing $$(echo "$$pkgs" | wc -l | tr -d ' ') packages"; \
-	go test -race -timeout=15m $$pkgs
+	go test -json -race -timeout=15m $$pkgs | go run ./scripts/testreport
 
-dev-test: dev-up       ## Run all tests against local postgres
-	$(DEV_PG_ENV) go test ./... -v -count=1
+dev-test: dev-up       ## Run all tests against the local postgres from dev-up
+	$(DEV_PG_ENV) go test -json -count=1 -timeout 30m ./... | go run ./scripts/testreport \
+	  -must-run '$(PARITY_SUITES),internal/e2e'
 
 # --- TODOs ---
 

--- a/docs/adr/0001-openapi-server-spec-conformance.md
+++ b/docs/adr/0001-openapi-server-spec-conformance.md
@@ -80,7 +80,7 @@ this ADR; revisiting requires a new ADR superseding this one.
 - **Runtime, not compile-time guarantee.** A handler can return the
   wrong shape and we find out at the next E2E run, not at build. This
   is acceptable while we have a robust E2E suite (we do — `make
-  test-all` covers all backends including postgres testcontainers); it
+  test-full` covers all backends including postgres testcontainers); it
   becomes weaker if a wire-shape regression slips into a less-covered
   path. **Mitigation:** treat E2E coverage as load-bearing for this
   guarantee; gaps surfaced during the spec audit get tests added

--- a/scripts/preflight-docker.sh
+++ b/scripts/preflight-docker.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Pre-flight for the Docker-backed test tiers.
+#
+# The tiers that matter stand up real PostgreSQL containers. When Docker cannot
+# serve them the tests fail in a way that reads like a product defect: a full
+# Docker VM disk surfaces only as
+#
+#   start postgres container: ... wait until ready: container exited with code 1
+#
+# with the actual cause (`FATAL: could not write to file ...: No space left on
+# device`) buried in a container log the test discards. Diagnosing that from a
+# test failure has cost this project hours.
+#
+# So: check here, fail loudly, and say what to do. There is deliberately no
+# Docker-free fallback tier — an unavailable Docker is a problem to surface,
+# not to work around.
+set -euo pipefail
+
+PROBE_IMAGE="${PROBE_IMAGE:-postgres:17-alpine}"
+
+fail() {
+  echo "" >&2
+  echo "PRE-FLIGHT FAILED: $1" >&2
+  echo "" >&2
+  shift
+  for line in "$@"; do echo "  $line" >&2; done
+  echo "" >&2
+  echo "Do not work around this by running a narrower tier. Fix Docker, then re-run." >&2
+  exit 1
+}
+
+# Resolve the docker binary by EXECUTING candidates, not by looking one up.
+# Two things defeat a naive `command -v docker` here:
+#   - a Docker Desktop install symlinks /usr/local/bin/docker into
+#     /Applications, where macOS privacy protection can deny stat() to a
+#     non-interactive shell, so lookup reports nothing for a working docker;
+#   - `docker` may resolve only in an interactive shell's environment, while
+#     make recipes run under sh and never see it.
+# Export DOCKER_BIN to override.
+resolve_docker() {
+  for cand in "${DOCKER_BIN:-}" docker /usr/local/bin/docker \
+              /Applications/Docker.app/Contents/Resources/bin/docker \
+              "$HOME/.docker/bin/docker" /opt/homebrew/bin/docker; do
+    [ -n "$cand" ] || continue
+    if "$cand" version >/dev/null 2>&1 || "$cand" info >/dev/null 2>&1; then
+      echo "$cand"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if ! DOCKER="$(resolve_docker)"; then
+  fail "docker could not be executed." \
+       "Either it is not installed, or the daemon is not responding." \
+       "Start Docker Desktop and wait for it to report running, then re-run." \
+       "If docker lives somewhere unusual, set DOCKER_BIN to its full path."
+fi
+
+# `docker version` can succeed against a live client with a dead daemon.
+if ! "$DOCKER" info >/dev/null 2>&1; then
+  fail "the Docker daemon is not responding." \
+       "The client works, so Docker is installed but not running." \
+       "Start Docker Desktop and wait for it to report running, then re-run."
+fi
+
+if ! "$DOCKER" image inspect "$PROBE_IMAGE" >/dev/null 2>&1; then
+  fail "the probe image $PROBE_IMAGE is not present locally." \
+       "Registry pulls have been unreliable on this machine, so the suites rely" \
+       "on locally-cached images. Restore it before running the Docker tiers."
+fi
+
+# Prove the VM disk can actually take a write. `docker info` stays happy on a
+# full disk; only a real write finds it. 64 MiB is far less than a PostgreSQL
+# initdb needs, so passing here is a floor, not a guarantee.
+if ! "$DOCKER" run --rm "$PROBE_IMAGE" \
+     sh -c 'dd if=/dev/zero of=/tmp/.preflight bs=1M count=64 >/dev/null 2>&1 && rm -f /tmp/.preflight' \
+     >/dev/null 2>&1; then
+  fail "Docker cannot write 64 MiB inside a container — its VM disk is full." \
+       "The host having free space is not the same thing; check the VM, not df." \
+       "" \
+       "Reclaim, in this order (none of these touch images, which cannot be re-pulled here):" \
+       "  docker volume prune -f     # anonymous testcontainer volumes" \
+       "  docker builder prune -f" \
+       "  docker container prune -f --filter label=org.testcontainers=true" \
+       "" \
+       "Plain 'volume prune' spares named volumes. Do NOT add -a."
+fi

--- a/scripts/preflight-docker.sh
+++ b/scripts/preflight-docker.sh
@@ -42,7 +42,10 @@ resolve_docker() {
               /Applications/Docker.app/Contents/Resources/bin/docker \
               "$HOME/.docker/bin/docker" /opt/homebrew/bin/docker; do
     [ -n "$cand" ] || continue
-    if "$cand" version >/dev/null 2>&1 || "$cand" info >/dev/null 2>&1; then
+    # --version is client-only and succeeds with the daemon down, which is
+    # what lets the daemon check below report that case precisely instead of
+    # every candidate failing and the script blaming the binary.
+    if "$cand" --version >/dev/null 2>&1; then
       echo "$cand"
       return 0
     fi

--- a/scripts/testreport/main.go
+++ b/scripts/testreport/main.go
@@ -1,0 +1,405 @@
+// Command testreport turns a `go test -json` stream into a per-package summary
+// plus the verbatim output of anything that failed, and fails the run when a
+// package that was required to execute tests did not execute any.
+//
+// It exists because `go test` cannot express the difference between "this
+// package passed" and "this package never started". A TestMain that calls
+// os.Exit(0) — which is how the parity suites and internal/e2e opt out of
+// -short — emits a package-level "pass" and no test events whatsoever. The
+// result is `ok  pkg  2.80s`, identical in shape to a real pass. A cheap tier
+// whose green cannot be falsified is a tier nobody can rely on, so every
+// verification round escalates to the full suite.
+//
+// Usage:
+//
+//	go test -json ./... | go run ./scripts/testreport -must-run e2e/parity,internal/e2e
+//
+// -must-run takes comma-separated substrings matched against the package path.
+// A matching package that ran no tests, or whose every test skipped, is a
+// failure naming the package.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// Status is a package's outcome, drawing the distinction `go test` does not:
+// passing is not the same as never having run.
+type Status string
+
+const (
+	StatusPass       Status = "PASS"
+	StatusFail       Status = "FAIL"
+	StatusAllSkipped Status = "SKIPPED"
+	StatusNoTests    Status = "NO-TESTS"
+)
+
+type event struct {
+	Action  string
+	Package string
+	Test    string
+	Output  string
+	Elapsed float64
+	// Compile errors arrive on "build-output" events keyed by ImportPath
+	// rather than Package, and the path carries a " [pkg.test]" suffix. Keying
+	// only on Package silently discards the line that says what is wrong.
+	ImportPath string
+}
+
+type pkgResult struct {
+	name       string
+	pass       int
+	fail       int
+	skip       int
+	elapsed    float64
+	failed     bool
+	failOutput []string // verbatim, in order, for failing tests and build errors
+}
+
+// Result is the analysed run.
+type Result struct {
+	pkgs     map[string]*pkgResult
+	order    []string
+	missed   []string // required packages that executed nothing
+	buffers  map[string]*perTest
+	ExitCode int
+}
+
+// Status reports how a package finished.
+func (r *Result) Status(pkg string) Status {
+	p, ok := r.pkgs[pkg]
+	if !ok {
+		return StatusNoTests
+	}
+	switch {
+	case p.failed || p.fail > 0:
+		return StatusFail
+	case p.pass > 0:
+		return StatusPass
+	case p.skip > 0:
+		return StatusAllSkipped
+	default:
+		return StatusNoTests
+	}
+}
+
+// analyse consumes a `go test -json` stream. mustRun holds substrings; any
+// package whose path contains one must have executed at least one passing
+// test, or the run fails.
+func analyse(src io.Reader, mustRun []string) (*Result, error) {
+	return analyseTo(src, mustRun, io.Discard)
+}
+
+// analyseTo is analyse with a progress sink. Failures are announced to it the
+// moment they are seen so a long tier can be abandoned early instead of
+// running to completion before revealing anything. Passes stay silent — the
+// whole point is to avoid recreating the -v firehose.
+func analyseTo(src io.Reader, mustRun []string, progress io.Writer) (*Result, error) {
+	res := &Result{pkgs: map[string]*pkgResult{}, buffers: map[string]*perTest{}}
+
+	get := func(name string) *pkgResult {
+		p, ok := res.pkgs[name]
+		if !ok {
+			p = &pkgResult{name: name}
+			res.pkgs[name] = p
+			res.order = append(res.order, name)
+		}
+		return p
+	}
+
+	sc := bufio.NewScanner(src)
+	// Test output lines can be long; the default 64KiB token cap truncates a
+	// panic's goroutine dump, which is exactly the detail worth keeping.
+	sc.Buffer(make([]byte, 0, 1<<20), 16<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue // `go test` interleaves non-JSON on some toolchain errors
+		}
+		var e event
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			continue
+		}
+		pkgName := e.Package
+		if pkgName == "" && e.ImportPath != "" {
+			pkgName = importPathToPackage(e.ImportPath)
+		}
+		if pkgName == "" {
+			continue
+		}
+		p := get(pkgName)
+
+		// Build diagnostics precede any test event and carry the real cause.
+		if e.Action == "build-output" || e.Action == "build-fail" {
+			if e.Action == "build-fail" {
+				p.failed = true
+			}
+			for _, l := range strings.Split(strings.TrimRight(e.Output, "\n"), "\n") {
+				// The "# pkg [pkg.test]" banner repeats the package name.
+				if l != "" && !strings.HasPrefix(l, "# ") {
+					p.failOutput = append(p.failOutput, l)
+				}
+			}
+			continue
+		}
+
+		if e.Test == "" {
+			switch e.Action {
+			case "pass", "fail", "skip":
+				p.elapsed = e.Elapsed
+				if e.Action == "fail" {
+					p.failed = true
+				}
+			case "output":
+				// Package-scoped output with no test: build errors live here.
+				if s := strings.TrimRight(e.Output, "\n"); s != "" && !isNoise(s) {
+					p.failOutput = append(p.failOutput, s)
+				}
+			}
+			continue
+		}
+
+		switch e.Action {
+		case "pass":
+			p.pass++
+		case "fail":
+			p.fail++
+			fmt.Fprintf(progress, "FAIL %s.%s\n", shortPkg(e.Package), e.Test)
+		case "skip":
+			p.skip++
+		case "output":
+			// Buffered against the test; kept only if that test fails.
+			res.bufferOutput(p.name, e.Test, e.Output)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("reading test output: %w", err)
+	}
+
+	res.finalise(mustRun)
+	return res, nil
+}
+
+// perTest buffers output per test so a passing test's chatter is discarded and
+// a failing test's is kept in full.
+type perTest struct {
+	order  []string
+	byTest map[string][]string
+}
+
+func (r *Result) bufferOutput(pkg, test, out string) {
+	b, ok := r.buffers[pkg]
+	if !ok {
+		b = &perTest{byTest: map[string][]string{}}
+		r.buffers[pkg] = b
+	}
+	if _, seen := b.byTest[test]; !seen {
+		b.order = append(b.order, test)
+	}
+	b.byTest[test] = append(b.byTest[test], strings.TrimRight(out, "\n"))
+}
+
+// isNoise drops go test's own framing lines, which carry no diagnostic value.
+func isNoise(s string) bool {
+	t := strings.TrimSpace(s)
+	return t == "" ||
+		strings.HasPrefix(t, "=== RUN") || strings.HasPrefix(t, "=== PAUSE") ||
+		strings.HasPrefix(t, "=== CONT") || strings.HasPrefix(t, "=== NAME") ||
+		strings.HasPrefix(t, "--- PASS") || strings.HasPrefix(t, "--- SKIP") ||
+		strings.HasPrefix(t, "PASS") || strings.HasPrefix(t, "ok ")
+}
+
+func (r *Result) finalise(mustRun []string) {
+	// Attach the buffered output of failing tests, in the order they ran.
+	for name, p := range r.pkgs {
+		b, ok := r.buffers[name]
+		if !ok {
+			continue
+		}
+		for _, test := range b.order {
+			lines := b.byTest[test]
+			if !containsFailure(lines) {
+				continue
+			}
+			p.failOutput = append(p.failOutput, "--- FAIL: "+test)
+			for _, l := range lines {
+				if !isNoise(l) {
+					p.failOutput = append(p.failOutput, l)
+				}
+			}
+		}
+	}
+	r.buffers = nil
+
+	for _, name := range r.order {
+		if !matchesAny(name, mustRun) {
+			continue
+		}
+		if r.Status(name) != StatusPass && r.Status(name) != StatusFail {
+			r.missed = append(r.missed, name)
+		}
+	}
+	// A required package absent from the stream entirely never compiled or was
+	// never selected — as much a hole as one that ran nothing.
+	for _, want := range mustRun {
+		if want == "" {
+			continue
+		}
+		if !anyPackageMatches(r.order, want) {
+			r.missed = append(r.missed, want+"  (no package matched)")
+		}
+	}
+	sort.Strings(r.missed)
+
+	for _, p := range r.pkgs {
+		if p.failed || p.fail > 0 {
+			r.ExitCode = 1
+		}
+	}
+	if len(r.missed) > 0 {
+		r.ExitCode = 1
+	}
+}
+
+// isMissed reports whether a package was required to run tests and did not.
+func (r *Result) isMissed(pkg string) bool {
+	for _, m := range r.missed {
+		if m == pkg {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFailure(lines []string) bool {
+	for _, l := range lines {
+		if strings.HasPrefix(strings.TrimSpace(l), "--- FAIL") {
+			return true
+		}
+	}
+	// A test can fail without a "--- FAIL" output line reaching this buffer;
+	// the caller only keeps output for tests it already knows failed when the
+	// marker is absent, so fall back to keeping it.
+	return len(lines) > 0
+}
+
+// importPathToPackage strips the " [pkg.test]" qualifier go test appends to a
+// build diagnostic's ImportPath, yielding the package the report keys on.
+func importPathToPackage(ip string) string {
+	if i := strings.Index(ip, " ["); i >= 0 {
+		return ip[:i]
+	}
+	return ip
+}
+
+// shortPkg trims the module prefix so a streamed line stays readable.
+func shortPkg(pkg string) string {
+	if i := strings.Index(pkg, "/cyoda-go/"); i >= 0 {
+		return pkg[i+len("/cyoda-go/"):]
+	}
+	return pkg
+}
+
+func matchesAny(pkg string, subs []string) bool {
+	for _, s := range subs {
+		if s != "" && strings.Contains(pkg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyPackageMatches(pkgs []string, sub string) bool {
+	for _, p := range pkgs {
+		if strings.Contains(p, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// Render produces the human-facing report: failures verbatim and first, then
+// anything that did not run, then a one-line-per-package summary of what did.
+func (r *Result) Render() string {
+	var b strings.Builder
+
+	for _, name := range r.order {
+		p := r.pkgs[name]
+		if len(p.failOutput) == 0 || r.Status(name) != StatusFail {
+			continue
+		}
+		fmt.Fprintf(&b, "\n=== FAILURES in %s ===\n", name)
+		for _, l := range p.failOutput {
+			b.WriteString(l + "\n")
+		}
+	}
+
+	if len(r.missed) > 0 {
+		b.WriteString("\n=== REQUIRED SUITES THAT DID NOT RUN ===\n")
+		for _, m := range r.missed {
+			fmt.Fprintf(&b, "  %s\n", m)
+		}
+		b.WriteString("\nThese were required to execute tests and did not. A package whose\n" +
+			"TestMain exits early reports `ok` with no tests — that is not a pass.\n")
+	}
+
+	var pass, fail, skipped, notests int
+	var sum strings.Builder
+	for _, name := range r.order {
+		p := r.pkgs[name]
+		st := r.Status(name)
+		switch st {
+		case StatusPass:
+			pass++
+			continue // the happy majority is a count, not a list
+		case StatusFail:
+			fail++
+		case StatusAllSkipped:
+			skipped++
+		case StatusNoTests:
+			notests++
+			// A package with no tests is usually correct — generated code,
+			// scenario libraries, skeletons. Only call it out when something
+			// required it to run. It stays in the count either way.
+			if !r.isMissed(name) {
+				continue
+			}
+		}
+		fmt.Fprintf(&sum, "  %-8s %6.2fs  %s\n", st, p.elapsed, name)
+	}
+	if sum.Len() > 0 {
+		b.WriteString("\n=== PACKAGES NOT PASSING NORMALLY ===\n")
+		b.WriteString(sum.String())
+	}
+	fmt.Fprintf(&b, "\n%d passed, %d failed, %d all-skipped, %d ran no tests\n",
+		pass, fail, skipped, notests)
+	return b.String()
+}
+
+func main() {
+	mustRun := flag.String("must-run", "",
+		"comma-separated package-path substrings that MUST execute at least one test")
+	flag.Parse()
+
+	var required []string
+	for _, s := range strings.Split(*mustRun, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			required = append(required, s)
+		}
+	}
+
+	res, err := analyseTo(os.Stdin, required, os.Stderr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "testreport:", err)
+		os.Exit(2)
+	}
+	fmt.Print(res.Render())
+	os.Exit(res.ExitCode)
+}

--- a/scripts/testreport/main.go
+++ b/scripts/testreport/main.go
@@ -54,13 +54,17 @@ type event struct {
 }
 
 type pkgResult struct {
-	name       string
-	pass       int
-	fail       int
-	skip       int
-	elapsed    float64
-	failed     bool
-	failOutput []string // verbatim, in order, for failing tests and build errors
+	name    string
+	pass    int
+	fail    int
+	skip    int
+	elapsed float64
+	failed  bool
+	// failedTests is which tests actually failed. Without it there is no way
+	// to tell a failing test's buffered output from a chatty passing one's,
+	// and every test that logged anything gets relabelled as a failure.
+	failedTests map[string]bool
+	failOutput  []string // verbatim, in order, for failing tests and build errors
 }
 
 // Result is the analysed run.
@@ -107,7 +111,7 @@ func analyseTo(src io.Reader, mustRun []string, progress io.Writer) (*Result, er
 	get := func(name string) *pkgResult {
 		p, ok := res.pkgs[name]
 		if !ok {
-			p = &pkgResult{name: name}
+			p = &pkgResult{name: name, failedTests: map[string]bool{}}
 			res.pkgs[name] = p
 			res.order = append(res.order, name)
 		}
@@ -171,7 +175,8 @@ func analyseTo(src io.Reader, mustRun []string, progress io.Writer) (*Result, er
 			p.pass++
 		case "fail":
 			p.fail++
-			fmt.Fprintf(progress, "FAIL %s.%s\n", shortPkg(e.Package), e.Test)
+			p.failedTests[e.Test] = true
+			fmt.Fprintf(progress, "FAIL %s.%s\n", shortPkg(pkgName), e.Test)
 		case "skip":
 			p.skip++
 		case "output":
@@ -213,7 +218,11 @@ func isNoise(s string) bool {
 		strings.HasPrefix(t, "=== RUN") || strings.HasPrefix(t, "=== PAUSE") ||
 		strings.HasPrefix(t, "=== CONT") || strings.HasPrefix(t, "=== NAME") ||
 		strings.HasPrefix(t, "--- PASS") || strings.HasPrefix(t, "--- SKIP") ||
-		strings.HasPrefix(t, "PASS") || strings.HasPrefix(t, "ok ")
+		strings.HasPrefix(t, "PASS") || strings.HasPrefix(t, "ok ") ||
+		// The report writes its own "--- FAIL: <test>" header and names the
+		// package itself, so the toolchain's copies of both are duplication.
+		strings.HasPrefix(t, "--- FAIL") || t == "FAIL" ||
+		strings.HasPrefix(t, "FAIL\t")
 }
 
 func (r *Result) finalise(mustRun []string) {
@@ -224,10 +233,10 @@ func (r *Result) finalise(mustRun []string) {
 			continue
 		}
 		for _, test := range b.order {
-			lines := b.byTest[test]
-			if !containsFailure(lines) {
-				continue
+			if !p.failedTests[test] {
+				continue // a passing test's output is noise, not a failure
 			}
+			lines := b.byTest[test]
 			p.failOutput = append(p.failOutput, "--- FAIL: "+test)
 			for _, l := range lines {
 				if !isNoise(l) {
@@ -278,18 +287,6 @@ func (r *Result) isMissed(pkg string) bool {
 	return false
 }
 
-func containsFailure(lines []string) bool {
-	for _, l := range lines {
-		if strings.HasPrefix(strings.TrimSpace(l), "--- FAIL") {
-			return true
-		}
-	}
-	// A test can fail without a "--- FAIL" output line reaching this buffer;
-	// the caller only keeps output for tests it already knows failed when the
-	// marker is absent, so fall back to keeping it.
-	return len(lines) > 0
-}
-
 // importPathToPackage strips the " [pkg.test]" qualifier go test appends to a
 // build diagnostic's ImportPath, yielding the package the report keys on.
 func importPathToPackage(ip string) string {
@@ -307,18 +304,29 @@ func shortPkg(pkg string) string {
 	return pkg
 }
 
+// matchesRequirement reports whether pkg IS the package a requirement names.
+// Substring matching is wrong here: "internal/e2e" would be satisfied by
+// "internal/e2e/goroutinesafety", a different package that really does exist,
+// and the requirement would silently evaporate.
+func matchesRequirement(pkg, req string) bool {
+	if req == "" {
+		return false
+	}
+	return pkg == req || shortPkg(pkg) == req || strings.HasSuffix(pkg, "/"+req)
+}
+
 func matchesAny(pkg string, subs []string) bool {
 	for _, s := range subs {
-		if s != "" && strings.Contains(pkg, s) {
+		if matchesRequirement(pkg, s) {
 			return true
 		}
 	}
 	return false
 }
 
-func anyPackageMatches(pkgs []string, sub string) bool {
+func anyPackageMatches(pkgs []string, req string) bool {
 	for _, p := range pkgs {
-		if strings.Contains(p, sub) {
+		if matchesRequirement(p, req) {
 			return true
 		}
 	}
@@ -351,6 +359,12 @@ func (r *Result) Render() string {
 	}
 
 	var pass, fail, skipped, notests int
+	var ranTests, failedTests, skippedTests int
+	for _, p := range r.pkgs {
+		ranTests += p.pass + p.fail
+		failedTests += p.fail
+		skippedTests += p.skip
+	}
 	var sum strings.Builder
 	for _, name := range r.order {
 		p := r.pkgs[name]
@@ -378,7 +392,12 @@ func (r *Result) Render() string {
 		b.WriteString("\n=== PACKAGES NOT PASSING NORMALLY ===\n")
 		b.WriteString(sum.String())
 	}
-	fmt.Fprintf(&b, "\n%d passed, %d failed, %d all-skipped, %d ran no tests\n",
+	// Both axes, because they answer different questions. The defect that
+	// prompted this tool looked like "7885 tests passing" — healthy — while
+	// five PACKAGES had run nothing at all.
+	fmt.Fprintf(&b, "\n%d tests (%d failed, %d skipped) across %d packages\n",
+		ranTests, failedTests, skippedTests, len(r.order))
+	fmt.Fprintf(&b, "%d packages passed, %d failed, %d all-skipped, %d ran no tests\n",
 		pass, fail, skipped, notests)
 	return b.String()
 }

--- a/scripts/testreport/report_test.go
+++ b/scripts/testreport/report_test.go
@@ -44,7 +44,7 @@ func trimFloat(f float64) string {
 func TestSilentSkip_RequiredPackageThatRanNoTests_IsAFailure(t *testing.T) {
 	stream := eventStream(pkgEvent("pass", pkgParity, 2.8))
 
-	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity"})
+	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity/memory"})
 	if err != nil {
 		t.Fatalf("analyse: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestRequiredPackageThatPassed_IsClean(t *testing.T) {
 		pkgEvent("pass", pkgParity, 2.8),
 	)
 
-	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity"})
+	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity/memory"})
 	if err != nil {
 		t.Fatalf("analyse: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestPackageWhereEveryTestSkipped_DoesNotSatisfyMustRun(t *testing.T) {
 		pkgEvent("pass", pkgParity, 2.8),
 	)
 
-	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity"})
+	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity/memory"})
 	if err != nil {
 		t.Fatalf("analyse: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestRequiredPackageAbsentFromStream_IsAFailure(t *testing.T) {
 		pkgEvent("pass", pkgSearch, 1.5),
 	)
 
-	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity"})
+	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity/memory"})
 	if err != nil {
 		t.Fatalf("analyse: %v", err)
 	}
@@ -324,5 +324,122 @@ func TestBuildError_KeyedByImportPath_IsAttributedAndShown(t *testing.T) {
 	}
 	if !strings.Contains(out, "x_test.go:6:2") {
 		t.Errorf("the file:line must be shown; got:\n%s", out)
+	}
+}
+
+// Only tests that ACTUALLY failed may appear under a --- FAIL header. A
+// package records no per-test outcome unless we track it, and a fallback of
+// "keep any test that produced output" relabels the passing majority as
+// failures — recreating the wall of output this tool exists to remove, now
+// with wrong labels.
+func TestOnlyFailingTests_AppearInTheFailureReport(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgSearch, "TestChatty"),
+		outEvent(pkgSearch, "TestChatty", "    chatty_test.go:3: progress\\n"),
+		testEvent("pass", pkgSearch, "TestChatty"),
+		runEvent(pkgSearch, "TestBroken"),
+		outEvent(pkgSearch, "TestBroken", "    x_test.go:9: want 7, got 3\\n"),
+		testEvent("fail", pkgSearch, "TestBroken"),
+		pkgEvent("fail", pkgSearch, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	out := res.Render()
+	if !strings.Contains(out, "want 7, got 3") {
+		t.Errorf("the real failure must be shown; got:\n%s", out)
+	}
+	if strings.Contains(out, "TestChatty") {
+		t.Errorf("a PASSING test must not appear in the failure report; got:\n%s", out)
+	}
+	if n := strings.Count(out, "--- FAIL:"); n != 1 {
+		t.Errorf("want exactly 1 --- FAIL header, got %d:\n%s", n, out)
+	}
+}
+
+// A must-run entry names ONE package. A different package that merely contains
+// the string as a path prefix does not satisfy it: internal/e2e/goroutinesafety
+// running is not internal/e2e running, and both exist in this repo.
+func TestMustRun_IsNotSatisfiedByASubpackage(t *testing.T) {
+	const sub = "github.com/cyoda-platform/cyoda-go/internal/e2e/goroutinesafety"
+	stream := eventStream(
+		runEvent(sub, "TestThing"),
+		testEvent("pass", sub, "TestThing"),
+		pkgEvent("pass", sub, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{"internal/e2e"})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("internal/e2e did not run; a subpackage must not satisfy it\n%s", res.Render())
+	}
+}
+
+// The exact package still satisfies its own requirement.
+func TestMustRun_IsSatisfiedByTheExactPackage(t *testing.T) {
+	const pkg = "github.com/cyoda-platform/cyoda-go/internal/e2e"
+	stream := eventStream(
+		runEvent(pkg, "TestThing"),
+		testEvent("pass", pkg, "TestThing"),
+		pkgEvent("pass", pkg, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{"internal/e2e"})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("the exact package ran; want exit 0, got %d\n%s", res.ExitCode, res.Render())
+	}
+}
+
+// The bug that started this was spotted as "7885 tests passing" next to five
+// silent packages. Reporting only package counts loses that smell, so the
+// executed-test total stays in the summary.
+func TestSummary_ReportsExecutedTestCount(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgSearch, "TestA"),
+		testEvent("pass", pkgSearch, "TestA"),
+		runEvent(pkgSearch, "TestB"),
+		testEvent("pass", pkgSearch, "TestB"),
+		pkgEvent("pass", pkgSearch, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if !strings.Contains(res.Render(), "2 tests") {
+		t.Errorf("summary must carry the executed-test count; got:\n%s", res.Render())
+	}
+}
+
+// The report writes its own "--- FAIL: <test>" header, so the toolchain's
+// duplicate of that line, and its bare package-level FAIL framing, are noise.
+func TestToolchainFailFraming_IsNotDuplicated(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgSearch, "TestBroken"),
+		outEvent(pkgSearch, "TestBroken", "=== RUN   TestBroken\\n"),
+		outEvent(pkgSearch, "TestBroken", "    x_test.go:9: want 7, got 3\\n"),
+		outEvent(pkgSearch, "TestBroken", "--- FAIL: TestBroken (0.00s)\\n"),
+		testEvent("fail", pkgSearch, "TestBroken"),
+		`{"Action":"output","Package":"`+pkgSearch+`","Output":"FAIL\n"}`,
+		pkgEvent("fail", pkgSearch, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	out := res.Render()
+	if n := strings.Count(out, "--- FAIL:"); n != 1 {
+		t.Errorf("want exactly 1 --- FAIL header, got %d:\n%s", n, out)
+	}
+	if !strings.Contains(out, "want 7, got 3") {
+		t.Errorf("the substance must survive; got:\n%s", out)
 	}
 }

--- a/scripts/testreport/report_test.go
+++ b/scripts/testreport/report_test.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// eventStream builds a go test -json stream from compact literals so the tests
+// read as the scenario they pin rather than as JSON.
+func eventStream(lines ...string) string { return strings.Join(lines, "\n") + "\n" }
+
+const (
+	pkgParity = "github.com/cyoda-platform/cyoda-go/e2e/parity/memory"
+	pkgSearch = "github.com/cyoda-platform/cyoda-go/internal/domain/search"
+)
+
+func runEvent(pkg, test string) string {
+	return `{"Action":"run","Package":"` + pkg + `","Test":"` + test + `"}`
+}
+func testEvent(action, pkg, test string) string {
+	return `{"Action":"` + action + `","Package":"` + pkg + `","Test":"` + test + `"}`
+}
+func outEvent(pkg, test, out string) string {
+	return `{"Action":"output","Package":"` + pkg + `","Test":"` + test + `","Output":"` + out + `"}`
+}
+func pkgEvent(action, pkg string, elapsed float64) string {
+	return `{"Action":"` + action + `","Package":"` + pkg + `","Elapsed":` + trimFloat(elapsed) + `}`
+}
+
+func trimFloat(f float64) string {
+	switch f {
+	case 2.8:
+		return "2.8"
+	case 1.5:
+		return "1.5"
+	default:
+		return "0"
+	}
+}
+
+// A package that exits TestMain with os.Exit(0) emits a package-level "pass"
+// and no test events at all. That is the exact shape this tool exists to
+// catch: it is indistinguishable from a real pass in `go test` output.
+func TestSilentSkip_RequiredPackageThatRanNoTests_IsAFailure(t *testing.T) {
+	stream := eventStream(pkgEvent("pass", pkgParity, 2.8))
+
+	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity"})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("a required package that ran zero tests must fail; got exit 0\n%s", res.Render())
+	}
+	if got := res.Status(pkgParity); got != StatusNoTests {
+		t.Errorf("status = %q, want %q", got, StatusNoTests)
+	}
+	if !strings.Contains(res.Render(), pkgParity) {
+		t.Errorf("report must name the offending package; got:\n%s", res.Render())
+	}
+}
+
+// The same shape in a package nobody requires is reported but not fatal —
+// plenty of packages legitimately hold no tests. The requirement here is met
+// by a different package that did run, so nothing is missing.
+func TestSilentSkip_UnrequiredPackageThatRanNoTests_IsReportedNotFatal(t *testing.T) {
+	stream := eventStream(
+		pkgEvent("pass", pkgParity, 2.8),
+		runEvent(pkgSearch, "TestThing"),
+		testEvent("pass", pkgSearch, "TestThing"),
+		pkgEvent("pass", pkgSearch, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{"internal/domain/search"})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("no required package was missed; want exit 0, got %d\n%s", res.ExitCode, res.Render())
+	}
+	if got := res.Status(pkgParity); got != StatusNoTests {
+		t.Errorf("status = %q, want %q", got, StatusNoTests)
+	}
+}
+
+// A required package that ran tests and passed them is the happy path.
+func TestRequiredPackageThatPassed_IsClean(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgParity, "TestThing"),
+		testEvent("pass", pkgParity, "TestThing"),
+		pkgEvent("pass", pkgParity, 2.8),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity"})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("want exit 0, got %d\n%s", res.ExitCode, res.Render())
+	}
+	if got := res.Status(pkgParity); got != StatusPass {
+		t.Errorf("status = %q, want %q", got, StatusPass)
+	}
+}
+
+// A package whose every test skipped is NOT a pass: it is reported distinctly,
+// and it does not satisfy a must-run requirement.
+func TestPackageWhereEveryTestSkipped_DoesNotSatisfyMustRun(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgParity, "TestThing"),
+		testEvent("skip", pkgParity, "TestThing"),
+		pkgEvent("pass", pkgParity, 2.8),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity"})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("an all-skipped required package must fail; got exit 0\n%s", res.Render())
+	}
+	if got := res.Status(pkgParity); got != StatusAllSkipped {
+		t.Errorf("status = %q, want %q", got, StatusAllSkipped)
+	}
+}
+
+// Failure output is reproduced verbatim and in full. This is the truncation
+// trap the tool exists to remove: piping -v through `tail` loses the failure.
+func TestFailureOutput_IsReproducedVerbatim(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgSearch, "TestBroken"),
+		outEvent(pkgSearch, "TestBroken", "    service_test.go:42: want 7, got 3\\n"),
+		testEvent("fail", pkgSearch, "TestBroken"),
+		pkgEvent("fail", pkgSearch, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatal("a failing test must produce a non-zero exit")
+	}
+	out := res.Render()
+	if !strings.Contains(out, "service_test.go:42: want 7, got 3") {
+		t.Errorf("failure detail must appear verbatim; got:\n%s", out)
+	}
+	if !strings.Contains(out, "TestBroken") {
+		t.Errorf("failing test name must appear; got:\n%s", out)
+	}
+}
+
+// A passing run must not reproduce per-test output: that is the 45k-event
+// noise that made agents pipe the output through `tail` in the first place.
+func TestPassingRun_DoesNotEchoPerTestOutput(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgSearch, "TestFine"),
+		outEvent(pkgSearch, "TestFine", "chatty progress line\\n"),
+		testEvent("pass", pkgSearch, "TestFine"),
+		pkgEvent("pass", pkgSearch, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if strings.Contains(res.Render(), "chatty progress line") {
+		t.Errorf("passing output must not be echoed; got:\n%s", res.Render())
+	}
+}
+
+// A build failure emits package-level output with no test events. It must be
+// surfaced, not silently classed as "no tests".
+func TestBuildFailure_IsFatalAndShown(t *testing.T) {
+	stream := eventStream(
+		`{"Action":"output","Package":"`+pkgSearch+`","Output":"service.go:9:2: undefined: wat\n"}`,
+		pkgEvent("fail", pkgSearch, 0),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatal("a build failure must produce a non-zero exit")
+	}
+	if !strings.Contains(res.Render(), "undefined: wat") {
+		t.Errorf("build error must be shown; got:\n%s", res.Render())
+	}
+}
+
+// A required package that never appears in the stream at all did not compile,
+// or was not selected by the package pattern. Either way the suite it names
+// did not run, and saying so is the whole point of the tool.
+func TestRequiredPackageAbsentFromStream_IsAFailure(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgSearch, "TestThing"),
+		testEvent("pass", pkgSearch, "TestThing"),
+		pkgEvent("pass", pkgSearch, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{"e2e/parity"})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("a required package absent from the run must fail; got exit 0\n%s", res.Render())
+	}
+	if !strings.Contains(res.Render(), "e2e/parity") {
+		t.Errorf("report must name the missing requirement; got:\n%s", res.Render())
+	}
+}
+
+// Most packages that hold no tests hold none legitimately — generated protobuf,
+// scenario libraries the runners consume, skeleton packages. Listing them all
+// as anomalies buries the ones that matter, which is the same noise problem
+// that made -v output unreadable.
+func TestTestFreePackages_AreNotListedUnlessRequired(t *testing.T) {
+	const pkgProto = "github.com/cyoda-platform/cyoda-go/proto"
+	stream := eventStream(
+		pkgEvent("pass", pkgProto, 0),
+		runEvent(pkgSearch, "TestThing"),
+		testEvent("pass", pkgSearch, "TestThing"),
+		pkgEvent("pass", pkgSearch, 1.5),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{"internal/domain/search"})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("want exit 0, got %d\n%s", res.ExitCode, res.Render())
+	}
+	if strings.Contains(res.Render(), pkgProto) {
+		t.Errorf("an unrequired test-free package must not be listed; got:\n%s", res.Render())
+	}
+	// It is still counted, so the totals stay honest.
+	if !strings.Contains(res.Render(), "ran no tests") {
+		t.Errorf("the count must still report it; got:\n%s", res.Render())
+	}
+}
+
+// A required package that ran nothing must still be listed in the summary, not
+// only in the missing-suites block.
+func TestRequiredTestFreePackage_IsListed(t *testing.T) {
+	stream := eventStream(pkgEvent("pass", pkgParity, 2.8))
+
+	res, err := analyse(strings.NewReader(stream), []string{pkgParity})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if !strings.Contains(res.Render(), pkgParity) {
+		t.Errorf("a required package that ran nothing must be listed; got:\n%s", res.Render())
+	}
+}
+
+// A 15-minute tier that stays silent until the end wastes the whole run when
+// something fails at minute three. Failures must surface as they happen; the
+// verbatim detail still lands in the final report.
+func TestFailures_AreStreamedAsTheyHappen(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgSearch, "TestBroken"),
+		outEvent(pkgSearch, "TestBroken", "    x_test.go:9: boom\\n"),
+		testEvent("fail", pkgSearch, "TestBroken"),
+		pkgEvent("fail", pkgSearch, 1.5),
+	)
+
+	var progress strings.Builder
+	res, err := analyseTo(strings.NewReader(stream), []string{}, &progress)
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if !strings.Contains(progress.String(), "TestBroken") {
+		t.Errorf("a failing test must be announced while the run proceeds; got %q", progress.String())
+	}
+	// The final report still carries the detail.
+	if !strings.Contains(res.Render(), "x_test.go:9: boom") {
+		t.Errorf("final report must still carry the detail; got:\n%s", res.Render())
+	}
+}
+
+// Passing tests must not stream, or the progress channel becomes the same
+// 45k-line firehose the -v output was.
+func TestPasses_AreNotStreamed(t *testing.T) {
+	stream := eventStream(
+		runEvent(pkgSearch, "TestFine"),
+		testEvent("pass", pkgSearch, "TestFine"),
+		pkgEvent("pass", pkgSearch, 1.5),
+	)
+
+	var progress strings.Builder
+	if _, err := analyseTo(strings.NewReader(stream), []string{}, &progress); err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if progress.Len() != 0 {
+		t.Errorf("passing tests must stay quiet; got %q", progress.String())
+	}
+}
+
+// go test reports compile errors on "build-output" events keyed by ImportPath
+// — NOT by Package, and the ImportPath carries a " [pkg.test]" suffix. A
+// parser that keys only on Package drops the one line that says what is
+// actually wrong, leaving "[build failed]" with no reason. This is the exact
+// shape the toolchain emits.
+func TestBuildError_KeyedByImportPath_IsAttributedAndShown(t *testing.T) {
+	const ip = pkgSearch + " [" + pkgSearch + ".test]"
+	stream := eventStream(
+		`{"ImportPath":"`+ip+`","Action":"build-output","Output":"# `+ip+`\n"}`,
+		`{"ImportPath":"`+ip+`","Action":"build-output","Output":"internal/domain/search/x_test.go:6:2: undefined: undefinedSymbol\n"}`,
+		`{"ImportPath":"`+ip+`","Action":"build-fail"}`,
+		`{"Action":"output","Package":"`+pkgSearch+`","Output":"FAIL\tpkg [build failed]\n"}`,
+		pkgEvent("fail", pkgSearch, 0),
+	)
+
+	res, err := analyse(strings.NewReader(stream), []string{})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatal("a build failure must produce a non-zero exit")
+	}
+	out := res.Render()
+	if !strings.Contains(out, "undefined: undefinedSymbol") {
+		t.Errorf("the compile error must be shown; got:\n%s", out)
+	}
+	if !strings.Contains(out, "x_test.go:6:2") {
+		t.Errorf("the file:line must be shown; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Makes a test suite that did not run stop reporting `ok`, and reshapes the local tiers around that.

Closes #546.

## The measurement

`go test -short ./...` — 37.85s, 70 packages, 7885 tests passing. Five of those packages executed nothing:

| package | reported | tests run |
|---|---|---|
| `internal/e2e` | `ok  1.26s` | 0 |
| `e2e/parity/postgres` | `ok  2.36s` | 0 |
| `e2e/parity/memory` | `ok  2.80s` | 0 |
| `e2e/parity/sqlite` | `ok  2.91s` | 0 |
| `internal/testpg` | `ok  1.79s` | 0 |

They exit `TestMain` with `os.Exit(0)` before any test runs, so they emit **no skip events** — not even a `SKIP` line. `ok  pkg  2.80s` is identical in shape to a genuine pass.

The cheap tier was therefore not merely narrower than the full one: its green was unfalsifiable. Escalating to the full suite every round is the correct response to that, and it is why verification became the slowest part of delivery.

## What changed

**`scripts/testreport`** consumes `go test -json` and classifies each package `PASS` / `FAIL` / `SKIPPED` / `NO-TESTS`. A package the tier required to run, that ran nothing, fails the run and is named. Failures print verbatim and in full; the passing majority collapses to a count. Failing tests stream to stderr as they occur, so a long tier can be killed at minute three instead of revealing itself at minute fifteen.

Two parser shapes are load-bearing and both are pinned by tests:

- Compile errors arrive on `build-output` events keyed by **`ImportPath`, not `Package`**, with a `" [pkg.test]"` suffix. Keying only on `Package` drops them and leaves `[build failed]` with no reason.
- `e2e/parity/{externalapi,scheduledfunction,scheduledtransition}` hold **no test files** — they are scenario libraries the three backend runners consume. A broad `e2e/parity` requirement reports a hole that is not one, so the must-run list names the runners explicitly.

**Two tiers, and no Docker-free tier by design.**

| target | scope | measured |
|---|---|---|
| `make test` | unit + cross-backend parity | **89s cold, 13.3s warm** |
| `make test-full` | everything, root + all three plugin submodules | ~15 min |

The warm number is Go's test cache, which works because the targets do not force `-count=1`. Both tiers state what they exclude.

**`scripts/preflight-docker.sh`** fails the run when Docker cannot serve the suites, rather than letting it surface mid-suite as `container exited with code 1`. It checks the daemon, the probe image, and that the VM disk can take a 64 MiB write — the case that cost hours this milestone, where the host had 64 GiB free and the real error (`FATAL: could not write to file ...: No space left on device`) was in a container log the test discards. It probes by **executing** candidates rather than looking the binary up: macOS privacy protection denies `stat()` on the Docker Desktop symlink target, so `command -v docker` reports nothing for a docker that runs fine, and bare `docker` does not resolve under `sh` at all — which every make recipe uses.

**CI gains the same guarantee.** Its own comment conceded the postgres plugin tests "skip when it is unset" — precisely the green a wholly-skipped suite also produces. The reporter is built once and reused, because the plugin steps run in their own modules where `go run ./scripts/testreport` would not resolve.

## Verified

- 13 unit tests on the reporter, including adversarial stream shapes.
- End to end: a failing test streams immediately, prints verbatim, exits 1; a compile error reports `undefined: undefinedSymbol` with file:line and exits 1.
- Replaying the real captured `-short` stream against the new must-run list names exactly the four silent suites and exits 1.
- `make test` green at 89s cold / 13.3s warm; `gofmt` and `go vet` clean.

## Note for reviewers

There is deliberately no Docker-free fallback tier. When Docker is unavailable the run stops and says so — surfacing the problem rather than routing around it into a narrower run that reports green.
