### PR TITLE
fix(messaging): a batch delete must not report success for an id it cannot match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1251,6 +1251,18 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **A batch message delete no longer reports success for an id it cannot
+  match.** `DELETE /api/message` declares its body as `format: uuid`, and every
+  message is stored under the canonical hyphenated form, because each save keys
+  the blob or the row by `uuid.UUID.String()`. The handler validated with
+  `uuid.Parse`, which is laxer than the declared format: a braced id, a
+  `urn:uuid:` prefix, an undashed 32-hex run and uppercase hex all parse. Each
+  was then forwarded to the store verbatim, matched no key on any backend, and
+  the caller received **200** with `success: true` for a delete that removed
+  nothing. Such an id is now rejected with **400 `BAD_REQUEST`**. No request
+  that previously succeeded is affected — a non-canonical id never deleted
+  anything.
+
 - **A whole-model delete honors `pointInTime` and `verbose` on both doors.**
   `DELETE /entity/{entityName}/{modelVersion}` with an empty body and the
   gRPC `EntityDeleteAllRequest` took a fast path that ignored the instant —

--- a/internal/domain/messaging/handler.go
+++ b/internal/domain/messaging/handler.go
@@ -285,9 +285,20 @@ func (h *Handler) DeleteMessages(w http.ResponseWriter, r *http.Request, params 
 		return
 	}
 
+	// The body declares `format: uuid`, which names the canonical hyphenated
+	// form — and that is the only form any message is ever stored under, since
+	// every save keys the blob or the row by uuid.UUID.String(). uuid.Parse is
+	// laxer: it also accepts a braced form, a urn:uuid: prefix, an undashed
+	// 32-hex run and uppercase hex. Those parsed cleanly and were then
+	// forwarded verbatim to the store, where they matched nothing, so the
+	// caller received 200 and success:true for a delete that removed nothing.
+	// An id that cannot match is a client error, not a silent no-op. No
+	// request that succeeded before is affected: a non-canonical id never
+	// deleted anything on any backend.
 	for _, id := range ids {
-		if _, err := uuid.Parse(id); err != nil {
-			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "id list contains a value that is not a valid UUID"))
+		if parsed, err := uuid.Parse(id); err != nil || parsed.String() != id {
+			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
+				"id list contains a value that is not a canonical UUID"))
 			return
 		}
 	}

--- a/internal/domain/messaging/handler_deletebatch_test.go
+++ b/internal/domain/messaging/handler_deletebatch_test.go
@@ -308,3 +308,55 @@ func TestDeleteMessages_NoParam_Success_SingleCallSingleElement(t *testing.T) {
 		t.Errorf("entityIds = %v, want 3 ids", resp[0]["entityIds"])
 	}
 }
+
+// The request body declares `format: uuid`, which names the canonical
+// hyphenated form. uuid.Parse is laxer than that: it also accepts a braced
+// form, a urn:uuid: prefix and an undashed 32-hex run. Those were validated
+// and then forwarded verbatim, so the store looked up a key no save had ever
+// written — the memory backend a filename, the SQL backends a message_id
+// column — and the caller got 200 with success:true for a delete that removed
+// nothing. Reject them instead: an id that cannot match is a client error, not
+// a silent no-op.
+func TestDeleteMessages_NonCanonicalUUIDForms_400(t *testing.T) {
+	canonical := uuid.NewString()
+
+	for name, id := range map[string]string{
+		"braced":    "{" + canonical + "}",
+		"urn":       "urn:uuid:" + canonical,
+		"undashed":  strings.ReplaceAll(canonical, "-", ""),
+		"uppercase": strings.ToUpper(canonical),
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := &fakeDeleteBatchStore{}
+			h := newDeleteBatchHandler(store)
+
+			w := httptest.NewRecorder()
+			h.DeleteMessages(w, newDeleteMessagesRequest(nil, idsBody([]string{id})), genapi.DeleteMessagesParams{})
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 for %q; body: %s", w.Code, id, w.Body.String())
+			}
+			if len(store.snapshot()) != 0 {
+				t.Fatalf("DeleteBatch must not be called for %q; got %d calls", id, len(store.snapshot()))
+			}
+		})
+	}
+}
+
+// The canonical form stays accepted, and reaches the store unaltered.
+func TestDeleteMessages_CanonicalUUID_ReachesStoreUnaltered(t *testing.T) {
+	store := &fakeDeleteBatchStore{}
+	h := newDeleteBatchHandler(store)
+
+	id := uuid.NewString()
+	w := httptest.NewRecorder()
+	h.DeleteMessages(w, newDeleteMessagesRequest(nil, idsBody([]string{id})), genapi.DeleteMessagesParams{})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	calls := store.snapshot()
+	if len(calls) != 1 || len(calls[0]) != 1 || calls[0][0] != id {
+		t.Fatalf("store received %v, want [[%s]]", calls, id)
+	}
+}


### PR DESCRIPTION
The quick, low-risk half of the CodeQL triage. The rest is #572, which is not a v0.8.4 blocker.

## The defect

`DELETE /api/message` declares its body as `format: uuid`. Every message is stored under the canonical hyphenated form, because each save keys the blob or the row by `uuid.UUID.String()`.

The handler validated with `uuid.Parse`, which is laxer than the declared format — a braced id, a `urn:uuid:` prefix, an undashed 32-hex run and uppercase hex all parse. It then **discarded the parsed value** and forwarded the client's original string to the store, where it matched no key on any backend: a filename on memory, a `message_id` column on sqlite and postgres.

The caller got `200` and `success: true` for a delete that removed nothing. The red test output shows it plainly:

```
status = 200, want 400 for "{c2d98e18-2275-4042-b370-33fef8c6e34c}";
body: [{"entityIds":["{c2d98e18-...}"],"success":true}]
```

Affects all three backends — the validation is in the shared handler, above the store.

## The fix

Reject anything that is not the canonical form, `400 BAD_REQUEST`.

Rejecting rather than normalising is deliberate and is the narrower change. **No request that previously succeeded is affected**, because a non-canonical id never deleted anything on any backend, and nothing that used to be a silent no-op starts removing rows. Normalising would have widened what a delete removes, which is the wrong direction for a pre-release change.

The `400` was already declared on this operation, described as "Invalid request body (not a JSON array of UUID strings)", so `api/openapi.yaml` needs no change.

## Tests

Red first, then green. Four rejected forms (braced, urn, undashed, uppercase), each asserting the store is never called, plus a case pinning that a canonical id still reaches the store unaltered.

## Verification

- `make test` — 9,743 tests, 0 failed (unit + cross-backend parity)
- `go test ./internal/e2e/ -run Message` green

## Context

Found while triaging CodeQL alert 92 during v0.8.4 release prep. That alert points at the message id; tracing it showed the id is the well-constrained input and the **tenant id** is the exposed one, reaching the filesystem from an unvalidated JWT claim. That is #572 — it touches authentication and rewrites a storage path, so it wants its own review rather than riding the release bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nzn5ien1FKiX9vnqtJMsoU