### PR TITLE
fix(build): check-gofmt must not walk into nested worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,15 @@ check-codegen:         ## Verify api/generated.go is in sync with api/openapi.ya
 	@./scripts/check-generated-in-sync.sh
 
 check-gofmt:           ## Verify all Go files are gofmt-clean (root + plugin submodules)
-	@dirty="$$(gofmt -l .)"; \
+	@# `gofmt -l .` walks into .claude/worktrees/, so any feature worktree
+	@# checked out there fails this gate with files that are neither in the
+	@# branch nor the author's. CI never saw it because CI checks out clean.
+	@# -c -o --exclude-standard is tracked PLUS untracked-not-ignored, so a
+	@# brand-new file is still caught (tracked-only would let it through until
+	@# git add), while .gitignore's .claude/worktrees/ entry excludes the
+	@# nested worktrees. It still covers the plugin submodules: separate Go
+	@# modules, same git repository.
+	@dirty="$$(gofmt -l $$(git ls-files -c -o --exclude-standard '*.go'))"; \
 	if [ -n "$$dirty" ]; then \
 		echo "gofmt-dirty files (run 'gofmt -w .'):"; echo "$$dirty"; exit 1; \
 	fi; \


### PR DESCRIPTION
`gofmt -l .` recurses into `.claude/worktrees/`, so anyone with a feature worktree checked out there fails `make check-gofmt` on files that are neither in their branch nor theirs to fix.

Measured on the current `release/v0.8.4` checkout: the tracked tree is gofmt-clean while `make check-gofmt` listed **52 dirty files**, every one of them belonging to an unrelated worktree sitting on an older base. CI never saw it, because CI checks out clean — so the gate was red locally and green remotely, which is the worst direction for a check to be wrong in. It trains people to ignore it.

`git ls-files -c -o --exclude-standard` is tracked **plus** untracked-not-ignored. Tracked-only would have been a regression — a brand-new file would pass the gate until `git add`. `.gitignore` already carries `.claude/worktrees/`, so nested worktrees drop out, and the plugin submodules stay in (separate Go modules, same git repository).

Verified three ways:

| case | result |
|---|---|
| clean tree | `OK: all Go files are gofmt-clean.` |
| untracked dirty file | caught, exit 1 |
| tracked dirty file | caught, exit 1 |

Follows #547, which made feature worktrees a routine part of this workflow and so made this failure mode routine too.