### PR TITLE
docs(help): close the four help gaps found auditing the v0.8.4 milestone

### DIFF
--- a/cmd/cyoda/help/content/cli/serve.md
+++ b/cmd/cyoda/help/content/cli/serve.md
@@ -54,10 +54,11 @@ Variables read specifically during server boot (not covered by the config subtop
 - `CYODA_LOG_LEVEL` (string, default: `info`) — accepted: `debug|info|warn|error`.
 - `CYODA_SUPPRESS_BANNER` (bool, default: `false`) — suppress the ASCII startup banner and mock-auth warning.
 
-## STARTUP EXIT CODES
+## EXIT CODES
 
 - `0` — clean shutdown after SIGINT or SIGTERM.
 - `1` — startup failure: IAM validation failed (`CYODA_REQUIRE_JWT` contract not met), OTel SDK initialization error, gRPC port-bind failure, or backend connection failure during `app.New`.
+- `2` — hard exit forced by a second SIGINT or SIGTERM delivered while the graceful drain was still running. Nothing is drained or flushed on this path.
 
 ## EXAMPLES
 

--- a/cmd/cyoda/help/content/errors/INVALID_FIELD_PATH.md
+++ b/cmd/cyoda/help/content/errors/INVALID_FIELD_PATH.md
@@ -29,14 +29,14 @@ Three checks emit this code.
 jsonPath  = "$." segment ( "." segment )*
 segment   = name subscript*
 name      = 1*( ALPHA / DIGIT / "_" / "-" )   ; ASCII only
-subscript = "[" ( "*" / 1*DIGIT ) "]"
+subscript = "[" ( "*" / 1*DIGIT ) "]"          ; the digit run must fit a signed 32-bit integer
 ```
 
 `$.amount` and `$.address.city` are paths. A bare `amount` is **not** one and is rejected — it is not a tolerated alias. So are an empty path, an empty or trailing segment (`$..a`, `$.a.`), bracket-quoted property access (`$['x']`, `$.['x']`, `$.a["b"]` — use dotted access instead), and any character outside the segment set.
 
 A **well-formed** array subscript — the wildcard `[*]` or a non-negative index `[0]` — is valid JSON Path and is **accepted** (`$.tags[*].name`, `$.arr[0]`, `$.matrix[*][*]`, `$.orders[*].lines[*].sku`); it cannot be pushed into the storage query, so it is evaluated in memory.
 
-Any other bracket spelling is rejected with this code: an unclosed or unmatched bracket (`$.a[`, `$.a[0`, `$.a]`), a subscript with no field name before it (`$.[0]`), an empty subscript (`$.a[]`), a negative or signed index (`$.a[-1]`, `$.a[+1]`), a slice (`$.a[0:2]`), a union (`$.a[0,1]`), a filter expression (`$.a[?(@.x)]`), and whitespace inside one (`$.a[ 0]`). Characters after a well-formed subscript are checked too — `$.a[0]b`, `$.a[0];DROP` and `$.a[*]..b` are all rejected. These previously slipped through unvalidated and answered `200` with an empty page (or, on the grouped-stats `condition` and workflow-criterion surfaces, wrong buckets and a criterion that silently never fired).
+Any other bracket spelling is rejected with this code: an unclosed or unmatched bracket (`$.a[`, `$.a[0`, `$.a]`), a subscript with no field name before it (`$.[0]`), an empty subscript (`$.a[]`), a negative or signed index (`$.a[-1]`, `$.a[+1]`), a slice (`$.a[0:2]`), a union (`$.a[0,1]`), a filter expression (`$.a[?(@.x)]`), and whitespace inside one (`$.a[ 0]`). A positional index must also fit a signed 32-bit integer: `2147483647` is the largest accepted, and a wider digit run (`$.a[2147483648]`) is rejected with this code rather than truncated or wrapped — no entity array is long enough for such an index to address a real position. Characters after a well-formed subscript are checked too — `$.a[0]b`, `$.a[0];DROP` and `$.a[*]..b` are all rejected. These previously slipped through unvalidated and answered `200` with an empty page (or, on the grouped-stats `condition` and workflow-criterion surfaces, wrong buckets and a criterion that silently never fired).
 
 This check is syntactic and runs on every search-shaped surface regardless of whether a schema is loaded: `/search` (sync and async), conditional delete, and the `condition` of a grouped-statistics query.
 

--- a/cmd/cyoda/help/content/run.md
+++ b/cmd/cyoda/help/content/run.md
@@ -265,7 +265,9 @@ CYODA_PROFILES=postgres,otel ./scripts/dev/run-local.sh
 - `SIGTERM` — same behavior as `SIGINT`. Kubernetes sends `SIGTERM` when a pod is evicted or deleted.
 - `SIGPIPE` — ignored. When the binary is piped through `tee` (e.g. `./bin/cyoda | tee log`) and Ctrl+C kills `tee` first, the broken pipe would cause the binary to exit immediately before the `SIGINT` handler runs. Ignoring `SIGPIPE` lets the write fail silently while the graceful shutdown proceeds. (Source: `cmd/cyoda/main.go`, `signal.Ignore(syscall.SIGPIPE)`.)
 
-Signal handling is established in `main()` before the listeners start. The signal channel has buffer size 1.
+A **second** `SIGINT` or `SIGTERM` delivered while the drain is still running forces an immediate exit with code `2`. This is the operator's recourse when a graceful shutdown hangs on a stuck in-flight request or a slow-closing storage pool; nothing is drained or flushed on that path. Only the first signal starts the graceful shutdown, and only a genuine second one forces the hard exit.
+
+Signal handling is established before the listeners start.
 
 ## HEALTH PROBES
 

--- a/cmd/cyoda/help/content/search.md
+++ b/cmd/cyoda/help/content/search.md
@@ -92,7 +92,7 @@ All search requests accept a `Condition` JSON document as the POST body. Conditi
 jsonPath  = "$." segment ( "." segment )*
 segment   = name subscript*
 name      = 1*( ALPHA / DIGIT / "_" / "-" )   ; ASCII only
-subscript = "[" ( "*" / 1*DIGIT ) "]"
+subscript = "[" ( "*" / 1*DIGIT ) "]"          ; the digit run must fit a signed 32-bit integer
 ```
 
 The `$.` leader is **required**. A bare `amount` is not a path and is rejected `400 errors.INVALID_FIELD_PATH` — it is not a tolerated alias for `$.amount`. So are an empty path, an empty or trailing segment (`$..a`, `$.a.`), bracket-quoted property access (`$['x']`, `$.['x']`, `$.a["b"]` — write `$.x`), and any character outside the segment set.
@@ -101,7 +101,11 @@ The `$.` leader is **required**. A bare `amount` is not a path and is rejected `
 
 `[*]` addresses **every** element, so a leaf on it holds when **some** element satisfies it: `$.tags[*] EQUALS "red"` selects the entities whose `tags` contains `"red"`. It is existential, so nothing matches an empty array — neither `IS_NULL` nor `NOT_NULL` holds on `{"tags": []}`. `[0]` addresses that one element. A trailing `[*]` on an array of **pure objects** is rejected `400 errors.INVALID_FIELD_PATH` under a scalar operator — the element has no scalar form, so navigate to the leaf (`$.items[*].sku`, not `$.items[*]`).
 
-Every other bracket spelling is rejected `400 errors.INVALID_FIELD_PATH`: unclosed or unmatched (`$.a[`, `$.a[0`, `$.a]`), no field name before it (`$.[0]`), empty (`$.a[]`), negative or signed (`$.a[-1]`, `$.a[+1]`), a slice (`$.a[0:2]`), a union (`$.a[0,1]`), a filter expression (`$.a[?(@.x)]`), or whitespace inside (`$.a[ 0]`). The path is scanned to the end, so trailing junk after a valid subscript is caught too (`$.a[0]b`, `$.a[0];DROP`, `$.a[*]..b`). These used to go unvalidated and return `200` with an empty page.
+**Multi-branch fields and vacuity.** A field may be declared as more than one shape, and a path is accepted when it is a valid statement for **at least one** declared branch. Per entity the predicate then applies to whichever branch that entity's data actually is; where the path is not a valid statement for that branch the entity simply does not match — that is a non-match, not an error. So for a field declared as string *and* array-of-string, `$.a EQUALS "A"` selects the scalar-shaped entities and `$.a[*] EQUALS "A"` the array-shaped ones, and neither condition is rejected.
+
+An empty array answers the three path forms differently, because each addresses something different. A bare `$.a` addresses the array itself, which exists when it is empty, so `NOT_NULL` is **true**. `$.a[*]` addresses the elements and never the array's own nullness, so over `[]` both `IS_NULL` and `NOT_NULL` are **false** — on a wildcard path the two are complements only where at least one element exists. `$.a[0]` addresses one position, which is absent and therefore null, so `IS_NULL` is **true**. Full addressing, branch and vacuity rules: `docs/cloud-parity/path-grammar.md`.
+
+Every other bracket spelling is rejected `400 errors.INVALID_FIELD_PATH`: unclosed or unmatched (`$.a[`, `$.a[0`, `$.a]`), no field name before it (`$.[0]`), empty (`$.a[]`), negative or signed (`$.a[-1]`, `$.a[+1]`), a slice (`$.a[0:2]`), a union (`$.a[0,1]`), a filter expression (`$.a[?(@.x)]`), whitespace inside (`$.a[ 0]`), or a positional index too large to fit a signed 32-bit integer (`$.a[2147483648]`) — `2147483647` is the largest index accepted, and no entity array is long enough for a larger one to address a real position. The path is scanned to the end, so trailing junk after a valid subscript is caught too (`$.a[0]b`, `$.a[0];DROP`, `$.a[*]..b`). These used to go unvalidated and return `200` with an empty page.
 
 Metadata is not addressed through `jsonPath` at all — a `lifecycle` condition names a meta field directly (see **LifecycleCondition**) and is not subject to this grammar. A *data* path that happens to spell `$._meta.state` is an ordinary dotted path.
 
@@ -270,6 +274,8 @@ Response: `200 OK`, `application/json`:
 - `finishTime`: RFC 3339 with nanoseconds; absent when status is `RUNNING`
 - `expirationDate`: `createTime + 24h` — job results expire after this time
 
+A job ends `FAILED` when the search itself failed, when the reaper claims it from a dead node, or when the model's schema becomes unloadable between submit and execution — the executor re-reads the schema, and a job that cannot validate its condition against it fails rather than finishing `SUCCESSFUL` with a short page.
+
 **GET /api/search/async/{jobId}** — Retrieve async job results (paginated)
 
 - `jobId` (path): UUID
@@ -378,6 +384,7 @@ Synchronous search neither paginates nor truncates: the matched set must fit wit
 - `errors.CONDITION_TYPE_MISMATCH` — `400` — condition value type is incompatible with the target field's locked DataType, e.g. an operand that parses into no temporal form on a temporal meta field (`creationDate`/`lastUpdateTime`); a string or pattern operator on one of those fields is `INVALID_CONDITION` instead, see **LifecycleCondition** above
 - `errors.INVALID_CONDITION` — `400` — a condition fails a structural or shape check rather than a path or type check: an unknown or missing `operatorType`, a `null`/object/complex operand on a binary or range operator, a malformed `LIKE`/`MATCHES_PATTERN` operand, a string or pattern operator on a temporal meta field, an `array` clause on a bare path or with a badly-shaped `values` entry, or a `function` clause at any depth (criteria only — see `predicates`)
 - `errors.BAD_REQUEST` — `400` — malformed condition JSON, invalid limit/pageSize/pageNumber, result retrieval on non-SUCCESSFUL job, unknown async job ID in result retrieval
+- `errors.SERVER_ERROR` — `500` — the target model's schema could not be loaded or parsed, so the condition could not be checked against it. The request fails with a ticket id and no result set rather than skipping validation: without declared types, comparison and ordering leaves match nothing, so the answer would be a short page indistinguishable from a complete one. HTTP and gRPC fail alike — over gRPC it is an envelope error, never an empty stream. A condition built only of `lifecycle` clauses needs no schema and is unaffected
 
 ## EXAMPLES
 


### PR DESCRIPTION
An audit of the 15 v0.8.4 milestone PRs that did not touch the help tree found two gaps in the `search` topic — the schema-load failure semantics (a model schema that cannot be loaded or parsed fails the request `500` with a ticket id on HTTP and gRPC alike instead of skipping validation, and an in-flight async job whose schema becomes unreadable ends `FAILED` rather than `SUCCESSFUL` with a short page; verified against `internal/domain/search/service.go`, `internal/grpc/errors.go` and `docs/cloud-parity/path-grammar.md` §6/§9/§11) and multi-branch path addressing with its vacuity distinctions (the union rule, and the three different answers a bare, wildcard and positional path give on an empty array; verified against `docs/cloud-parity/path-grammar.md` §3-5) — plus two incidental ones fixed here: the signed-32-bit bound on a positional subscript, now stated in both the `search` grammar note and `errors.INVALID_FIELD_PATH` (verified against `filter_path.go` in the pinned cyoda-go-spi and `internal/domain/search/jsonpath_grammar.go`), and the second-signal exit code, added to `run`'s signal section and `cli.serve`'s exit-code list (verified against `cmd/cyoda/main.go`). While there, `cli.serve`'s heading loses its inaccurate "STARTUP" qualifier, since neither exit `0` nor the new exit `2` is a startup outcome, and `run`'s stale "the signal channel has buffer size 1" claim is dropped.

Documentation only — no code changes. `go test ./cmd/cyoda/help/...` (cross-reference and content tests) and `go build ./cmd/cyoda` are green, and each of the four was eyeballed in the rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0157hdW8WkcnyEpfLeqZ4EwF
